### PR TITLE
Add optional magellan discovery commands

### DIFF
--- a/cmd/magellan.go
+++ b/cmd/magellan.go
@@ -1,0 +1,15 @@
+//go:build magellan || all
+// +build magellan all
+
+package cmd
+
+import (
+	magellan_cmd "github.com/OpenCHAMI/magellan/cmd"
+)
+
+func init() {
+	discoverCmd.AddCommand(magellan_cmd.ScanCmd)
+	discoverCmd.AddCommand(magellan_cmd.CollectCmd)
+	discoverCmd.AddCommand(magellan_cmd.ListCmd)
+	discoverCmd.AddCommand(magellan_cmd.CrawlCmd)
+}


### PR DESCRIPTION
This PR adds the ability to compile the `magellan` commands into the `ochami` executable via a `--tags` flag. To add the `magellan` commands to the build, run `go build` with `--tags=magellan`. The commands can be found with `ochami discover` and are used similarly to the standalone binary.

For example,

```bash
ochami discover scan \
    --subnet 172.16.0.0 \
    --subnet-mask 255.255.255.0 \
    --format json \
    --cache data/assets.db \
```
...is equivalent to the following...
```bash
./magellan scan \
    --subnet 172.16.0.0 \
    --subnet-mask 255.255.255.0 \
    --format json \
    --cache data/assets.db \
```
Any fixes and updates applied to the upstream `magellan` with subsequently be applied to the `ochami discover` equivalent as well without any additional modifications needed.