### PR TITLE
fix: uname is more common than hostname

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set build environment variables
         run: |
           echo GOVERSION=$(go env GOVERSION) >> $GITHUB_ENV
-          echo BUILD_HOST=$(hostname) >> $GITHUB_ENV
+          echo BUILD_HOST=$(uname -n) >> $GITHUB_ENV
           echo BUILD_USER=$(whoami) >> $GITHUB_ENV
       - name: Release with goreleaser
         uses: goreleaser/goreleaser-action@v6

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ supported build method for troubleshooting.
 
 ```bash
 export GOVERSION=$(go env GOVERSION)
-export BUILD_HOST=$(hostname)
+export BUILD_HOST=$(uname -n)
 export BUILD_USER=$(whoami)
 goreleaser build --clean --snapshot --single-target
 ```


### PR DESCRIPTION
- uname is a GNU coreutils
- hostname is a GNU inetutils

coreutils is more common than inetutils

an explanation of the difference on this forum [1]

[1]: https://askubuntu.com/a/294584
