### PR TITLE
feat: improve `config` commands; fix some minor inconveniences

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ configuration file called `foobar` whose base URI is
 `https://foobar.openchami.cluster`:
 
 ```bash
-ochami config cluster set --user foobar --default --base-uri https://foobar.openchami.cluster
+ochami config cluster set --user --default foobar cluster.uri https://foobar.openchami.cluster:8443
 ```
 
 > [!NOTE]
@@ -69,7 +69,7 @@ Now, when the configuration is shown, we should see the new cluster's details:
 $ ochami config show
 clusters:
     - cluster:
-        api-uri: https://foobar.openchami.cluster:8443
+        uri: https://foobar.openchami.cluster:8443
       name: foobar
 default-cluster: foobar
 log:

--- a/cmd/bss-boot-params-add.go
+++ b/cmd/bss-boot-params-add.go
@@ -41,11 +41,7 @@ This command sends a POST to BSS. An access token is required.`,
 		if len(args) == 0 &&
 			!cmd.Flag("xname").Changed && !cmd.Flag("nid").Changed && !cmd.Flag("mac").Changed &&
 			!cmd.Flag("kernel").Changed && !cmd.Flag("initrd").Changed && !cmd.Flag("payload").Changed {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
 

--- a/cmd/bss-boot-params-add.go
+++ b/cmd/bss-boot-params-add.go
@@ -24,7 +24,9 @@ var bootParamsAddCmd = &cobra.Command{
 --payload-format, JSON by default), but the rules above still apply for the
 payload. If the specified file path is -, the data is read from standard input.
 
-This command sends a POST to BSS. An access token is required.`,
+This command sends a POST to BSS. An access token is required.
+
+See ochami-bss(1) for more details.`,
 	Example: `  ochami bss boot params add \
     --mac 00:de:ad:be:ef:00 \
     --kernel https://example.com/kernel \
@@ -52,6 +54,7 @@ This command sends a POST to BSS. An access token is required.`,
 		bssBaseURI, err := getBaseURIBSS(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for BSS")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -63,6 +66,7 @@ This command sends a POST to BSS. An access token is required.`,
 		bssClient, err := bss.NewClient(bssBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new BSS client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -80,6 +84,7 @@ This command sends a POST to BSS. An access token is required.`,
 			bp.Hosts, err = cmd.Flags().GetStringSlice("xname")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch xname list")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}
@@ -87,10 +92,12 @@ This command sends a POST to BSS. An access token is required.`,
 			bp.Macs, err = cmd.Flags().GetStringSlice("mac")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch mac list")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 			if err = bp.CheckMacs(); err != nil {
 				log.Logger.Error().Err(err).Msg("invalid mac(s)")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}
@@ -98,6 +105,7 @@ This command sends a POST to BSS. An access token is required.`,
 			bp.Nids, err = cmd.Flags().GetInt32Slice("nid")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch nid list")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}
@@ -107,6 +115,7 @@ This command sends a POST to BSS. An access token is required.`,
 			bp.Kernel, err = cmd.Flags().GetString("kernel")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch kernel uri")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}
@@ -114,6 +123,7 @@ This command sends a POST to BSS. An access token is required.`,
 			bp.Initrd, err = cmd.Flags().GetString("initrd")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch initrd uri")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}
@@ -121,6 +131,7 @@ This command sends a POST to BSS. An access token is required.`,
 			bp.Params, err = cmd.Flags().GetString("params")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch params")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}
@@ -133,6 +144,7 @@ This command sends a POST to BSS. An access token is required.`,
 			} else {
 				log.Logger.Error().Err(err).Msg("failed to add boot parameters to BSS")
 			}
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 	},

--- a/cmd/bss-boot-params-add.go
+++ b/cmd/bss-boot-params-add.go
@@ -36,11 +36,7 @@ This command sends a POST to BSS. An access token is required.`,
   ochami bss boot params add -f payload.yaml --payload-format yaml
   echo '<json_data>' | ochami bss boot params add -f -
   echo '<yaml_data>' | ochami bss boot params add -f - --payload-format yaml`,
-	Run: func(cmd *cobra.Command, args []string) {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// cmd.LocalFlags().NFlag() doesn't seem to work, so we check every flag
 		if len(args) == 0 &&
 			!cmd.Flag("xname").Changed && !cmd.Flag("nid").Changed && !cmd.Flag("mac").Changed &&
@@ -49,6 +45,13 @@ This command sends a POST to BSS. An access token is required.`,
 			os.Exit(0)
 		}
 
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		bssBaseURI, err := getBaseURIBSS(cmd)
 		if err != nil {

--- a/cmd/bss-boot-params-add.go
+++ b/cmd/bss-boot-params-add.go
@@ -45,10 +45,6 @@ This command sends a POST to BSS. An access token is required.`,
 			os.Exit(0)
 		}
 
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/bss-boot-params-add.go
+++ b/cmd/bss-boot-params-add.go
@@ -37,6 +37,10 @@ This command sends a POST to BSS. An access token is required.`,
   echo '<json_data>' | ochami bss boot params add -f -
   echo '<yaml_data>' | ochami bss boot params add -f - --payload-format yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// cmd.LocalFlags().NFlag() doesn't seem to work, so we check every flag
 		if len(args) == 0 &&
 			!cmd.Flag("xname").Changed && !cmd.Flag("nid").Changed && !cmd.Flag("mac").Changed &&

--- a/cmd/bss-boot-params-delete.go
+++ b/cmd/bss-boot-params-delete.go
@@ -28,7 +28,9 @@ a file (optionally specifying --payload-format, JSON by default),
 but the rules above still apply for the payload. If the specified
 file path is -, the data is read from standard input.
 
-This command sends a DELETE to BSS. An access token is required.`,
+This command sends a DELETE to BSS. An access token is required.
+
+See ochami-bss(1) for more details.`,
 	Example: `  ochami bss boot params delete --kernel https://example.com/kernel
   ochami bss boot params delete --kernel https://example.com/kernel --initrd https://example.com/initrd
   ochami bss boot params delete -f payload.json
@@ -51,6 +53,7 @@ This command sends a DELETE to BSS. An access token is required.`,
 		bssBaseURI, err := getBaseURIBSS(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for BSS")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -62,6 +65,7 @@ This command sends a DELETE to BSS. An access token is required.`,
 		bssClient, err := bss.NewClient(bssBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new BSS client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -79,6 +83,7 @@ This command sends a DELETE to BSS. An access token is required.`,
 			bp.Hosts, err = cmd.Flags().GetStringSlice("xname")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch xname list")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}
@@ -86,10 +91,12 @@ This command sends a DELETE to BSS. An access token is required.`,
 			bp.Macs, err = cmd.Flags().GetStringSlice("mac")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch mac list")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 			if err = bp.CheckMacs(); err != nil {
 				log.Logger.Error().Err(err).Msg("invalid mac(s)")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}
@@ -97,6 +104,7 @@ This command sends a DELETE to BSS. An access token is required.`,
 			bp.Nids, err = cmd.Flags().GetInt32Slice("nid")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch nid list")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}
@@ -106,6 +114,7 @@ This command sends a DELETE to BSS. An access token is required.`,
 			bp.Kernel, err = cmd.Flags().GetString("kernel")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch kernel uri")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}
@@ -113,6 +122,7 @@ This command sends a DELETE to BSS. An access token is required.`,
 			bp.Initrd, err = cmd.Flags().GetString("initrd")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch initrd uri")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}
@@ -120,6 +130,7 @@ This command sends a DELETE to BSS. An access token is required.`,
 			bp.Params, err = cmd.Flags().GetString("params")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch params")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}
@@ -144,6 +155,7 @@ This command sends a DELETE to BSS. An access token is required.`,
 			} else {
 				log.Logger.Error().Err(err).Msg("failed to set boot parameters in BSS")
 			}
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 	},

--- a/cmd/bss-boot-params-delete.go
+++ b/cmd/bss-boot-params-delete.go
@@ -40,11 +40,7 @@ This command sends a DELETE to BSS. An access token is required.`,
 		if len(args) == 0 &&
 			!cmd.Flag("xname").Changed && !cmd.Flag("nid").Changed && !cmd.Flag("mac").Changed &&
 			!cmd.Flag("kernel").Changed && !cmd.Flag("initrd").Changed && !cmd.Flag("payload").Changed {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
 

--- a/cmd/bss-boot-params-delete.go
+++ b/cmd/bss-boot-params-delete.go
@@ -35,11 +35,7 @@ This command sends a DELETE to BSS. An access token is required.`,
   ochami bss boot params delete -f payload.yaml --payload-format yaml
   echo '<json_data>' | ochami bss boot params delete -f -
   echo '<yaml_data>' | ochami bss boot params delete -f - --payload-format yaml`,
-	Run: func(cmd *cobra.Command, args []string) {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// cmd.LocalFlags().NFlag() doesn't seem to work, so we check every flag
 		if len(args) == 0 &&
 			!cmd.Flag("xname").Changed && !cmd.Flag("nid").Changed && !cmd.Flag("mac").Changed &&
@@ -48,6 +44,13 @@ This command sends a DELETE to BSS. An access token is required.`,
 			os.Exit(0)
 		}
 
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		bssBaseURI, err := getBaseURIBSS(cmd)
 		if err != nil {

--- a/cmd/bss-boot-params-delete.go
+++ b/cmd/bss-boot-params-delete.go
@@ -36,6 +36,10 @@ This command sends a DELETE to BSS. An access token is required.`,
   echo '<json_data>' | ochami bss boot params delete -f -
   echo '<yaml_data>' | ochami bss boot params delete -f - --payload-format yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// cmd.LocalFlags().NFlag() doesn't seem to work, so we check every flag
 		if len(args) == 0 &&
 			!cmd.Flag("xname").Changed && !cmd.Flag("nid").Changed && !cmd.Flag("mac").Changed &&

--- a/cmd/bss-boot-params-delete.go
+++ b/cmd/bss-boot-params-delete.go
@@ -44,10 +44,6 @@ This command sends a DELETE to BSS. An access token is required.`,
 			os.Exit(0)
 		}
 
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/bss-boot-params-get.go
+++ b/cmd/bss-boot-params-get.go
@@ -23,7 +23,9 @@ var bootParamsGetCmd = &cobra.Command{
 parameters are returned. Optionally, --mac, --xname, and/or --nid can be passed at least once
 to get boot parameters for specific components.
 
-This command sends a GET to BSS. An access token is required.`,
+This command sends a GET to BSS. An access token is required.
+
+See ochami-bss(1) for more details.`,
 	Example: `  ochami bss boot params get
   ochami bss boot params get --mac 00:de:ad:be:ef:00
   ochami bss boot params get --mac 00:de:ad:be:ef:00,00:c0:ff:ee:00:00
@@ -44,6 +46,7 @@ This command sends a GET to BSS. An access token is required.`,
 		bssClient, err := bss.NewClient(bssBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new BSS client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -60,6 +63,7 @@ This command sends a GET to BSS. An access token is required.`,
 				s, err := cmd.Flags().GetStringSlice("xname")
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch xname list")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 				for _, x := range s {
@@ -70,6 +74,7 @@ This command sends a GET to BSS. An access token is required.`,
 				s, err := cmd.Flags().GetStringSlice("mac")
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch mac list")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 				for _, m := range s {
@@ -80,6 +85,7 @@ This command sends a GET to BSS. An access token is required.`,
 				s, err := cmd.Flags().GetInt32Slice("nid")
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch nid list")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 				for _, n := range s {
@@ -95,16 +101,19 @@ This command sends a GET to BSS. An access token is required.`,
 			} else {
 				log.Logger.Error().Err(err).Msg("failed to request boot parameters from BSS")
 			}
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
 		outFmt, err := cmd.Flags().GetString("output-format")
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 		if outBytes, err := client.FormatBody(httpEnv.Body, outFmt); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to format output")
+			logHelpError(cmd)
 			os.Exit(1)
 		} else {
 			fmt.Printf(string(outBytes))

--- a/cmd/bss-boot-params-get.go
+++ b/cmd/bss-boot-params-get.go
@@ -28,11 +28,14 @@ This command sends a GET to BSS. An access token is required.`,
   ochami bss boot params get --mac 00:de:ad:be:ef:00
   ochami bss boot params get --mac 00:de:ad:be:ef:00,00:c0:ff:ee:00:00
   ochami bss boot params get --mac 00:de:ad:be:ef:00 --mac 00:c0:ff:ee:00:00`,
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		bssBaseURI, err := getBaseURIBSS(cmd)
 		if err != nil {

--- a/cmd/bss-boot-params-get.go
+++ b/cmd/bss-boot-params-get.go
@@ -28,13 +28,6 @@ This command sends a GET to BSS. An access token is required.`,
   ochami bss boot params get --mac 00:de:ad:be:ef:00
   ochami bss boot params get --mac 00:de:ad:be:ef:00,00:c0:ff:ee:00:00
   ochami bss boot params get --mac 00:de:ad:be:ef:00 --mac 00:c0:ff:ee:00:00`,
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
-		return nil
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		bssBaseURI, err := getBaseURIBSS(cmd)

--- a/cmd/bss-boot-params-get.go
+++ b/cmd/bss-boot-params-get.go
@@ -29,6 +29,10 @@ This command sends a GET to BSS. An access token is required.`,
   ochami bss boot params get --mac 00:de:ad:be:ef:00,00:c0:ff:ee:00:00
   ochami bss boot params get --mac 00:de:ad:be:ef:00 --mac 00:c0:ff:ee:00:00`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Without a base URI, we cannot do anything
 		bssBaseURI, err := getBaseURIBSS(cmd)
 		if err != nil {

--- a/cmd/bss-boot-params-set.go
+++ b/cmd/bss-boot-params-set.go
@@ -27,7 +27,9 @@ file (optionally specifying --payload-format, JSON by default),
 but the rules above still apply for the payload. If the specified
 file path is -, the data is read from standard input.
 
-This command sends a PUT to BSS. An access token is required.`,
+This command sends a PUT to BSS. An access token is required.
+
+See ochami-bss(1) for more details.`,
 	Example: `  ochami bss boot params set --xname x1000c1s7b0 --kernel https://example.com/kernel
   ochami bss boot params set --xname x1000c1s7b0,x1000c1s7b1 --kernel https://example.com/kernel
   ochami bss boot params set --xname x1000c1s7b0 --xname x1000c1s7b1 --kernel https://example.com/kernel
@@ -52,6 +54,7 @@ This command sends a PUT to BSS. An access token is required.`,
 		bssBaseURI, err := getBaseURIBSS(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for BSS")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -63,6 +66,7 @@ This command sends a PUT to BSS. An access token is required.`,
 		bssClient, err := bss.NewClient(bssBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new BSS client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -80,6 +84,7 @@ This command sends a PUT to BSS. An access token is required.`,
 			bp.Hosts, err = cmd.Flags().GetStringSlice("xname")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch xname list")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}
@@ -87,10 +92,12 @@ This command sends a PUT to BSS. An access token is required.`,
 			bp.Macs, err = cmd.Flags().GetStringSlice("mac")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch mac list")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 			if err = bp.CheckMacs(); err != nil {
 				log.Logger.Error().Err(err).Msg("invalid mac(s)")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}
@@ -98,6 +105,7 @@ This command sends a PUT to BSS. An access token is required.`,
 			bp.Nids, err = cmd.Flags().GetInt32Slice("nid")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch nid list")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}
@@ -107,6 +115,7 @@ This command sends a PUT to BSS. An access token is required.`,
 			bp.Kernel, err = cmd.Flags().GetString("kernel")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch kernel uri")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}
@@ -114,6 +123,7 @@ This command sends a PUT to BSS. An access token is required.`,
 			bp.Initrd, err = cmd.Flags().GetString("initrd")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch initrd uri")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}
@@ -121,6 +131,7 @@ This command sends a PUT to BSS. An access token is required.`,
 			bp.Params, err = cmd.Flags().GetString("params")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch params")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}
@@ -133,6 +144,7 @@ This command sends a PUT to BSS. An access token is required.`,
 			} else {
 				log.Logger.Error().Err(err).Msg("failed to set boot parameters in BSS")
 			}
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 	},

--- a/cmd/bss-boot-params-set.go
+++ b/cmd/bss-boot-params-set.go
@@ -41,11 +41,7 @@ This command sends a PUT to BSS. An access token is required.`,
 		if len(args) == 0 &&
 			!cmd.Flag("xname").Changed && !cmd.Flag("nid").Changed && !cmd.Flag("mac").Changed &&
 			!cmd.Flag("kernel").Changed && !cmd.Flag("initrd").Changed && !cmd.Flag("payload").Changed {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
 

--- a/cmd/bss-boot-params-set.go
+++ b/cmd/bss-boot-params-set.go
@@ -45,10 +45,6 @@ This command sends a PUT to BSS. An access token is required.`,
 			os.Exit(0)
 		}
 
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/bss-boot-params-set.go
+++ b/cmd/bss-boot-params-set.go
@@ -36,11 +36,7 @@ This command sends a PUT to BSS. An access token is required.`,
   ochami bss boot params set -f payload.yaml --payload-format yaml
   echo <json_data> | ochami bss boot params set -f -
   echo <yaml_data> | ochami bss boot params set -f - --payload-format yaml`,
-	Run: func(cmd *cobra.Command, args []string) {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// cmd.LocalFlags().NFlag() doesn't seem to work, so we check every flag
 		if len(args) == 0 &&
 			!cmd.Flag("xname").Changed && !cmd.Flag("nid").Changed && !cmd.Flag("mac").Changed &&
@@ -49,6 +45,13 @@ This command sends a PUT to BSS. An access token is required.`,
 			os.Exit(0)
 		}
 
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		bssBaseURI, err := getBaseURIBSS(cmd)
 		if err != nil {

--- a/cmd/bss-boot-params-set.go
+++ b/cmd/bss-boot-params-set.go
@@ -37,6 +37,10 @@ This command sends a PUT to BSS. An access token is required.`,
   echo <json_data> | ochami bss boot params set -f -
   echo <yaml_data> | ochami bss boot params set -f - --payload-format yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// cmd.LocalFlags().NFlag() doesn't seem to work, so we check every flag
 		if len(args) == 0 &&
 			!cmd.Flag("xname").Changed && !cmd.Flag("nid").Changed && !cmd.Flag("mac").Changed &&

--- a/cmd/bss-boot-params-update.go
+++ b/cmd/bss-boot-params-update.go
@@ -25,7 +25,9 @@ file (optionally specifying --payload-format, JSON by default), but
 the rules above still apply for the payload. If the specified file
 path is -, the data is read from standard input.
 
-This command sends a PATCH to BSS. An access token is required.`,
+This command sends a PATCH to BSS. An access token is required.
+
+See ochami-bss(1) for details.`,
 	Example: `  ochami bss boot params update --xname x1000c1s7b0 --kernel https://example.com/kernel
   ochami bss boot params update --xname x1000c1s7b0,x1000c1s7b1 --kernel https://example.com/kernel
   ochami bss boot params update --xname x1000c1s7b0 --xname x1000c1s7b1 --kernel https://example.com/kernel
@@ -50,6 +52,7 @@ This command sends a PATCH to BSS. An access token is required.`,
 		bssBaseURI, err := getBaseURIBSS(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for BSS")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -61,6 +64,7 @@ This command sends a PATCH to BSS. An access token is required.`,
 		bssClient, err := bss.NewClient(bssBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new BSS client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -78,6 +82,7 @@ This command sends a PATCH to BSS. An access token is required.`,
 			bp.Hosts, err = cmd.Flags().GetStringSlice("xname")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch xname list")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}
@@ -85,10 +90,12 @@ This command sends a PATCH to BSS. An access token is required.`,
 			bp.Macs, err = cmd.Flags().GetStringSlice("mac")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch mac list")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 			if err = bp.CheckMacs(); err != nil {
 				log.Logger.Error().Err(err).Msg("invalid mac(s)")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}
@@ -96,6 +103,7 @@ This command sends a PATCH to BSS. An access token is required.`,
 			bp.Nids, err = cmd.Flags().GetInt32Slice("nid")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch nid list")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}
@@ -105,6 +113,7 @@ This command sends a PATCH to BSS. An access token is required.`,
 			bp.Kernel, err = cmd.Flags().GetString("kernel")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch kernel uri")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}
@@ -112,6 +121,7 @@ This command sends a PATCH to BSS. An access token is required.`,
 			bp.Initrd, err = cmd.Flags().GetString("initrd")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch initrd uri")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}
@@ -119,6 +129,7 @@ This command sends a PATCH to BSS. An access token is required.`,
 			bp.Params, err = cmd.Flags().GetString("params")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch params")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}
@@ -131,6 +142,7 @@ This command sends a PATCH to BSS. An access token is required.`,
 			} else {
 				log.Logger.Error().Err(err).Msg("failed to set boot parameters in BSS")
 			}
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 	},

--- a/cmd/bss-boot-params-update.go
+++ b/cmd/bss-boot-params-update.go
@@ -39,11 +39,7 @@ This command sends a PATCH to BSS. An access token is required.`,
 		if len(args) == 0 &&
 			!cmd.Flag("xname").Changed && !cmd.Flag("nid").Changed && !cmd.Flag("mac").Changed &&
 			!cmd.Flag("kernel").Changed && !cmd.Flag("initrd").Changed && !cmd.Flag("payload").Changed {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
 

--- a/cmd/bss-boot-params-update.go
+++ b/cmd/bss-boot-params-update.go
@@ -34,11 +34,7 @@ This command sends a PATCH to BSS. An access token is required.`,
   ochami bss boot params update -f payload.yaml --payload-format yaml
   echo '<json_data>' | ochami bss boot params update -f -
   echo '<yaml_data>' | ochami bss boot params update -f - --payload-format yaml`,
-	Run: func(cmd *cobra.Command, args []string) {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// cmd.LocalFlags().NFlag() doesn't seem to work, so we check every flag
 		if len(args) == 0 &&
 			!cmd.Flag("xname").Changed && !cmd.Flag("nid").Changed && !cmd.Flag("mac").Changed &&
@@ -47,6 +43,13 @@ This command sends a PATCH to BSS. An access token is required.`,
 			os.Exit(0)
 		}
 
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		bssBaseURI, err := getBaseURIBSS(cmd)
 		if err != nil {

--- a/cmd/bss-boot-params-update.go
+++ b/cmd/bss-boot-params-update.go
@@ -35,6 +35,10 @@ This command sends a PATCH to BSS. An access token is required.`,
   echo '<json_data>' | ochami bss boot params update -f -
   echo '<yaml_data>' | ochami bss boot params update -f - --payload-format yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// cmd.LocalFlags().NFlag() doesn't seem to work, so we check every flag
 		if len(args) == 0 &&
 			!cmd.Flag("xname").Changed && !cmd.Flag("nid").Changed && !cmd.Flag("mac").Changed &&

--- a/cmd/bss-boot-params-update.go
+++ b/cmd/bss-boot-params-update.go
@@ -43,10 +43,6 @@ This command sends a PATCH to BSS. An access token is required.`,
 			os.Exit(0)
 		}
 
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/bss-boot-params.go
+++ b/cmd/bss-boot-params.go
@@ -14,7 +14,9 @@ var bootParamsCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Short: "Work with boot parameters for components",
 	Long: `Work with boot parameters for components, including kernel URI, initrd URI,
-and kernel command line arguments. This is a metacommand.`,
+and kernel command line arguments. This is a metacommand.
+
+See ochami-bss(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			printUsageHandleError(cmd)

--- a/cmd/bss-boot-params.go
+++ b/cmd/bss-boot-params.go
@@ -5,7 +5,6 @@ package cmd
 import (
 	"os"
 
-	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/spf13/cobra"
 )
 
@@ -18,11 +17,7 @@ var bootParamsCmd = &cobra.Command{
 and kernel command line arguments. This is a metacommand.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
 	},

--- a/cmd/bss-boot-script-get.go
+++ b/cmd/bss-boot-script-get.go
@@ -22,13 +22,16 @@ var bootScriptGetCmd = &cobra.Command{
 	Long: `Get iPXE boot script for a component. Specifying one of --mac, --xname,
 or --nid is required to specify which component to fetch the boot script for.
 
-This command sends a GET to BSS. An access token is not required.`,
+This command sends a GET to BSS. An access token is not required.
+
+See ochami-bss(1) for more details.`,
 	Example: `  ochami boot script get --mac 00:c0:ff:ee:00:00`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		bssBaseURI, err := getBaseURIBSS(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for BSS")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -36,6 +39,7 @@ This command sends a GET to BSS. An access token is not required.`,
 		bssClient, err := bss.NewClient(bssBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new BSS client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -50,6 +54,7 @@ This command sends a GET to BSS. An access token is not required.`,
 			s, err := cmd.Flags().GetStringSlice("xname")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch xname list")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 			for _, x := range s {
@@ -60,6 +65,7 @@ This command sends a GET to BSS. An access token is not required.`,
 			s, err := cmd.Flags().GetStringSlice("mac")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch mac list")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 			for _, m := range s {
@@ -70,6 +76,7 @@ This command sends a GET to BSS. An access token is not required.`,
 			s, err := cmd.Flags().GetInt32Slice("nid")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch nid list")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 			for _, n := range s {
@@ -82,6 +89,7 @@ This command sends a GET to BSS. An access token is not required.`,
 			s, err := cmd.Flags().GetInt("retry")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch number of retries")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 			values.Add("retry", fmt.Sprintf("%d", s))
@@ -90,6 +98,7 @@ This command sends a GET to BSS. An access token is not required.`,
 			s, err := cmd.Flags().GetString("arch")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch arch")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 			values.Add("arch", s)
@@ -98,6 +107,7 @@ This command sends a GET to BSS. An access token is not required.`,
 			s, err := cmd.Flags().GetInt("timestamp")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("unable to fetch timestamp")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 			values.Add("timestamp", fmt.Sprintf("%d", s))
@@ -111,6 +121,7 @@ This command sends a GET to BSS. An access token is not required.`,
 			} else {
 				log.Logger.Error().Err(err).Msg("failed to request boot script from BSS")
 			}
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 		fmt.Println(string(httpEnv.Body))

--- a/cmd/bss-boot-script-get.go
+++ b/cmd/bss-boot-script-get.go
@@ -24,11 +24,14 @@ or --nid is required to specify which component to fetch the boot script for.
 
 This command sends a GET to BSS. An access token is not required.`,
 	Example: `  ochami boot script get --mac 00:c0:ff:ee:00:00`,
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		bssBaseURI, err := getBaseURIBSS(cmd)
 		if err != nil {

--- a/cmd/bss-boot-script-get.go
+++ b/cmd/bss-boot-script-get.go
@@ -25,6 +25,10 @@ or --nid is required to specify which component to fetch the boot script for.
 This command sends a GET to BSS. An access token is not required.`,
 	Example: `  ochami boot script get --mac 00:c0:ff:ee:00:00`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Without a base URI, we cannot do anything
 		bssBaseURI, err := getBaseURIBSS(cmd)
 		if err != nil {

--- a/cmd/bss-boot-script-get.go
+++ b/cmd/bss-boot-script-get.go
@@ -24,13 +24,6 @@ or --nid is required to specify which component to fetch the boot script for.
 
 This command sends a GET to BSS. An access token is not required.`,
 	Example: `  ochami boot script get --mac 00:c0:ff:ee:00:00`,
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
-		return nil
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		bssBaseURI, err := getBaseURIBSS(cmd)

--- a/cmd/bss-boot-script.go
+++ b/cmd/bss-boot-script.go
@@ -5,7 +5,6 @@ package cmd
 import (
 	"os"
 
-	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/spf13/cobra"
 )
 
@@ -17,11 +16,7 @@ var bootScriptCmd = &cobra.Command{
 	Long:  `Work with boot scripts for components. This is a metacommand.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
 	},

--- a/cmd/bss-boot-script.go
+++ b/cmd/bss-boot-script.go
@@ -13,7 +13,9 @@ var bootScriptCmd = &cobra.Command{
 	Use:   "script",
 	Args:  cobra.NoArgs,
 	Short: "Work with boot scripts for components",
-	Long:  `Work with boot scripts for components. This is a metacommand.`,
+	Long: `Work with boot scripts for components. This is a metacommand.
+
+See ochami-bss(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			printUsageHandleError(cmd)

--- a/cmd/bss-boot.go
+++ b/cmd/bss-boot.go
@@ -5,7 +5,6 @@ package cmd
 import (
 	"os"
 
-	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/spf13/cobra"
 )
 
@@ -18,11 +17,7 @@ var bootCmd = &cobra.Command{
 under this one interact with the Boot Script Service (BSS).`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
 	},

--- a/cmd/bss-boot.go
+++ b/cmd/bss-boot.go
@@ -14,7 +14,9 @@ var bootCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Short: "Manage boot configuration for components",
 	Long: `Manage boot configuration for components. This is a metacommand. Commands
-under this one interact with the Boot Script Service (BSS).`,
+under this one interact with the Boot Script Service (BSS).
+
+See ochami-bss(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			printUsageHandleError(cmd)

--- a/cmd/bss-dumpstate.go
+++ b/cmd/bss-dumpstate.go
@@ -18,11 +18,15 @@ var bssDumpStateCmd = &cobra.Command{
 	Use:   "dumpstate",
 	Args:  cobra.NoArgs,
 	Short: "Retrieve the current state of BSS",
+	Long: `Retrieve the current state of BSS.
+
+See ochami-bss(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		bssBaseURI, err := getBaseURIBSS(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for BSS")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -30,6 +34,7 @@ var bssDumpStateCmd = &cobra.Command{
 		bssClient, err := bss.NewClient(bssBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new BSS client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -44,6 +49,7 @@ var bssDumpStateCmd = &cobra.Command{
 			} else {
 				log.Logger.Error().Err(err).Msg("failed to request dump state from BSS")
 			}
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -52,10 +58,12 @@ var bssDumpStateCmd = &cobra.Command{
 		outFmt, err := cmd.Flags().GetString("output-format")
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 		if outBytes, err := client.FormatBody(httpEnv.Body, outFmt); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to format output")
+			logHelpError(cmd)
 			os.Exit(1)
 		} else {
 			fmt.Printf(string(outBytes))

--- a/cmd/bss-dumpstate.go
+++ b/cmd/bss-dumpstate.go
@@ -19,6 +19,10 @@ var bssDumpStateCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Short: "Retrieve the current state of BSS",
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Without a base URI, we cannot do anything
 		bssBaseURI, err := getBaseURIBSS(cmd)
 		if err != nil {

--- a/cmd/bss-dumpstate.go
+++ b/cmd/bss-dumpstate.go
@@ -18,13 +18,6 @@ var bssDumpStateCmd = &cobra.Command{
 	Use:   "dumpstate",
 	Args:  cobra.NoArgs,
 	Short: "Retrieve the current state of BSS",
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
-		return nil
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		bssBaseURI, err := getBaseURIBSS(cmd)

--- a/cmd/bss-dumpstate.go
+++ b/cmd/bss-dumpstate.go
@@ -18,11 +18,14 @@ var bssDumpStateCmd = &cobra.Command{
 	Use:   "dumpstate",
 	Args:  cobra.NoArgs,
 	Short: "Retrieve the current state of BSS",
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		bssBaseURI, err := getBaseURIBSS(cmd)
 		if err != nil {

--- a/cmd/bss-history.go
+++ b/cmd/bss-history.go
@@ -19,11 +19,15 @@ var bssHistoryCmd = &cobra.Command{
 	Use:   "history",
 	Args:  cobra.NoArgs,
 	Short: "Fetch the endpoint history of BSS",
+	Long: `Fetch the endpoint history of BSS.
+
+See ochami-bss(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		bssBaseURI, err := getBaseURIBSS(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for BSS")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -31,6 +35,7 @@ var bssHistoryCmd = &cobra.Command{
 		bssClient, err := bss.NewClient(bssBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new BSS client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -45,6 +50,7 @@ var bssHistoryCmd = &cobra.Command{
 				x, err := cmd.Flags().GetString("xname")
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch xname")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 				values.Add("name", x)
@@ -53,6 +59,7 @@ var bssHistoryCmd = &cobra.Command{
 				e, err := cmd.Flags().GetString("endpoint")
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch endpoint")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 				values.Add("endpoint", e)
@@ -68,6 +75,7 @@ var bssHistoryCmd = &cobra.Command{
 			} else {
 				log.Logger.Error().Err(err).Msg("failed to request endpoint history from BSS")
 			}
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -75,10 +83,12 @@ var bssHistoryCmd = &cobra.Command{
 		outFmt, err := cmd.Flags().GetString("output-format")
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 		if outBytes, err := client.FormatBody(httpEnv.Body, outFmt); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to format output")
+			logHelpError(cmd)
 			os.Exit(1)
 		} else {
 			fmt.Printf(string(outBytes))

--- a/cmd/bss-history.go
+++ b/cmd/bss-history.go
@@ -19,13 +19,6 @@ var bssHistoryCmd = &cobra.Command{
 	Use:   "history",
 	Args:  cobra.NoArgs,
 	Short: "Fetch the endpoint history of BSS",
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
-		return nil
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		bssBaseURI, err := getBaseURIBSS(cmd)

--- a/cmd/bss-history.go
+++ b/cmd/bss-history.go
@@ -20,6 +20,10 @@ var bssHistoryCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Short: "Fetch the endpoint history of BSS",
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Without a base URI, we cannot do anything
 		bssBaseURI, err := getBaseURIBSS(cmd)
 		if err != nil {

--- a/cmd/bss-history.go
+++ b/cmd/bss-history.go
@@ -19,11 +19,14 @@ var bssHistoryCmd = &cobra.Command{
 	Use:   "history",
 	Args:  cobra.NoArgs,
 	Short: "Fetch the endpoint history of BSS",
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		bssBaseURI, err := getBaseURIBSS(cmd)
 		if err != nil {

--- a/cmd/bss-hosts-get.go
+++ b/cmd/bss-hosts-get.go
@@ -19,11 +19,15 @@ var bssHostsGetCmd = &cobra.Command{
 	Use:   "get",
 	Args:  cobra.NoArgs,
 	Short: "Get information on hosts known to BSS",
+	Long: `Get information on hosts known to BSS.
+
+See ochami-bss(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		bssBaseURI, err := getBaseURIBSS(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for BSS")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -31,6 +35,7 @@ var bssHostsGetCmd = &cobra.Command{
 		bssClient, err := bss.NewClient(bssBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new BSS client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -47,6 +52,7 @@ var bssHostsGetCmd = &cobra.Command{
 				x, err := cmd.Flags().GetString("xname")
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch xname")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 				values.Add("name", x)
@@ -55,6 +61,7 @@ var bssHostsGetCmd = &cobra.Command{
 				m, err := cmd.Flags().GetString("mac")
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch mac")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 				values.Add("mac", m)
@@ -63,6 +70,7 @@ var bssHostsGetCmd = &cobra.Command{
 				n, err := cmd.Flags().GetInt32("nid")
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch nid")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 				values.Add("nid", fmt.Sprintf("%d", n))
@@ -76,6 +84,7 @@ var bssHostsGetCmd = &cobra.Command{
 			} else {
 				log.Logger.Error().Err(err).Msg("failed to request hosts from BSS")
 			}
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -83,10 +92,12 @@ var bssHostsGetCmd = &cobra.Command{
 		outFmt, err := cmd.Flags().GetString("output-format")
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 		if outBytes, err := client.FormatBody(httpEnv.Body, outFmt); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to format output")
+			logHelpError(cmd)
 			os.Exit(1)
 		} else {
 			fmt.Printf(string(outBytes))

--- a/cmd/bss-hosts-get.go
+++ b/cmd/bss-hosts-get.go
@@ -19,11 +19,14 @@ var bssHostsGetCmd = &cobra.Command{
 	Use:   "get",
 	Args:  cobra.NoArgs,
 	Short: "Get information on hosts known to BSS",
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		bssBaseURI, err := getBaseURIBSS(cmd)
 		if err != nil {

--- a/cmd/bss-hosts-get.go
+++ b/cmd/bss-hosts-get.go
@@ -20,6 +20,10 @@ var bssHostsGetCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Short: "Get information on hosts known to BSS",
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Without a base URI, we cannot do anything
 		bssBaseURI, err := getBaseURIBSS(cmd)
 		if err != nil {

--- a/cmd/bss-hosts-get.go
+++ b/cmd/bss-hosts-get.go
@@ -19,13 +19,6 @@ var bssHostsGetCmd = &cobra.Command{
 	Use:   "get",
 	Args:  cobra.NoArgs,
 	Short: "Get information on hosts known to BSS",
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
-		return nil
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		bssBaseURI, err := getBaseURIBSS(cmd)

--- a/cmd/bss-hosts.go
+++ b/cmd/bss-hosts.go
@@ -5,7 +5,6 @@ package cmd
 import (
 	"os"
 
-	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/spf13/cobra"
 )
 
@@ -16,11 +15,7 @@ var bssHostsCmd = &cobra.Command{
 	Short: "Work with hosts in BSS",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
 	},

--- a/cmd/bss-hosts.go
+++ b/cmd/bss-hosts.go
@@ -13,6 +13,9 @@ var bssHostsCmd = &cobra.Command{
 	Use:   "hosts",
 	Args:  cobra.NoArgs,
 	Short: "Work with hosts in BSS",
+	Long: `Work with hosts in BSS.
+
+See ochami-bss(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			printUsageHandleError(cmd)

--- a/cmd/bss-status.go
+++ b/cmd/bss-status.go
@@ -17,12 +17,16 @@ import (
 var bssStatusCmd = &cobra.Command{
 	Use:   "status",
 	Args:  cobra.NoArgs,
-	Short: "Get status of BSS service",
+	Short: "Get status of the Boot Script Service (BSS)",
+	Long: `Get status of the Boot Script Service (BSS).
+
+See ochami-bss(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		bssBaseURI, err := getBaseURIBSS(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for BSS")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -30,6 +34,7 @@ var bssStatusCmd = &cobra.Command{
 		bssClient, err := bss.NewClient(bssBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new BSS client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -55,6 +60,7 @@ var bssStatusCmd = &cobra.Command{
 			} else {
 				log.Logger.Error().Err(err).Msg("failed to get BSS status")
 			}
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -62,10 +68,12 @@ var bssStatusCmd = &cobra.Command{
 		outFmt, err := cmd.Flags().GetString("output-format")
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 		if outBytes, err := client.FormatBody(httpEnv.Body, outFmt); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to format output")
+			logHelpError(cmd)
 			os.Exit(1)
 		} else {
 			fmt.Printf(string(outBytes))

--- a/cmd/bss-status.go
+++ b/cmd/bss-status.go
@@ -19,6 +19,10 @@ var bssStatusCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Short: "Get status of BSS service",
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Without a base URI, we cannot do anything
 		bssBaseURI, err := getBaseURIBSS(cmd)
 		if err != nil {

--- a/cmd/bss-status.go
+++ b/cmd/bss-status.go
@@ -18,13 +18,6 @@ var bssStatusCmd = &cobra.Command{
 	Use:   "status",
 	Args:  cobra.NoArgs,
 	Short: "Get status of BSS service",
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
-		return nil
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		bssBaseURI, err := getBaseURIBSS(cmd)

--- a/cmd/bss-status.go
+++ b/cmd/bss-status.go
@@ -18,11 +18,14 @@ var bssStatusCmd = &cobra.Command{
 	Use:   "status",
 	Args:  cobra.NoArgs,
 	Short: "Get status of BSS service",
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		bssBaseURI, err := getBaseURIBSS(cmd)
 		if err != nil {

--- a/cmd/bss.go
+++ b/cmd/bss.go
@@ -13,6 +13,9 @@ var bssCmd = &cobra.Command{
 	Use:   "bss",
 	Args:  cobra.NoArgs,
 	Short: "Communicate with the Boot Script Service (BSS)",
+	Long: `Communicate with the Boot Script Service (BSS).
+
+See ochami-bss(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			printUsageHandleError(cmd)

--- a/cmd/bss.go
+++ b/cmd/bss.go
@@ -5,7 +5,6 @@ package cmd
 import (
 	"os"
 
-	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/spf13/cobra"
 )
 
@@ -16,11 +15,7 @@ var bssCmd = &cobra.Command{
 	Short: "Communicate with the Boot Script Service (BSS)",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
 	},

--- a/cmd/cloud_init-config-add.go
+++ b/cmd/cloud_init-config-add.go
@@ -27,7 +27,9 @@ even if only one is being passed. An alternative to using
 -d would be to use -f and passing -, which will cause ochami
 to read the data from standard input.
 
-This command sends a POST to cloud-init.`,
+This command sends a POST to cloud-init.
+
+See ochami-cloud-init(1) for more details.`,
 	Example: `  ochami cloud-init config add -d \
     '[ \
        { \
@@ -56,6 +58,7 @@ This command sends a POST to cloud-init.`,
 		cloudInitBaseURI, err := getBaseURI(cmd, config.ServiceCloudInit)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for cloud-init")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -67,6 +70,7 @@ This command sends a POST to cloud-init.`,
 		cloudInitClient, err := ci.NewClient(cloudInitBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new cloud-init client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -82,11 +86,13 @@ This command sends a POST to cloud-init.`,
 			rawJSON, err := cmd.Flags().GetString("data")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to fetch json data")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 			err = json.Unmarshal([]byte(rawJSON), &ciData)
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to marshal json data")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}
@@ -100,6 +106,7 @@ This command sends a POST to cloud-init.`,
 		}
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to add cloud-init configs")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 		// Since cloudInitClient.Post* functions do the addition iteratively, we need to deal with
@@ -109,8 +116,10 @@ This command sends a POST to cloud-init.`,
 			if e != nil {
 				if errors.Is(err, client.UnsuccessfulHTTPError) {
 					log.Logger.Error().Err(e).Msg("cloud-init config request yielded unsuccessful HTTP response")
+					logHelpError(cmd)
 				} else {
 					log.Logger.Error().Err(e).Msg("failed to add config(s) to cloud-init")
+					logHelpError(cmd)
 				}
 				errorsOccurred = true
 			}
@@ -118,6 +127,7 @@ This command sends a POST to cloud-init.`,
 		// Warn the user if any errors occurred during addition iterations
 		if errorsOccurred {
 			log.Logger.Warn().Msg("cloud-init config addition completed with errors")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 	},

--- a/cmd/cloud_init-config-add.go
+++ b/cmd/cloud_init-config-add.go
@@ -52,6 +52,10 @@ This command sends a POST to cloud-init.`,
   echo '<json_data>' | ochami cloud-init config add -f -
   echo '<yaml_data>' | ochami cloud-init config add -f - --payload-format yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Without a base URI, we cannot do anything
 		cloudInitBaseURI, err := getBaseURI(cmd, config.ServiceCloudInit)
 		if err != nil {

--- a/cmd/cloud_init-config-add.go
+++ b/cmd/cloud_init-config-add.go
@@ -51,13 +51,6 @@ This command sends a POST to cloud-init.`,
   ochami cloud-init config add -f payload.yaml --payload-format yaml
   echo '<json_data>' | ochami cloud-init config add -f -
   echo '<yaml_data>' | ochami cloud-init config add -f - --payload-format yaml`,
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
-		return nil
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		cloudInitBaseURI, err := getBaseURI(cmd, config.ServiceCloudInit)

--- a/cmd/cloud_init-config-add.go
+++ b/cmd/cloud_init-config-add.go
@@ -51,11 +51,14 @@ This command sends a POST to cloud-init.`,
   ochami cloud-init config add -f payload.yaml --payload-format yaml
   echo '<json_data>' | ochami cloud-init config add -f -
   echo '<yaml_data>' | ochami cloud-init config add -f - --payload-format yaml`,
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		cloudInitBaseURI, err := getBaseURI(cmd, config.ServiceCloudInit)
 		if err != nil {

--- a/cmd/cloud_init-config-delete.go
+++ b/cmd/cloud_init-config-delete.go
@@ -15,15 +15,19 @@ import (
 
 // cloudInitConfigDeleteCmd represents the cloud-init-config-delete command
 var cloudInitConfigDeleteCmd = &cobra.Command{
-	Use:     "delete <id>...",
-	Args:    cobra.MinimumNArgs(1),
-	Short:   "Delete one or more cloud-init configs",
+	Use:   "delete <id>...",
+	Args:  cobra.MinimumNArgs(1),
+	Short: "Delete one or more cloud-init configs",
+	Long: `Delete one or more cloud-init configs.
+
+See ochami-cloud-init(1) for more details.`,
 	Example: `  ochami cloud-init config delete compute`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		cloudInitBaseURI, err := getBaseURI(cmd, config.ServiceCloudInit)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for cloud-init")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -35,6 +39,7 @@ var cloudInitConfigDeleteCmd = &cobra.Command{
 		cloudInitClient, err := ci.NewClient(cloudInitBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new cloud-init client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -62,6 +67,7 @@ var cloudInitConfigDeleteCmd = &cobra.Command{
 		}
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to delete cloud-init configs")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 		// Since cloudInitClient.Delete* functions do the deletion iteratively, we need to deal with
@@ -80,6 +86,7 @@ var cloudInitConfigDeleteCmd = &cobra.Command{
 		// Warn the user if any errors occurred during deletion iterations
 		if errorsOccurred {
 			log.Logger.Warn().Msg("cloud-init config deletion completed with errors")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 	},

--- a/cmd/cloud_init-config-delete.go
+++ b/cmd/cloud_init-config-delete.go
@@ -19,11 +19,14 @@ var cloudInitConfigDeleteCmd = &cobra.Command{
 	Args:    cobra.MinimumNArgs(1),
 	Short:   "Delete one or more cloud-init configs",
 	Example: `  ochami cloud-init config delete compute`,
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		cloudInitBaseURI, err := getBaseURI(cmd, config.ServiceCloudInit)
 		if err != nil {

--- a/cmd/cloud_init-config-delete.go
+++ b/cmd/cloud_init-config-delete.go
@@ -20,6 +20,10 @@ var cloudInitConfigDeleteCmd = &cobra.Command{
 	Short:   "Delete one or more cloud-init configs",
 	Example: `  ochami cloud-init config delete compute`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Without a base URI, we cannot do anything
 		cloudInitBaseURI, err := getBaseURI(cmd, config.ServiceCloudInit)
 		if err != nil {

--- a/cmd/cloud_init-config-delete.go
+++ b/cmd/cloud_init-config-delete.go
@@ -19,13 +19,6 @@ var cloudInitConfigDeleteCmd = &cobra.Command{
 	Args:    cobra.MinimumNArgs(1),
 	Short:   "Delete one or more cloud-init configs",
 	Example: `  ochami cloud-init config delete compute`,
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
-		return nil
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		cloudInitBaseURI, err := getBaseURI(cmd, config.ServiceCloudInit)

--- a/cmd/cloud_init-config-get.go
+++ b/cmd/cloud_init-config-get.go
@@ -19,6 +19,9 @@ var cloudInitConfigGetCmd = &cobra.Command{
 	Use:   "get [id]",
 	Args:  cobra.MaximumNArgs(1),
 	Short: "Get cloud-init configs, all or for an identifier",
+	Long: `Get cloud-init configs, all or for an identifier.
+
+See ochami-cloud-init(1) for more details.`,
 	Example: `ochami cloud-init config get
   ochami cloud-init config get compute
   ochami cloud-init config get --secure compute`,
@@ -27,6 +30,7 @@ var cloudInitConfigGetCmd = &cobra.Command{
 		cloudInitbaseURI, err := getBaseURI(cmd, config.ServiceCloudInit)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for cloud-init")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -34,6 +38,7 @@ var cloudInitConfigGetCmd = &cobra.Command{
 		cloudInitClient, err := ci.NewClient(cloudInitbaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new cloud-init client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -61,6 +66,7 @@ var cloudInitConfigGetCmd = &cobra.Command{
 			} else {
 				log.Logger.Error().Err(err).Msg("failed to request configs from cloud-init")
 			}
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -68,10 +74,12 @@ var cloudInitConfigGetCmd = &cobra.Command{
 		outFmt, err := cmd.Flags().GetString("output-format")
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 		if outBytes, err := client.FormatBody(httpEnv.Body, outFmt); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to format output")
+			logHelpError(cmd)
 			os.Exit(1)
 		} else {
 			fmt.Printf(string(outBytes))

--- a/cmd/cloud_init-config-get.go
+++ b/cmd/cloud_init-config-get.go
@@ -23,6 +23,10 @@ var cloudInitConfigGetCmd = &cobra.Command{
   ochami cloud-init config get compute
   ochami cloud-init config get --secure compute`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Without a base URI, we cannot do anything
 		cloudInitbaseURI, err := getBaseURI(cmd, config.ServiceCloudInit)
 		if err != nil {

--- a/cmd/cloud_init-config-get.go
+++ b/cmd/cloud_init-config-get.go
@@ -22,11 +22,14 @@ var cloudInitConfigGetCmd = &cobra.Command{
 	Example: `ochami cloud-init config get
   ochami cloud-init config get compute
   ochami cloud-init config get --secure compute`,
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		cloudInitbaseURI, err := getBaseURI(cmd, config.ServiceCloudInit)
 		if err != nil {

--- a/cmd/cloud_init-config-get.go
+++ b/cmd/cloud_init-config-get.go
@@ -22,13 +22,6 @@ var cloudInitConfigGetCmd = &cobra.Command{
 	Example: `ochami cloud-init config get
   ochami cloud-init config get compute
   ochami cloud-init config get --secure compute`,
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
-		return nil
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		cloudInitbaseURI, err := getBaseURI(cmd, config.ServiceCloudInit)

--- a/cmd/cloud_init-config-update.go
+++ b/cmd/cloud_init-config-update.go
@@ -27,7 +27,9 @@ one is being passed. An alternative to using -d would be to use -f
 and passing -, which will cause ochami to read the data from
 standard input.
 
-This command sends a PUT to cloud-init.`,
+This command sends a PUT to cloud-init.
+
+See ochami-cloud-init(1) for more details.`,
 	Example: `  ochami cloud-init config update -d \
     '[ \
        { \
@@ -53,6 +55,7 @@ This command sends a PUT to cloud-init.`,
 		cloudInitBaseURI, err := getBaseURI(cmd, config.ServiceCloudInit)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for cloud-init")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -64,6 +67,7 @@ This command sends a PUT to cloud-init.`,
 		cloudInitClient, err := ci.NewClient(cloudInitBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new cloud-init client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -79,11 +83,13 @@ This command sends a PUT to cloud-init.`,
 			rawJSON, err := cmd.Flags().GetString("data")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to fetch json data")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 			err = json.Unmarshal([]byte(rawJSON), &ciData)
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to marshal json data")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}
@@ -97,6 +103,7 @@ This command sends a PUT to cloud-init.`,
 		}
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to set cloud-init configs")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 		// Since cloudInitClient.Put* functions do the setting iteratively, we need to deal with
@@ -115,6 +122,7 @@ This command sends a PUT to cloud-init.`,
 		// Warn the user if any errors occurred during editing iterations
 		if errorsOccurred {
 			log.Logger.Warn().Msgf("cloud-init config setting completed with errors")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 	},

--- a/cmd/cloud_init-config-update.go
+++ b/cmd/cloud_init-config-update.go
@@ -48,13 +48,6 @@ This command sends a PUT to cloud-init.`,
   ochami cloud-init config update -f payload.yaml --payload-format yaml
   echo '<json_data>' | ochami cloud-init config update -f -
   echo '<yaml_data>' | ochami cloud-init config update -f - --payload-format yaml`,
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
-		return nil
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		cloudInitBaseURI, err := getBaseURI(cmd, config.ServiceCloudInit)

--- a/cmd/cloud_init-config-update.go
+++ b/cmd/cloud_init-config-update.go
@@ -48,11 +48,14 @@ This command sends a PUT to cloud-init.`,
   ochami cloud-init config update -f payload.yaml --payload-format yaml
   echo '<json_data>' | ochami cloud-init config update -f -
   echo '<yaml_data>' | ochami cloud-init config update -f - --payload-format yaml`,
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		cloudInitBaseURI, err := getBaseURI(cmd, config.ServiceCloudInit)
 		if err != nil {

--- a/cmd/cloud_init-config-update.go
+++ b/cmd/cloud_init-config-update.go
@@ -49,6 +49,10 @@ This command sends a PUT to cloud-init.`,
   echo '<json_data>' | ochami cloud-init config update -f -
   echo '<yaml_data>' | ochami cloud-init config update -f - --payload-format yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Without a base URI, we cannot do anything
 		cloudInitBaseURI, err := getBaseURI(cmd, config.ServiceCloudInit)
 		if err != nil {

--- a/cmd/cloud_init-config.go
+++ b/cmd/cloud_init-config.go
@@ -15,7 +15,9 @@ var cloudInitConfigCmd = &cobra.Command{
 	Short: "Manage cloud-init configurations for components",
 	Long: `Manage cloud-init configurations for components. This is a metacommand. Commands
 under this one interact with the cloud-init service and deal with
-cloud-init configurations.`,
+cloud-init configurations.
+
+See ochami-cloud-init(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			printUsageHandleError(cmd)

--- a/cmd/cloud_init-config.go
+++ b/cmd/cloud_init-config.go
@@ -5,7 +5,6 @@ package cmd
 import (
 	"os"
 
-	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/spf13/cobra"
 )
 
@@ -19,11 +18,7 @@ under this one interact with the cloud-init service and deal with
 cloud-init configurations.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
 	},

--- a/cmd/cloud_init-data-get.go
+++ b/cmd/cloud_init-data-get.go
@@ -22,7 +22,9 @@ var cloudInitDataGetCmd = &cobra.Command{
 	Long: `Get cloud-init data for an identifier. By default, user-data is
 retrieved. This also occurs if --user is passed. --meta or
 --vendor can also be specified to fetch cloud-init meta-data
-or vendor-data, respectively.`,
+or vendor-data, respectively.
+
+See ochami-cloud-init(1) for more details.`,
 	Example: `  ochami cloud-init data get compute
   ochami cloud-init data get --user compute
   ochami cloud-init data get --meta compute
@@ -32,6 +34,7 @@ or vendor-data, respectively.`,
 		cloudInitbaseURI, err := getBaseURI(cmd, config.ServiceCloudInit)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for cloud-init")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -39,6 +42,7 @@ or vendor-data, respectively.`,
 		cloudInitClient, err := ci.NewClient(cloudInitbaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new cloud-init client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -71,6 +75,7 @@ or vendor-data, respectively.`,
 
 		if err != nil {
 			log.Logger.Error().Err(err).Msgf("failed to get %s from cloud-init", ciType)
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 		// Since the cloud-init data get functions do the deletion
@@ -90,6 +95,7 @@ or vendor-data, respectively.`,
 		// Warn the user if any errors occurred during deletion iterations
 		if errorsOccurred {
 			log.Logger.Warn().Msgf("cloud-init %s get completed with errors", ciType)
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 

--- a/cmd/cloud_init-data-get.go
+++ b/cmd/cloud_init-data-get.go
@@ -27,6 +27,10 @@ or vendor-data, respectively.`,
   ochami cloud-init data get --meta compute
   ochami cloud-init data get --vendor compute`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// We need at least one ID to do anything
 		if len(args) == 0 {
 			printUsageHandleError(cmd)

--- a/cmd/cloud_init-data-get.go
+++ b/cmd/cloud_init-data-get.go
@@ -17,6 +17,7 @@ import (
 // cloudInitDataGetCmd represents the cloud-init-data-get command
 var cloudInitDataGetCmd = &cobra.Command{
 	Use:   "get [--user | --meta | --vendor] <id>...",
+	Args:  cobra.MinimumNArgs(1),
 	Short: "Get cloud-init data for an identifier",
 	Long: `Get cloud-init data for an identifier. By default, user-data is
 retrieved. This also occurs if --user is passed. --meta or
@@ -26,17 +27,14 @@ or vendor-data, respectively.`,
   ochami cloud-init data get --user compute
   ochami cloud-init data get --meta compute
   ochami cloud-init data get --vendor compute`,
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
 
-		// We need at least one ID to do anything
-		if len(args) == 0 {
-			printUsageHandleError(cmd)
-			os.Exit(0)
-		}
-
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		cloudInitbaseURI, err := getBaseURI(cmd, config.ServiceCloudInit)
 		if err != nil {

--- a/cmd/cloud_init-data-get.go
+++ b/cmd/cloud_init-data-get.go
@@ -27,13 +27,6 @@ or vendor-data, respectively.`,
   ochami cloud-init data get --user compute
   ochami cloud-init data get --meta compute
   ochami cloud-init data get --vendor compute`,
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
-		return nil
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		cloudInitbaseURI, err := getBaseURI(cmd, config.ServiceCloudInit)

--- a/cmd/cloud_init-data-get.go
+++ b/cmd/cloud_init-data-get.go
@@ -29,11 +29,7 @@ or vendor-data, respectively.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// We need at least one ID to do anything
 		if len(args) == 0 {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
 

--- a/cmd/cloud_init-data.go
+++ b/cmd/cloud_init-data.go
@@ -5,7 +5,6 @@ package cmd
 import (
 	"os"
 
-	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/spf13/cobra"
 )
 
@@ -18,11 +17,7 @@ var cloudInitDataCmd = &cobra.Command{
 interact with the cloud-init service and deal with cloud-init data.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
 	},

--- a/cmd/cloud_init-data.go
+++ b/cmd/cloud_init-data.go
@@ -14,7 +14,9 @@ var cloudInitDataCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Short: "View cloud-init data",
 	Long: `View cloud-init data. This is a metacommand. Commands under this one
-interact with the cloud-init service and deal with cloud-init data.`,
+interact with the cloud-init service and deal with cloud-init data.
+
+See ochami-cloud-init(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			printUsageHandleError(cmd)

--- a/cmd/cloud_init.go
+++ b/cmd/cloud_init.go
@@ -5,7 +5,6 @@ package cmd
 import (
 	"os"
 
-	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/spf13/cobra"
 )
 
@@ -17,11 +16,7 @@ var cloudInitCmd = &cobra.Command{
 	Long:  `Interact with the cloud-init service. This is a metacommand.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
 	},

--- a/cmd/cloud_init.go
+++ b/cmd/cloud_init.go
@@ -13,7 +13,9 @@ var cloudInitCmd = &cobra.Command{
 	Use:   "cloud-init",
 	Args:  cobra.NoArgs,
 	Short: "Interact with the cloud-init service",
-	Long:  `Interact with the cloud-init service. This is a metacommand.`,
+	Long: `Interact with the cloud-init service. This is a metacommand.
+
+See ochami-cloud-init(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			printUsageHandleError(cmd)

--- a/cmd/config-cluster-delete.go
+++ b/cmd/config-cluster-delete.go
@@ -15,6 +15,10 @@ var configClusterDeleteCmd = &cobra.Command{
 	Use:   "delete <cluster_name>",
 	Args:  cobra.ExactArgs(1),
 	Short: "Delete a cluster from the configuration file",
+	Long: `Delete a cluster from the configuration file.
+
+See ochami-config(1) for details on the config commands.
+See ochami-config(5) for details on configuration options.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		// It doesn't make sense to delete a cluster from a
 		// non-existent config file, so err if the config file doesn't
@@ -43,6 +47,7 @@ var configClusterDeleteCmd = &cobra.Command{
 			var err error
 			if fileToModify, err = rootCmd.PersistentFlags().GetString("config"); err != nil {
 				log.Logger.Error().Err(err).Msgf("unable to get value from --config flag")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		} else if configCmd.PersistentFlags().Lookup("system").Changed {
@@ -55,6 +60,8 @@ var configClusterDeleteCmd = &cobra.Command{
 		cfg, err := config.ReadConfig(fileToModify)
 		if err != nil {
 			log.Logger.Error().Err(err).Msgf("failed to read config from %s", fileToModify)
+			logHelpError(cmd)
+			os.Exit(1)
 		}
 
 		// Fetch existing cluster list config
@@ -76,6 +83,7 @@ var configClusterDeleteCmd = &cobra.Command{
 				// comments will get erased.
 				if err := config.WriteConfig(fileToModify, cfg); err != nil {
 					log.Logger.Error().Err(err).Msgf("failed to write modified config to %s", fileToModify)
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 				log.Logger.Info().Msgf("cluster %s removed from config file %s", clusterName, configFile)
@@ -86,6 +94,7 @@ var configClusterDeleteCmd = &cobra.Command{
 
 		// If we have reached here, the cluster was not found
 		log.Logger.Error().Msgf("cluster %s not found in config file %s", clusterName, configFile)
+		logHelpError(cmd)
 		os.Exit(1)
 	},
 }

--- a/cmd/config-cluster-delete.go
+++ b/cmd/config-cluster-delete.go
@@ -17,11 +17,7 @@ var configClusterDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		// Check that cluster name is only arg
 		if len(args) == 0 {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		} else if len(args) > 1 {
 			log.Logger.Error().Msgf("expected 1 argument (cluster name) but got %d: %v", len(args), args)

--- a/cmd/config-cluster-delete.go
+++ b/cmd/config-cluster-delete.go
@@ -14,6 +14,13 @@ import (
 var configClusterDeleteCmd = &cobra.Command{
 	Use:   "delete <cluster_name>",
 	Short: "Delete a cluster from the configuration file",
+	PreRun: func(cmd *cobra.Command, args []string) {
+		// To mark both persistent and regular flags mutually exclusive,
+		// this function must be run before the command is executed. It
+		// will not work in init(). This means that this needs to be
+		// presend in all child commands.
+		cmd.MarkFlagsMutuallyExclusive("system", "user", "config")
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Check that cluster name is only arg
 		if len(args) == 0 {

--- a/cmd/config-cluster-delete.go
+++ b/cmd/config-cluster-delete.go
@@ -13,28 +13,22 @@ import (
 // configClusterDeleteCmd represents the config-cluster-delete command
 var configClusterDeleteCmd = &cobra.Command{
 	Use:   "delete <cluster_name>",
+	Args:  cobra.ExactArgs(1),
 	Short: "Delete a cluster from the configuration file",
-	PreRun: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// To mark both persistent and regular flags mutually exclusive,
 		// this function must be run before the command is executed. It
 		// will not work in init(). This means that this needs to be
 		// present in all child commands.
 		cmd.MarkFlagsMutuallyExclusive("system", "user", "config")
-	},
-	Run: func(cmd *cobra.Command, args []string) {
+
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
 
-		// Check that cluster name is only arg
-		if len(args) == 0 {
-			printUsageHandleError(cmd)
-			os.Exit(0)
-		} else if len(args) > 1 {
-			log.Logger.Error().Msgf("expected 1 argument (cluster name) but got %d: %v", len(args), args)
-			os.Exit(1)
-		}
-
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// We must have a config file in order to write cluster info
 		var fileToModify string
 		if rootCmd.PersistentFlags().Lookup("config").Changed {

--- a/cmd/config-cluster-delete.go
+++ b/cmd/config-cluster-delete.go
@@ -15,6 +15,14 @@ var configClusterDeleteCmd = &cobra.Command{
 	Use:   "delete <cluster_name>",
 	Args:  cobra.ExactArgs(1),
 	Short: "Delete a cluster from the configuration file",
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// It doesn't make sense to delete a cluster from a
+		// non-existent config file, so err if the config file doesn't
+		// exist.
+		initConfigAndLogging(cmd, false)
+
+		return nil
+	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// To mark both persistent and regular flags mutually exclusive,
 		// this function must be run before the command is executed. It

--- a/cmd/config-cluster-delete.go
+++ b/cmd/config-cluster-delete.go
@@ -18,10 +18,14 @@ var configClusterDeleteCmd = &cobra.Command{
 		// To mark both persistent and regular flags mutually exclusive,
 		// this function must be run before the command is executed. It
 		// will not work in init(). This means that this needs to be
-		// presend in all child commands.
+		// present in all child commands.
 		cmd.MarkFlagsMutuallyExclusive("system", "user", "config")
 	},
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Check that cluster name is only arg
 		if len(args) == 0 {
 			printUsageHandleError(cmd)

--- a/cmd/config-cluster-set.go
+++ b/cmd/config-cluster-set.go
@@ -33,8 +33,17 @@ If this is the first cluster created, the following is also set:
 default-cluster is used to determine which cluster in the list should be used for subcommands.
 
 This same command can be use to modify existing cluster information. Running the same command above
-with a different base URL will change the base URL for the 'foobar' cluster.`,
-	Example: `  ochami config cluster set foobar.openchami.cluster --base-uri https://foobar.openchami.cluster`,
+with a different base URL will change the API base URL for the 'foobar' cluster.`,
+	Example: `  ochami config cluster set foobar cluster.api-uri https://foobar.openchami.cluster
+  ochami config cluster set foobar cluster.smd-uri /hsm/v2
+  ochami config cluster set foobar name new-foobar`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		// To mark both persistent and regular flags mutually exclusive,
+		// this function must be run before the command is executed. It
+		// will not work in init(). This means that this needs to be
+		// presend in all child commands.
+		cmd.MarkFlagsMutuallyExclusive("system", "user", "config")
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Check that cluster name is only arg
 		if len(args) == 0 {

--- a/cmd/config-cluster-set.go
+++ b/cmd/config-cluster-set.go
@@ -33,7 +33,10 @@ If this is the first cluster created, the following is also set:
 default-cluster is used to determine which cluster in the list should be used for subcommands.
 
 This same command can be use to modify existing cluster information. Running the same command above
-with a different base URI will change the cluster base URI for the 'foobar' cluster.`,
+with a different base URI will change the cluster base URI for the 'foobar' cluster.
+
+See ochami-config(1) for details on the config commands.
+See ochami-config(5) for details on the configuration options.`,
 	Example: `  ochami config cluster set foobar cluster.uri https://foobar.openchami.cluster
   ochami config cluster set foobar cluster.smd.uri /hsm/v2
   ochami config cluster set foobar name new-foobar`,
@@ -61,11 +64,13 @@ with a different base URI will change the cluster base URI for the 'foobar' clus
 		if create, err := askToCreate(fileToModify); err != nil {
 			if err != FileExistsError {
 				log.Logger.Error().Err(err).Msg("error asking to create file")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		} else if create {
 			if err := createIfNotExists(fileToModify); err != nil {
 				log.Logger.Error().Err(err).Msg("error creating file")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		} else {
@@ -77,10 +82,12 @@ with a different base URI will change the cluster base URI for the 'foobar' clus
 		dflt, err := cmd.Flags().GetBool("default")
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to retrieve \"default\" flag")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 		if err := config.ModifyConfigCluster(fileToModify, args[0], args[1], dflt, args[2]); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to modify config file")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 	},

--- a/cmd/config-cluster-set.go
+++ b/cmd/config-cluster-set.go
@@ -38,11 +38,7 @@ with a different base URL will change the base URL for the 'foobar' cluster.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Check that cluster name is only arg
 		if len(args) == 0 {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		} else if len(args) > 1 {
 			log.Logger.Error().Msgf("expected 1 argument (cluster name) but got %d: %v", len(args), args)

--- a/cmd/config-cluster-set.go
+++ b/cmd/config-cluster-set.go
@@ -41,11 +41,15 @@ with a different base URL will change the API base URL for the 'foobar' cluster.
 		// To mark both persistent and regular flags mutually exclusive,
 		// this function must be run before the command is executed. It
 		// will not work in init(). This means that this needs to be
-		// presend in all child commands.
+		// present in all child commands.
 		cmd.MarkFlagsMutuallyExclusive("system", "user", "config")
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		// Check that cluster name is only arg
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
+		// Check that cluster name, key, val are only args
 		if len(args) == 0 {
 			printUsageHandleError(cmd)
 			os.Exit(0)

--- a/cmd/config-cluster-set.go
+++ b/cmd/config-cluster-set.go
@@ -18,13 +18,13 @@ var configClusterSetCmd = &cobra.Command{
 	Long: `Add cluster with its configuration or set the configuration for
 an existing cluster. For example:
 
-	ochami config cluster set foobar --base-uri https://foobar.openchami.cluster
+	ochami config cluster set foobar cluster.uri https://foobar.openchami.cluster
 
 Creates the following entry in the 'clusters' list:
 
 	- name: foobar
 	  cluster:
-	    api-uri: https://foobar.openchami.cluster
+	    uri: https://foobar.openchami.cluster
 
 If this is the first cluster created, the following is also set:
 
@@ -33,9 +33,9 @@ If this is the first cluster created, the following is also set:
 default-cluster is used to determine which cluster in the list should be used for subcommands.
 
 This same command can be use to modify existing cluster information. Running the same command above
-with a different base URL will change the API base URL for the 'foobar' cluster.`,
-	Example: `  ochami config cluster set foobar cluster.api-uri https://foobar.openchami.cluster
-  ochami config cluster set foobar cluster.smd-uri /hsm/v2
+with a different base URI will change the cluster base URI for the 'foobar' cluster.`,
+	Example: `  ochami config cluster set foobar cluster.uri https://foobar.openchami.cluster
+  ochami config cluster set foobar cluster.smd.uri /hsm/v2
   ochami config cluster set foobar name new-foobar`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// To mark both persistent and regular flags mutually exclusive,
@@ -49,13 +49,9 @@ with a different base URL will change the API base URL for the 'foobar' cluster.
 	Run: func(cmd *cobra.Command, args []string) {
 		// We must have a config file in order to write cluster info
 		var fileToModify string
-		if rootCmd.PersistentFlags().Lookup("config").Changed {
-			var err error
-			if fileToModify, err = rootCmd.PersistentFlags().GetString("config"); err != nil {
-				log.Logger.Error().Err(err).Msgf("unable to get value from --config flag")
-				os.Exit(1)
-			}
-		} else if configCmd.PersistentFlags().Lookup("system").Changed {
+		if cmd.Flags().Changed("config") {
+			fileToModify = configFile
+		} else if configCmd.Flags().Changed("system") {
 			fileToModify = config.SystemConfigFile
 		} else {
 			fileToModify = config.UserConfigFile
@@ -77,71 +73,20 @@ with a different base URL will change the API base URL for the 'foobar' cluster.
 			os.Exit(0)
 		}
 
-		// Read in config from file
-		cfg, err := config.ReadConfig(fileToModify)
+		// Perform modification
+		dflt, err := cmd.Flags().GetBool("default")
 		if err != nil {
-			log.Logger.Error().Err(err).Msgf("failed to read config from %s", fileToModify)
+			log.Logger.Error().Err(err).Msg("failed to retrieve \"default\" flag")
+			os.Exit(1)
 		}
-
-		// Fetch existing cluster list config
-		clusterName := args[0]
-		clusterUrl := cmd.Flag("base-uri").Value.String()
-		clusterIdx := -1
-
-		// If cluster name already exists, we are modifying it instead of creating a new one
-		for idx, cluster := range cfg.Clusters {
-			if cluster.Name == clusterName {
-				clusterIdx = idx
-				break
-			}
-		}
-
-		if clusterIdx == -1 {
-			// Cluster does not exist, create a new entry for it in the config
-			newCluster := config.ConfigCluster{
-				Name: clusterName,
-			}
-			if clusterUrl != "" {
-				newCluster.Cluster.APIURI = clusterUrl
-				log.Logger.Debug().Msgf("using api-uri %s", clusterUrl)
-			}
-
-			// If this is the first cluster to be added, set it as the default
-			if len(cfg.Clusters) == 0 {
-				cfg.DefaultCluster = clusterName
-				log.Logger.Info().Msgf("first and new cluster %s set as default-cluster", clusterName)
-			}
-
-			// Add new cluster to list
-			cfg.Clusters = append(cfg.Clusters, newCluster)
-			log.Logger.Info().Msgf("added new cluster: %s", clusterName)
-		} else {
-			// Cluster exists, modify it
-			if clusterUrl != "" {
-				cfg.Clusters[clusterIdx].Cluster.APIURI = clusterUrl
-				log.Logger.Debug().Msgf("updating base-uri for cluster %s: %s", clusterName, clusterUrl)
-			}
-			log.Logger.Info().Msgf("modified config for existing cluster: %s", clusterName)
-		}
-
-		// If --default was passed, make this cluster the default one
-		if cmd.Flag("default").Changed {
-			cfg.DefaultCluster = clusterName
-			log.Logger.Info().Msgf("cluster %s set as default-cluster since --default passed", clusterName)
-		}
-
-		// Write out modified config to the config file
-		// WARNING: This will rewrite the whole config file so modifications like
-		// comments will get erased.
-		if err := config.WriteConfig(fileToModify, cfg); err != nil {
-			log.Logger.Error().Err(err).Msgf("failed to write modified config to %s", fileToModify)
+		if err := config.ModifyConfigCluster(fileToModify, args[0], args[1], dflt, args[2]); err != nil {
+			log.Logger.Error().Err(err).Msg("failed to modify config file")
 			os.Exit(1)
 		}
 	},
 }
 
 func init() {
-	configClusterSetCmd.Flags().StringP("api-uri", "u", "", "base URL of cluster")
 	configClusterSetCmd.Flags().BoolP("default", "d", false, "set cluster as the default")
 	configClusterCmd.AddCommand(configClusterSetCmd)
 }

--- a/cmd/config-cluster-set.go
+++ b/cmd/config-cluster-set.go
@@ -44,10 +44,6 @@ with a different base URL will change the API base URL for the 'foobar' cluster.
 		// present in all child commands.
 		cmd.MarkFlagsMutuallyExclusive("system", "user", "config")
 
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/config-cluster-set.go
+++ b/cmd/config-cluster-set.go
@@ -24,7 +24,7 @@ Creates the following entry in the 'clusters' list:
 
 	- name: foobar
 	  cluster:
-	    base-uri: https://foobar.openchami.cluster
+	    api-uri: https://foobar.openchami.cluster
 
 If this is the first cluster created, the following is also set:
 

--- a/cmd/config-cluster-set.go
+++ b/cmd/config-cluster-set.go
@@ -72,15 +72,20 @@ with a different base URL will change the API base URL for the 'foobar' cluster.
 			fileToModify = config.UserConfigFile
 		}
 
-		// Ask user to create file if it does not exist
-		if err := askToCreate(fileToModify); err != nil {
-			if errors.Is(err, UserDeclinedError) {
-				log.Logger.Info().Msgf("user declined creating config file %s, exiting")
-				os.Exit(0)
-			} else {
-				log.Logger.Error().Err(err).Msgf("failed to create %s")
+		// Ask to create file if it doesn't exist
+		if create, err := askToCreate(fileToModify); err != nil {
+			if err != FileExistsError {
+				log.Logger.Error().Err(err).Msg("error asking to create file")
 				os.Exit(1)
 			}
+		} else if create {
+			if err := createIfNotExists(fileToModify); err != nil {
+				log.Logger.Error().Err(err).Msg("error creating file")
+				os.Exit(1)
+			}
+		} else {
+			log.Logger.Error().Msg("user declined to create file, not modifying")
+			os.Exit(0)
 		}
 
 		// Read in config from file

--- a/cmd/config-cluster-show.go
+++ b/cmd/config-cluster-show.go
@@ -16,6 +16,10 @@ var configClusterShowCmd = &cobra.Command{
 	Use:   "show [cluster_name] [key]",
 	Args:  cobra.MaximumNArgs(2),
 	Short: "View cluster configuration options the CLI sees from a config file",
+	Long: `View cluster configuration options the CLI sees from a config file.
+
+See ochami-config(1) for details on the config commands.
+See ochami-config(5) for details on the configuration options.`,
 	Example: `  ochami config cluster show
   ochami config cluster show foobar
   ochami config cluster show foobar cluster.uri`,
@@ -46,11 +50,13 @@ var configClusterShowCmd = &cobra.Command{
 			cfg, err = config.ReadConfig(config.SystemConfigFile)
 			if err != nil {
 				log.Logger.Error().Err(err).Msgf("failed to read system config file")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		} else if cmd.Flags().Changed("user") {
 			cfg, err = config.ReadConfig(config.UserConfigFile)
 			if err != nil {
+				logHelpError(cmd)
 				log.Logger.Error().Err(err).Msgf("failed to read user config file")
 				os.Exit(1)
 			}
@@ -58,6 +64,7 @@ var configClusterShowCmd = &cobra.Command{
 			cfg, err = config.ReadConfig(cmd.Flag("config").Value.String())
 			if err != nil {
 				log.Logger.Error().Err(err).Msgf("failed to read config file %s", cmd.Flag("config").Value.String())
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		} else {
@@ -71,6 +78,7 @@ var configClusterShowCmd = &cobra.Command{
 			val, err = config.GetConfigString(cfg, "clusters", format)
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to fetch config for all clusters")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		} else {
@@ -83,6 +91,7 @@ var configClusterShowCmd = &cobra.Command{
 			}
 			if cfgCl == nil {
 				log.Logger.Error().Msgf("cluster %q not found", args[0])
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 
@@ -97,6 +106,7 @@ var configClusterShowCmd = &cobra.Command{
 				} else {
 					log.Logger.Error().Err(err).Msgf("failed to get cluster config for key %q", key)
 				}
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}

--- a/cmd/config-cluster-unset.go
+++ b/cmd/config-cluster-unset.go
@@ -1,0 +1,57 @@
+// This source code is licensed under the license found in the LICENSE file at
+// the root directory of this source tree.
+package cmd
+
+import (
+	"os"
+
+	"github.com/OpenCHAMI/ochami/internal/config"
+	"github.com/OpenCHAMI/ochami/internal/log"
+	"github.com/spf13/cobra"
+)
+
+// configClusterUnsetCmd represents the config-cluster-unset command
+var configClusterUnsetCmd = &cobra.Command{
+	Use:     "unset [--user | --system | --config <path>] <cluster_name> <key>",
+	Args:    cobra.ExactArgs(2),
+	Short:   "Unset parameter for a cluster",
+	Example: `  ochami config cluster unset foobar cluster.smd.uri`,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// It doesn't make sense to unset a cluster config from a
+		// non-existent config file, so err if the specified config
+		// file doesn't exist.
+		initConfigAndLogging(cmd, false)
+
+		return nil
+	},
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		// To mark both persistent and regular flags mutually exclusive,
+		// this function must be run before the command is executed. It
+		// will not work in init(). This means that this needs to be
+		// presend in all child commands.
+		cmd.MarkFlagsMutuallyExclusive("system", "user", "config")
+
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		// We must have a config file in order to write cluster info
+		var fileToModify string
+		if cmd.Flags().Changed("config") {
+			fileToModify = configFile
+		} else if configCmd.Flags().Changed("system") {
+			fileToModify = config.SystemConfigFile
+		} else {
+			fileToModify = config.UserConfigFile
+		}
+
+		// Perform modification
+		if err := config.DeleteConfigCluster(fileToModify, args[0], args[1]); err != nil {
+			log.Logger.Error().Err(err).Msg("failed to modify config file")
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	configClusterCmd.AddCommand(configClusterUnsetCmd)
+}

--- a/cmd/config-cluster-unset.go
+++ b/cmd/config-cluster-unset.go
@@ -12,9 +12,13 @@ import (
 
 // configClusterUnsetCmd represents the config-cluster-unset command
 var configClusterUnsetCmd = &cobra.Command{
-	Use:     "unset [--user | --system | --config <path>] <cluster_name> <key>",
-	Args:    cobra.ExactArgs(2),
-	Short:   "Unset parameter for a cluster",
+	Use:   "unset [--user | --system | --config <path>] <cluster_name> <key>",
+	Args:  cobra.ExactArgs(2),
+	Short: "Unset parameter for a cluster",
+	Long: `Unset parameter for a cluster.
+
+See ochami-config(1) for details on the config commands.
+See ochami-config(5) for details on the configuration options.`,
 	Example: `  ochami config cluster unset foobar cluster.smd.uri`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		// It doesn't make sense to unset a cluster config from a
@@ -47,6 +51,7 @@ var configClusterUnsetCmd = &cobra.Command{
 		// Perform modification
 		if err := config.DeleteConfigCluster(fileToModify, args[0], args[1]); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to modify config file")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 	},

--- a/cmd/config-cluster.go
+++ b/cmd/config-cluster.go
@@ -13,6 +13,10 @@ var configClusterCmd = &cobra.Command{
 	Use:   "cluster",
 	Args:  cobra.NoArgs,
 	Short: "Manage cluster configuration",
+	Long: `Manage cluster configuration.
+
+See ochami-config(1) for details on the config commands.
+See ochami-config(5) for details on the configuration options.`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// To mark both persistent and regular flags mutually exclusive,
 		// this function must be run before the command is executed. It

--- a/cmd/config-cluster.go
+++ b/cmd/config-cluster.go
@@ -5,7 +5,6 @@ package cmd
 import (
 	"os"
 
-	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/spf13/cobra"
 )
 
@@ -16,11 +15,7 @@ var configClusterCmd = &cobra.Command{
 	Short: "Manage cluster configuration",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
 	},

--- a/cmd/config-cluster.go
+++ b/cmd/config-cluster.go
@@ -13,6 +13,13 @@ var configClusterCmd = &cobra.Command{
 	Use:   "cluster",
 	Args:  cobra.NoArgs,
 	Short: "Manage cluster configuration",
+	PreRun: func(cmd *cobra.Command, args []string) {
+		// To mark both persistent and regular flags mutually exclusive,
+		// this function must be run before the command is executed. It
+		// will not work in init(). This means that this needs to be
+		// presend in all child commands.
+		cmd.MarkFlagsMutuallyExclusive("system", "user", "config")
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			printUsageHandleError(cmd)

--- a/cmd/config-cluster.go
+++ b/cmd/config-cluster.go
@@ -13,12 +13,14 @@ var configClusterCmd = &cobra.Command{
 	Use:   "cluster",
 	Args:  cobra.NoArgs,
 	Short: "Manage cluster configuration",
-	PreRun: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// To mark both persistent and regular flags mutually exclusive,
 		// this function must be run before the command is executed. It
 		// will not work in init(). This means that this needs to be
 		// present in all child commands.
 		cmd.MarkFlagsMutuallyExclusive("system", "user", "config")
+
+		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {

--- a/cmd/config-cluster.go
+++ b/cmd/config-cluster.go
@@ -17,7 +17,7 @@ var configClusterCmd = &cobra.Command{
 		// To mark both persistent and regular flags mutually exclusive,
 		// this function must be run before the command is executed. It
 		// will not work in init(). This means that this needs to be
-		// presend in all child commands.
+		// present in all child commands.
 		cmd.MarkFlagsMutuallyExclusive("system", "user", "config")
 	},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/config-set.go
+++ b/cmd/config-set.go
@@ -27,6 +27,13 @@ This command does not handle cluster configs. For that, use the
   ochami config set --user log.format json
   ochami config set --system log.format json
   ochami --config ./test.yaml config set log.format json`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		// To mark both persistent and regular flags mutually exclusive,
+		// this function must be run before the command is executed. It
+		// will not work in init(). This means that this needs to be
+		// presend in all child commands.
+		cmd.MarkFlagsMutuallyExclusive("system", "user", "config")
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Ensure we have 2 args
 		if len(args) == 0 {

--- a/cmd/config-set.go
+++ b/cmd/config-set.go
@@ -22,7 +22,10 @@ this command edits the system configuration file. If --config is passed
 instead, this command edits the file at the path specified.
 
 This command does not handle cluster configs. For that, use the
-'ochami config cluster set' command.`,
+'ochami config cluster set' command.
+
+See ochami-config(1) for details on the config commands.
+See ochami-config(5) for details on the configuration options.`,
 	Example: `  ochami config set log.format json
   ochami config set --user log.format json
   ochami config set --system log.format json
@@ -50,6 +53,7 @@ This command does not handle cluster configs. For that, use the
 		// Refuse to modify config if user tries to modify cluster config
 		if strings.HasPrefix(args[0], "clusters") {
 			log.Logger.Error().Msg("`ochami config set` is meant for modifying general config, use `ochami config cluster set` for modifying cluster config")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -57,11 +61,13 @@ This command does not handle cluster configs. For that, use the
 		if create, err := askToCreate(fileToModify); err != nil {
 			if err != FileExistsError {
 				log.Logger.Error().Err(err).Msg("error asking to create file")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		} else if create {
 			if err := createIfNotExists(fileToModify); err != nil {
 				log.Logger.Error().Err(err).Msg("error creating file")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		} else {
@@ -72,6 +78,7 @@ This command does not handle cluster configs. For that, use the
 		// Perform modification
 		if err := config.ModifyConfig(fileToModify, args[0], args[1]); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to modify config file")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 	},

--- a/cmd/config-set.go
+++ b/cmd/config-set.go
@@ -30,11 +30,7 @@ This command does not handle cluster configs. For that, use the
 	Run: func(cmd *cobra.Command, args []string) {
 		// Ensure we have 2 args
 		if len(args) == 0 {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		} else if len(args) != 2 {
 			log.Logger.Error().Msgf("expected 2 arguments (key, value) but got %s: %v", len(args), args)

--- a/cmd/config-set.go
+++ b/cmd/config-set.go
@@ -35,10 +35,6 @@ This command does not handle cluster configs. For that, use the
 		// present in all child commands.
 		cmd.MarkFlagsMutuallyExclusive("system", "user", "config")
 
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/config-set.go
+++ b/cmd/config-set.go
@@ -3,7 +3,6 @@
 package cmd
 
 import (
-	"errors"
 	"os"
 	"strings"
 
@@ -40,27 +39,12 @@ This command does not handle cluster configs. For that, use the
 	Run: func(cmd *cobra.Command, args []string) {
 		// We must have a config file in order to write config
 		var fileToModify string
-		if rootCmd.PersistentFlags().Lookup("config").Changed {
-			var err error
-			if fileToModify, err = rootCmd.PersistentFlags().GetString("config"); err != nil {
-				log.Logger.Error().Err(err).Msgf("unable to get value from --config flag")
-				os.Exit(1)
-			}
+		if cmd.Flags().Changed("config") {
+			fileToModify = configFile
 		} else if configCmd.PersistentFlags().Lookup("system").Changed {
 			fileToModify = config.SystemConfigFile
 		} else {
 			fileToModify = config.UserConfigFile
-		}
-
-		// Ask user to create file if it does not exist
-		if err := askToCreate(fileToModify); err != nil {
-			if errors.Is(err, UserDeclinedError) {
-				log.Logger.Info().Msgf("user declined creating config file %s, exiting")
-				os.Exit(0)
-			} else {
-				log.Logger.Error().Err(err).Msgf("failed to create %s")
-				os.Exit(1)
-			}
 		}
 
 		// Refuse to modify config if user tries to modify cluster config

--- a/cmd/config-set.go
+++ b/cmd/config-set.go
@@ -79,6 +79,22 @@ This command does not handle cluster configs. For that, use the
 			os.Exit(1)
 		}
 
+		// Ask to create file if it doesn't exist.
+		if create, err := askToCreate(fileToModify); err != nil {
+			if err != FileExistsError {
+				log.Logger.Error().Err(err).Msg("error asking to create file")
+				os.Exit(1)
+			}
+		} else if create {
+			if err := createIfNotExists(fileToModify); err != nil {
+				log.Logger.Error().Err(err).Msg("error creating file")
+				os.Exit(1)
+			}
+		} else {
+			log.Logger.Error().Msg("user declined to create file, not modifying")
+			os.Exit(0)
+		}
+
 		// Perform modification
 		if err := config.ModifyConfig(fileToModify, args[0], args[1]); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to modify config file")

--- a/cmd/config-set.go
+++ b/cmd/config-set.go
@@ -15,6 +15,7 @@ import (
 // configSetCmd represents the config-set command
 var configSetCmd = &cobra.Command{
 	Use:   "set [--user | --system | --config <path>] <key> <value>",
+	Args:  cobra.ExactArgs(2),
 	Short: "Modify ochami CLI configuration",
 	Long: `Modify ochami CLI configuration. By default, this command modifies the user
 config file, which also occurs if --user is passed. If --system is passed,
@@ -27,27 +28,20 @@ This command does not handle cluster configs. For that, use the
   ochami config set --user log.format json
   ochami config set --system log.format json
   ochami --config ./test.yaml config set log.format json`,
-	PreRun: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// To mark both persistent and regular flags mutually exclusive,
 		// this function must be run before the command is executed. It
 		// will not work in init(). This means that this needs to be
 		// present in all child commands.
 		cmd.MarkFlagsMutuallyExclusive("system", "user", "config")
-	},
-	Run: func(cmd *cobra.Command, args []string) {
+
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
 
-		// Ensure we have 2 args
-		if len(args) == 0 {
-			printUsageHandleError(cmd)
-			os.Exit(0)
-		} else if len(args) != 2 {
-			log.Logger.Error().Msgf("expected 2 arguments (key, value) but got %s: %v", len(args), args)
-			os.Exit(1)
-		}
-
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// We must have a config file in order to write config
 		var fileToModify string
 		if rootCmd.PersistentFlags().Lookup("config").Changed {

--- a/cmd/config-set.go
+++ b/cmd/config-set.go
@@ -31,10 +31,14 @@ This command does not handle cluster configs. For that, use the
 		// To mark both persistent and regular flags mutually exclusive,
 		// this function must be run before the command is executed. It
 		// will not work in init(). This means that this needs to be
-		// presend in all child commands.
+		// present in all child commands.
 		cmd.MarkFlagsMutuallyExclusive("system", "user", "config")
 	},
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Ensure we have 2 args
 		if len(args) == 0 {
 			printUsageHandleError(cmd)

--- a/cmd/config-show.go
+++ b/cmd/config-show.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"gopkg.in/yaml.v3"
 	"os"
+	"strings"
 
 	"github.com/OpenCHAMI/ochami/internal/config"
 	"github.com/OpenCHAMI/ochami/internal/log"
@@ -19,6 +20,14 @@ var configShowCmd = &cobra.Command{
 	Use:   "show",
 	Args:  cobra.NoArgs,
 	Short: "View configuration options the CLI sees from a config file",
+	PreRun: func(cmd *cobra.Command, args []string) {
+		log.Logger.Debug().Msgf("COMMAND: %v", strings.Split(cmd.CommandPath(), " "))
+		// To mark both persistent and regular flags mutually exclusive,
+		// this function must be run before the command is executed. It
+		// will not work in init(). This means that this needs to be
+		// presend in all child commands.
+		cmd.MarkFlagsMutuallyExclusive("system", "user", "config")
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		var (
 			err          error

--- a/cmd/config-show.go
+++ b/cmd/config-show.go
@@ -17,6 +17,10 @@ var configShowCmd = &cobra.Command{
 	Use:   "show [key]",
 	Args:  cobra.MaximumNArgs(1),
 	Short: "View configuration options the CLI sees from a config file",
+	Long: `View configuration options the CLI sees from a config file.
+
+See ochami-config(1) for details on the config commands.
+See ochami-config(5) for details on the configuration options.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		// It doesn't make sense to show the config value from a config
 		// file that doesn't exist, so err if the specified config file
@@ -45,18 +49,21 @@ var configShowCmd = &cobra.Command{
 			cfg, err = config.ReadConfig(config.SystemConfigFile)
 			if err != nil {
 				log.Logger.Error().Err(err).Msgf("failed to read system config file")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		} else if cmd.Flags().Changed("user") {
 			cfg, err = config.ReadConfig(config.UserConfigFile)
 			if err != nil {
 				log.Logger.Error().Err(err).Msgf("failed to read user config file")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		} else if cmd.Flags().Changed("config") {
 			cfg, err = config.ReadConfig(cmd.Flag("config").Value.String())
 			if err != nil {
 				log.Logger.Error().Err(err).Msgf("failed to read config file %s", cmd.Flag("config").Value.String())
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		} else {
@@ -76,6 +83,7 @@ var configShowCmd = &cobra.Command{
 			} else {
 				log.Logger.Error().Err(err).Msgf("failed to get config for key %q", key)
 			}
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 		if val != "" {

--- a/cmd/config-show.go
+++ b/cmd/config-show.go
@@ -25,14 +25,18 @@ var configShowCmd = &cobra.Command{
 		// To mark both persistent and regular flags mutually exclusive,
 		// this function must be run before the command is executed. It
 		// will not work in init(). This means that this needs to be
-		// presend in all child commands.
+		// present in all child commands.
 		cmd.MarkFlagsMutuallyExclusive("system", "user", "config")
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		var (
-			err          error
-			cfgDataBytes []byte
-		)
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, false)
+
+		// Get the config from the relevant file depending on the flag,
+		// or the merged config if none.
+		var cfg config.Config
+		var err error
 		format := cmd.Flag("format").Value.String()
 		switch format {
 		case "yaml":

--- a/cmd/config-show.go
+++ b/cmd/config-show.go
@@ -20,19 +20,21 @@ var configShowCmd = &cobra.Command{
 	Use:   "show",
 	Args:  cobra.NoArgs,
 	Short: "View configuration options the CLI sees from a config file",
-	PreRun: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		log.Logger.Debug().Msgf("COMMAND: %v", strings.Split(cmd.CommandPath(), " "))
 		// To mark both persistent and regular flags mutually exclusive,
 		// this function must be run before the command is executed. It
 		// will not work in init(). This means that this needs to be
 		// present in all child commands.
 		cmd.MarkFlagsMutuallyExclusive("system", "user", "config")
-	},
-	Run: func(cmd *cobra.Command, args []string) {
+
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, false)
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Get the config from the relevant file depending on the flag,
 		// or the merged config if none.
 		var cfg config.Config

--- a/cmd/config-show.go
+++ b/cmd/config-show.go
@@ -20,6 +20,14 @@ var configShowCmd = &cobra.Command{
 	Use:   "show",
 	Args:  cobra.NoArgs,
 	Short: "View configuration options the CLI sees from a config file",
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// It doesn't make sense to show the config value from a config
+		// file that doesn't exist, so err if the specified config file
+		// doesn't exist.
+		initConfigAndLogging(cmd, false)
+
+		return nil
+	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		log.Logger.Debug().Msgf("COMMAND: %v", strings.Split(cmd.CommandPath(), " "))
 		// To mark both persistent and regular flags mutually exclusive,
@@ -27,10 +35,6 @@ var configShowCmd = &cobra.Command{
 		// will not work in init(). This means that this needs to be
 		// present in all child commands.
 		cmd.MarkFlagsMutuallyExclusive("system", "user", "config")
-
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, false)
 
 		return nil
 	},

--- a/cmd/config-unset.go
+++ b/cmd/config-unset.go
@@ -26,6 +26,13 @@ This command does not handle cluster configs. For that, use the
   ochami config unset --user log.format
   ochami config unset --system log.format
   ochami --config ./test.yaml config unset log.format`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		// To mark both persistent and regular flags mutually exclusive,
+		// this function must be run before the command is executed. It
+		// will not work in init(). This means that this needs to be
+		// presend in all child commands.
+		cmd.MarkFlagsMutuallyExclusive("system", "user", "config")
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Ensure we have 1 args
 		if len(args) == 0 {

--- a/cmd/config-unset.go
+++ b/cmd/config-unset.go
@@ -22,7 +22,10 @@ is passed, this command edits the system configuration file. If --config
 is passed instead, this command edits the file at the path specified.
 
 This command does not handle cluster configs. For that, use the
-'ochami config cluster delete' command.`,
+'ochami config cluster delete' command.
+
+See ochami-config(1) for details on the config commands.
+See ochami-config(5) for details on the configuration options.`,
 	Example: `  ochami config unset log.format
   ochami config unset --user log.format
   ochami config unset --system log.format
@@ -58,12 +61,14 @@ This command does not handle cluster configs. For that, use the
 		// Refuse to modify config if user tries to modify cluster config
 		if strings.HasPrefix(args[0], "clusters") {
 			log.Logger.Error().Msg("`ochami config unset` is meant for unsetting general config, use `ochami config cluster delete` for deleting cluster config")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
 		// Perform modification
 		if err := config.DeleteConfig(fileToModify, args[0]); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to modify config file")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 	},

--- a/cmd/config-unset.go
+++ b/cmd/config-unset.go
@@ -47,12 +47,8 @@ This command does not handle cluster configs. For that, use the
 	Run: func(cmd *cobra.Command, args []string) {
 		// We must have a config file in order to write config
 		var fileToModify string
-		if rootCmd.PersistentFlags().Lookup("config").Changed {
-			var err error
-			if fileToModify, err = rootCmd.PersistentFlags().GetString("config"); err != nil {
-				log.Logger.Error().Err(err).Msgf("unable to get value from --config flag")
-				os.Exit(1)
-			}
+		if rootCmd.Flags().Changed("config") {
+			fileToModify = configFile
 		} else if configCmd.PersistentFlags().Lookup("system").Changed {
 			fileToModify = config.SystemConfigFile
 		} else {

--- a/cmd/config-unset.go
+++ b/cmd/config-unset.go
@@ -29,11 +29,7 @@ This command does not handle cluster configs. For that, use the
 	Run: func(cmd *cobra.Command, args []string) {
 		// Ensure we have 1 args
 		if len(args) == 0 {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		} else if len(args) != 1 {
 			log.Logger.Error().Msgf("expected 1 argument (key) but got %s: %v", len(args), args)

--- a/cmd/config-unset.go
+++ b/cmd/config-unset.go
@@ -27,16 +27,20 @@ This command does not handle cluster configs. For that, use the
   ochami config unset --user log.format
   ochami config unset --system log.format
   ochami --config ./test.yaml config unset log.format`,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// It doesn't make sense to unset from a config file that
+		// doesn't exist, so err if the specified config file doesn't
+		// exist.
+		initConfigAndLogging(cmd, false)
+
+		return nil
+	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// To mark both persistent and regular flags mutually exclusive,
 		// this function must be run before the command is executed. It
 		// will not work in init(). This means that this needs to be
 		// present in all child commands.
 		cmd.MarkFlagsMutuallyExclusive("system", "user", "config")
-
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
 
 		return nil
 	},

--- a/cmd/config-unset.go
+++ b/cmd/config-unset.go
@@ -14,6 +14,7 @@ import (
 // configUnsetCmd represents the unset command
 var configUnsetCmd = &cobra.Command{
 	Use:   "unset [--user | --system | --config <path>] <key>",
+	Args:  cobra.ExactArgs(1),
 	Short: "Unset a key in ochami CLI configuration",
 	Long: `Unset a key in ochami CLI configuration. By default, this command modifies
 the user config file, which also occurs if --user is passed. If --system
@@ -26,27 +27,20 @@ This command does not handle cluster configs. For that, use the
   ochami config unset --user log.format
   ochami config unset --system log.format
   ochami --config ./test.yaml config unset log.format`,
-	PreRun: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// To mark both persistent and regular flags mutually exclusive,
 		// this function must be run before the command is executed. It
 		// will not work in init(). This means that this needs to be
 		// present in all child commands.
 		cmd.MarkFlagsMutuallyExclusive("system", "user", "config")
-	},
-	Run: func(cmd *cobra.Command, args []string) {
+
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
 
-		// Ensure we have 1 args
-		if len(args) == 0 {
-			printUsageHandleError(cmd)
-			os.Exit(0)
-		} else if len(args) != 1 {
-			log.Logger.Error().Msgf("expected 1 argument (key) but got %s: %v", len(args), args)
-			os.Exit(1)
-		}
-
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// We must have a config file in order to write config
 		var fileToModify string
 		if rootCmd.PersistentFlags().Lookup("config").Changed {

--- a/cmd/config-unset.go
+++ b/cmd/config-unset.go
@@ -30,10 +30,14 @@ This command does not handle cluster configs. For that, use the
 		// To mark both persistent and regular flags mutually exclusive,
 		// this function must be run before the command is executed. It
 		// will not work in init(). This means that this needs to be
-		// presend in all child commands.
+		// present in all child commands.
 		cmd.MarkFlagsMutuallyExclusive("system", "user", "config")
 	},
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Ensure we have 1 args
 		if len(args) == 0 {
 			printUsageHandleError(cmd)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -11,9 +11,13 @@ import (
 // The 'config' command is a metacommand that allows the user to show and set
 // configuration options in the passed config file.
 var configCmd = &cobra.Command{
-	Use:     "config",
-	Args:    cobra.NoArgs,
-	Short:   "Set or view configuration options",
+	Use:   "config",
+	Args:  cobra.NoArgs,
+	Short: "Set or view configuration options",
+	Long: `Set or view configuration options.
+
+See ochami-config(1) for details on the config commands.
+See ochami-config(5) for details on the configuration options.`,
 	Example: `ochami config show`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// To mark both persistent and regular flags mutually exclusive,

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -5,7 +5,6 @@ package cmd
 import (
 	"os"
 
-	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/spf13/cobra"
 )
 
@@ -18,11 +17,7 @@ var configCmd = &cobra.Command{
 	Example: `ochami config show`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
 	},

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -15,6 +15,13 @@ var configCmd = &cobra.Command{
 	Args:    cobra.NoArgs,
 	Short:   "Set or view configuration options",
 	Example: `ochami config show`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		// To mark both persistent and regular flags mutually exclusive,
+		// this function must be run before the command is executed. It
+		// will not work in init(). This means that this needs to be
+		// presend in all child commands.
+		cmd.MarkFlagsMutuallyExclusive("system", "user", "config")
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			printUsageHandleError(cmd)
@@ -26,8 +33,6 @@ var configCmd = &cobra.Command{
 func init() {
 	configCmd.PersistentFlags().Bool("system", false, "modify system config")
 	configCmd.PersistentFlags().Bool("user", true, "modify user config")
-
-	configCmd.MarkFlagsMutuallyExclusive("system", "user")
 
 	rootCmd.AddCommand(configCmd)
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -15,12 +15,14 @@ var configCmd = &cobra.Command{
 	Args:    cobra.NoArgs,
 	Short:   "Set or view configuration options",
 	Example: `ochami config show`,
-	PreRun: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// To mark both persistent and regular flags mutually exclusive,
 		// this function must be run before the command is executed. It
 		// will not work in init(). This means that this needs to be
 		// present in all child commands.
 		cmd.MarkFlagsMutuallyExclusive("system", "user", "config")
+
+		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -19,7 +19,7 @@ var configCmd = &cobra.Command{
 		// To mark both persistent and regular flags mutually exclusive,
 		// this function must be run before the command is executed. It
 		// will not work in init(). This means that this needs to be
-		// presend in all child commands.
+		// present in all child commands.
 		cmd.MarkFlagsMutuallyExclusive("system", "user", "config")
 	},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -49,7 +49,8 @@ nodes:
     - name: HSN
       ip_addr: 192.168.0.1
 
-`,
+
+See ochami-discover(1) for more details.`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// Check that all required args are passed
 		if len(args) == 0 && !cmd.Flag("payload").Changed {
@@ -64,6 +65,7 @@ nodes:
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -75,6 +77,7 @@ nodes:
 		smdClient, err := smd.NewClient(smdBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new SMD client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -96,6 +99,7 @@ nodes:
 		comps, rfes, ifaces, err := discover.DiscoveryInfoV2(smdBaseURI, nodes)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to construct structures to send to SMD")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 		log.Logger.Debug().Msgf("generated redfish structures: %v", rfes.RedfishEndpoints)
@@ -428,6 +432,9 @@ nodes:
 
 		// Notify user if any request errors occurred
 		exitStatus := 0
+		if compErrorsOccurred || rfeErrorsOccurred || ifaceErrorsOccurred || groupErrorsOccurred {
+			logHelpError(cmd)
+		}
 		if compErrorsOccurred {
 			log.Logger.Warn().Msg("component requests completed with errors")
 			exitStatus = 1

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -53,11 +53,7 @@ nodes:
 	Run: func(cmd *cobra.Command, args []string) {
 		// Check that all required args are passed
 		if len(args) == 0 && !cmd.Flag("payload").Changed {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
 

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -51,6 +51,10 @@ nodes:
 
 `,
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Check that all required args are passed
 		if len(args) == 0 && !cmd.Flag("payload").Changed {
 			printUsageHandleError(cmd)

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -51,10 +51,6 @@ nodes:
 
 `,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
 		// Check that all required args are passed
 		if len(args) == 0 && !cmd.Flag("payload").Changed {
 			printUsageHandleError(cmd)

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -50,7 +50,7 @@ nodes:
       ip_addr: 192.168.0.1
 
 `,
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
@@ -61,6 +61,9 @@ nodes:
 			os.Exit(0)
 		}
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/lib.go
+++ b/cmd/lib.go
@@ -110,10 +110,12 @@ func initLogging(cmd *cobra.Command) error {
 func initConfigAndLogging(cmd *cobra.Command, createCfg bool) {
 	if err := initConfig(cmd, createCfg); err != nil {
 		earlyMsgf("failed to initialize config: %v", err)
+		earlyMsgf("see '%s --help' for long command help", cmd.CommandPath())
 		os.Exit(1)
 	}
 	if err := initLogging(cmd); err != nil {
 		earlyMsgf("failed to initialized logging: %v", err)
+		earlyMsgf("see '%s --help' for long command help", cmd.CommandPath())
 		os.Exit(1)
 	}
 }
@@ -370,6 +372,7 @@ func setTokenFromEnvVar(cmd *cobra.Command) {
 		log.Logger.Debug().Msg("--cluster not specified, using default-cluster: " + clusterName)
 	} else {
 		log.Logger.Error().Msg("No default-cluster specified and --token not passed")
+		logHelpError(cmd)
 		os.Exit(1)
 	}
 
@@ -386,6 +389,7 @@ func setTokenFromEnvVar(cmd *cobra.Command) {
 
 	log.Logger.Error().Msgf("Environment variable %s unset for reading token for cluster %q", envVarToRead, clusterName)
 	os.Exit(1)
+	logHelpError(cmd)
 }
 
 // handlePayload unmarshals a payload file into data for command cmd if
@@ -397,6 +401,7 @@ func handlePayload(cmd *cobra.Command, data any) {
 		err := client.ReadPayload(dFile, dFormat, data)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("unable to read payload for request")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 	}
@@ -409,4 +414,20 @@ func printUsageHandleError(cmd *cobra.Command) {
 		log.Logger.Error().Err(err).Msg("failed to print usage")
 		os.Exit(1)
 	}
+	logHelpWarn(cmd)
+}
+
+// logHelpError logs a message at error level telling the user to use the
+// '--help' flag of the passed command to get more information on the command.
+// The full command invocation without flags or arguments is printed in the
+// message.
+func logHelpError(cmd *cobra.Command) {
+	log.Logger.Error().Msgf("see '%s --help' for long command help", cmd.CommandPath())
+}
+
+// logHelpWarn logs a message at warn level telling the user to use the '--help'
+// flag of the passed command to get more information on the command.  The full
+// command invocation without flags or arguments is printed in the message.
+func logHelpWarn(cmd *cobra.Command) {
+	log.Logger.Warn().Msgf("see '%s --help' for long command help", cmd.CommandPath())
 }

--- a/cmd/lib.go
+++ b/cmd/lib.go
@@ -269,8 +269,8 @@ func getBaseURI(cmd *cobra.Command, serviceName config.ServiceName) (string, err
 	//    specified), use cluster identified by that name as source of info.
 	// 2. If --cluster is set, search config file for matching name and read
 	//    details from there.
-	// 3. If flags corresponding to cluster info (e.g. --api-uri,
-	//    --<service>-uri) are set, read details from them.
+	// 3. If flags corresponding to cluster info (e.g. --cluster-uri,
+	//    --uri) are set, read details from them.
 	var (
 		clusterName   string
 		clusterToUse  config.ConfigCluster
@@ -308,20 +308,20 @@ func getBaseURI(cmd *cobra.Command, serviceName config.ServiceName) (string, err
 
 		clusterConfig = clusterToUse.Cluster
 	}
-	// 1. Check flags (--api-uri and/or --uri) and override any
+	// 1. Check flags (--cluster-uri and/or --uri) and override any
 	// previously-set values while leaving unspecified ones alone.
-	if cmd.Flag("api-uri").Changed || (cmd.Flag("uri") != nil && cmd.Flag("uri").Changed) {
+	if cmd.Flag("cluster-uri").Changed || (cmd.Flag("uri") != nil && cmd.Flag("uri").Changed) {
 		log.Logger.Debug().Msg("using base URI passed on command line")
-		ccc := config.ConfigClusterConfig{APIURI: cmd.Flag("api-uri").Value.String()}
+		ccc := config.ConfigClusterConfig{URI: cmd.Flag("cluster-uri").Value.String()}
 		switch serviceName {
 		case config.ServiceBSS:
-			ccc.BSSURI = cmd.Flag("uri").Value.String()
+			ccc.BSS.URI = cmd.Flag("uri").Value.String()
 		case config.ServiceCloudInit:
-			ccc.CloudInitURI = cmd.Flag("uri").Value.String()
+			ccc.CloudInit.URI = cmd.Flag("uri").Value.String()
 		case config.ServicePCS:
-			ccc.PCSURI = cmd.Flag("uri").Value.String()
+			ccc.PCS.URI = cmd.Flag("uri").Value.String()
 		case config.ServiceSMD:
-			ccc.SMDURI = cmd.Flag("uri").Value.String()
+			ccc.SMD.URI = cmd.Flag("uri").Value.String()
 		default:
 			return "", fmt.Errorf("unknown service %q specified when generating base URI", serviceName)
 		}

--- a/cmd/lib.go
+++ b/cmd/lib.go
@@ -346,3 +346,12 @@ func handlePayload(cmd *cobra.Command, data any) {
 		}
 	}
 }
+
+// printUsageHandleError is a simple wrapper around printing a command's usage
+// that handles errors.
+func printUsageHandleError(cmd *cobra.Command) {
+	if err := cmd.Usage(); err != nil {
+		log.Logger.Error().Err(err).Msg("failed to print usage")
+		os.Exit(1)
+	}
+}

--- a/cmd/lib.go
+++ b/cmd/lib.go
@@ -105,7 +105,8 @@ func initLogging(cmd *cobra.Command) error {
 // initConfigAndLogging is a wrapper around the config and logging init
 // functions that is meant to be the first thing a command runs in its "Run"
 // directive. createCfg determines whether a config file should be created if
-// missing.
+// missing. This creation only applies when a config file is explicitly
+// specified on the command line and not the merged config.
 func initConfigAndLogging(cmd *cobra.Command, createCfg bool) {
 	if err := initConfig(cmd, createCfg); err != nil {
 		earlyMsgf("failed to initialize config: %v", err)
@@ -405,7 +406,7 @@ func handlePayload(cmd *cobra.Command, data any) {
 // that handles errors.
 func printUsageHandleError(cmd *cobra.Command) {
 	if err := cmd.Usage(); err != nil {
-		earlyMsgf("failed to print usage: %v", err)
+		log.Logger.Error().Err(err).Msg("failed to print usage")
 		os.Exit(1)
 	}
 }

--- a/cmd/lib.go
+++ b/cmd/lib.go
@@ -137,6 +137,9 @@ func askToCreate(path string) (bool, error) {
 	return false, nil
 }
 
+// createIfNotExists creates path (a file with optional leading directories) if
+// any of the path components do not exist, returning an error if one occurred
+// with the creation.
 func createIfNotExists(path string) error {
 	if path == "" {
 		return fmt.Errorf("path cannot be empty")

--- a/cmd/lib.go
+++ b/cmd/lib.go
@@ -22,6 +22,7 @@ import (
 
 var (
 	// Errors
+	FileExistsError   = fmt.Errorf("file exists")
 	NoConfigFileError = fmt.Errorf("no config file to read")
 )
 
@@ -129,6 +130,8 @@ func askToCreate(path string) (bool, error) {
 		if respConfigCreate {
 			return true, nil
 		}
+	} else {
+		return false, FileExistsError
 	}
 
 	return false, nil

--- a/cmd/lib.go
+++ b/cmd/lib.go
@@ -7,7 +7,6 @@ package cmd
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -21,77 +20,47 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Set log level verbosity based on config file (log.level) or --log-level.
-// The command line option overrides the config file option.
-func initLogging() {
-	if rootCmd.PersistentFlags().Lookup("log-format").Changed {
-		lf, err := rootCmd.PersistentFlags().GetString("log-format")
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s: failed to fetch flag log-format: %v\n", config.ProgName, err)
-			os.Exit(1)
-		}
-		config.GlobalConfig.Log.Format = lf
-	}
-	if rootCmd.PersistentFlags().Lookup("log-level").Changed {
-		ll, err := rootCmd.PersistentFlags().GetString("log-level")
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s: failed to fetch flag log-level: %v\n", config.ProgName, err)
-			os.Exit(1)
-		}
-		config.GlobalConfig.Log.Level = ll
-	}
+var (
+	// Errors
+	NoConfigFileError = fmt.Errorf("no config file to read")
+)
 
-	if err := log.Init(config.GlobalConfig.Log.Level, config.GlobalConfig.Log.Format); err != nil {
-		fmt.Fprintf(os.Stderr, "%s: failed to initialize logger: %v\n", config.ProgName, err)
-		os.Exit(1)
-	}
-
-	log.Logger.Debug().Msg("logging has been initialized")
+// earlyMsg is a primitive log function that works like fmt.Fprintln, printing
+// to standard error using the program prefix.
+func earlyMsg(arg ...interface{}) {
+	fmt.Fprintf(os.Stderr, "%s: ", config.ProgName)
+	fmt.Fprintln(os.Stderr, arg...)
 }
 
-// askToCreate prompts the user to, if path does not exist, to create a blank
-// file at path. If it exists, nil is returned. If the user declines, a
-// UserDeclinedError is returned. If an error occurs during creation, an error
-// is returned.
-func askToCreate(path string) error {
-	if path == "" {
-		return fmt.Errorf("path cannot be empty")
-	}
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		respConfigCreate := loopYesNo(fmt.Sprintf("%s does not exist. Create it?", path))
-		if respConfigCreate {
-			parentDir := filepath.Dir(path)
-			if err := os.MkdirAll(parentDir, 0755); err != nil {
-				return fmt.Errorf("could not create parent dir %s: %w", parentDir, err)
-			}
-			f, err := os.OpenFile(path, os.O_RDONLY|os.O_CREATE, 0644)
-			if err != nil {
-				return fmt.Errorf("creating %s failed: %w", path, err)
-			}
-			f.Close()
-		} else {
-			return UserDeclinedError
-		}
-	}
-
-	return nil
+// earlyMsgf is like earlyMsg, except it accepts a format string. It works like
+// fmt.Fprintf.
+func earlyMsgf(fstr string, arg ...interface{}) {
+	fmt.Fprintf(os.Stderr, "%s: ", config.ProgName)
+	fmt.Fprintf(os.Stderr, fstr+"\n", arg...)
 }
 
-func initConfig() {
+// initConfig initializes the global configuration for a command, creating the
+// config file if create is true, if it does not already exist.
+func initConfig(cmd *cobra.Command, create bool) error {
 	// Do not read or write config file if --ignore-config passed
-	if rootCmd.Flag("ignore-config").Changed {
-		return
+	if cmd.Flags().Changed("ignore-config") {
+		return nil
 	}
 
 	if configFile != "" {
-		// Try to create config file with default values if it doesn't exist
-		if err := askToCreate(configFile); err != nil {
-			if errors.Is(err, UserDeclinedError) {
-				fmt.Fprintf(os.Stderr, "%s: user declined to create file; exiting...\n", config.ProgName)
-				os.Exit(0)
+		if create {
+			// Try to create config file with default values if it doesn't exist
+			if cr, err := askToCreate(configFile); err != nil {
+				// Error occurred during prompt
+				return fmt.Errorf("error occurred asking to create config file: %w", err)
+			} else if cr {
+				// User answered yes
+				if err := createIfNotExists(configFile); err != nil {
+					return fmt.Errorf("failed to create %s: %w", configFile, err)
+				}
 			} else {
-				fmt.Fprintf(os.Stderr, "%s: failed to create %s: %v\n", config.ProgName, configFile, err)
-				os.Exit(1)
+				// User answered no
+				return fmt.Errorf("user declined to create file; exiting...")
 			}
 		}
 	}
@@ -100,9 +69,88 @@ func initConfig() {
 	// config file and user config file if not passed.
 	err := config.LoadConfig(configFile)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s: failed to load configuration: %v\n", config.ProgName, err)
+		err = fmt.Errorf("failed to load configuration: %w", err)
+	}
+
+	return err
+}
+
+// Set log level verbosity based on config file (log.level) or --log-level.
+// The command line option overrides the config file option.
+func initLogging(cmd *cobra.Command) error {
+	if cmd.Flags().Changed("log-format") {
+		lf, err := cmd.Flags().GetString("log-format")
+		if err != nil {
+			return fmt.Errorf("failed to fetch flag log-format: %w", err)
+		}
+		config.GlobalConfig.Log.Format = lf
+	}
+	if cmd.Flags().Changed("log-level") {
+		ll, err := cmd.Flags().GetString("log-level")
+		if err != nil {
+			return fmt.Errorf("failed to fetch flag log-level: %w", err)
+		}
+		config.GlobalConfig.Log.Level = ll
+	}
+
+	if err := log.Init(config.GlobalConfig.Log.Level, config.GlobalConfig.Log.Format); err != nil {
+		return fmt.Errorf("failed to initialize logger: %w", err)
+	}
+
+	log.Logger.Debug().Msg("logging has been initialized")
+	return nil
+}
+
+// initConfigAndLogging is a wrapper around the config and logging init
+// functions that is meant to be the first thing a command runs in its "Run"
+// directive. createCfg determines whether a config file should be created if
+// missing.
+func initConfigAndLogging(cmd *cobra.Command, createCfg bool) {
+	if err := initConfig(cmd, createCfg); err != nil {
+		earlyMsgf("failed to initialize config: %v", err)
 		os.Exit(1)
 	}
+	if err := initLogging(cmd); err != nil {
+		earlyMsgf("failed to initialized logging: %v", err)
+		os.Exit(1)
+	}
+}
+
+// askToCreate prompts the user to, if path does not exist, to create a blank
+// file at path. If it exists, nil is returned. If the user declines, a
+// UserDeclinedError is returned. If an error occurs during creation, an error
+// is returned.
+func askToCreate(path string) (bool, error) {
+	if path == "" {
+		return false, fmt.Errorf("path cannot be empty")
+	}
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		respConfigCreate := loopYesNo(fmt.Sprintf("%s does not exist. Create it?", path))
+		if respConfigCreate {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func createIfNotExists(path string) error {
+	if path == "" {
+		return fmt.Errorf("path cannot be empty")
+	}
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		parentDir := filepath.Dir(path)
+		if err := os.MkdirAll(parentDir, 0755); err != nil {
+			return fmt.Errorf("could not create parent dir %s: %w", parentDir, err)
+		}
+		f, err := os.OpenFile(path, os.O_RDONLY|os.O_CREATE, 0644)
+		if err != nil {
+			return fmt.Errorf("creating %s failed: %w", path, err)
+		}
+		f.Close()
+	}
+
+	return nil
 }
 
 // prompt displays a text prompt and returns what the user entered. It continues
@@ -351,7 +399,7 @@ func handlePayload(cmd *cobra.Command, data any) {
 // that handles errors.
 func printUsageHandleError(cmd *cobra.Command) {
 	if err := cmd.Usage(); err != nil {
-		log.Logger.Error().Err(err).Msg("failed to print usage")
+		earlyMsgf("failed to print usage: %v", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/pcs-status.go
+++ b/cmd/pcs-status.go
@@ -101,6 +101,10 @@ var pcsStatusCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Short: "Get status of PCS service",
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Without a base URI, we cannot do anything
 		pcsBaseURI, err := getBaseURIPCS(cmd)
 		if err != nil {

--- a/cmd/pcs-status.go
+++ b/cmd/pcs-status.go
@@ -100,13 +100,6 @@ var pcsStatusCmd = &cobra.Command{
 	Use:   "status",
 	Args:  cobra.NoArgs,
 	Short: "Get status of PCS service",
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
-		return nil
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		pcsBaseURI, err := getBaseURIPCS(cmd)

--- a/cmd/pcs-status.go
+++ b/cmd/pcs-status.go
@@ -100,11 +100,14 @@ var pcsStatusCmd = &cobra.Command{
 	Use:   "status",
 	Args:  cobra.NoArgs,
 	Short: "Get status of PCS service",
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		pcsBaseURI, err := getBaseURIPCS(cmd)
 		if err != nil {

--- a/cmd/pcs.go
+++ b/cmd/pcs.go
@@ -13,6 +13,9 @@ var pcsCmd = &cobra.Command{
 	Use:   "pcs",
 	Args:  cobra.NoArgs,
 	Short: "Interact with the Power Control Service (PCS)",
+	Long: `Interact with the Power Control Service (PCS).
+
+See ochami-pcs(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			printUsageHandleError(cmd)

--- a/cmd/pcs.go
+++ b/cmd/pcs.go
@@ -5,7 +5,6 @@ package cmd
 import (
 	"os"
 
-	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/spf13/cobra"
 )
 
@@ -16,11 +15,7 @@ var pcsCmd = &cobra.Command{
 	Short: "Interact with the Power Control Service (PCS)",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,7 +62,18 @@ See ochami-config(5) for more details on configuring the ochami config file(s).`
 func Execute() {
 	err := rootCmd.Execute()
 	if err != nil {
-		log.Logger.Error().Err(err).Msg("failed to execute root command")
+		log.Logger.Error().Err(err).Msg("failed to execute command")
+		if cmd, _, err := rootCmd.Find(os.Args[1:]); err != nil {
+			// Error looking up invoked command, default to printing
+			// help suggestion for root command, printing debug
+			// message only for debugging (most users don't need to
+			// know an error occurred).
+			log.Logger.Debug().Err(err).Msg("failed to lookup invoked command")
+			logHelpError(rootCmd)
+		} else {
+			// Print help suggestion for invoked command
+			logHelpError(cmd)
+		}
 		os.Exit(1)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,5 +80,5 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&config.EarlyVerbose, "verbose", "v", false, "be verbose before logging is initialized")
 
 	// Either use cluster from config file or specify details on CLI
-	rootCmd.MarkFlagsMutuallyExclusive("cluster", "api-uri")
+	rootCmd.MarkFlagsMutuallyExclusive("cluster", "cluster-uri")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,7 +3,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/OpenCHAMI/ochami/internal/config"
@@ -18,9 +17,6 @@ const (
 )
 
 var (
-	// Errors
-	UserDeclinedError = fmt.Errorf("user declined")
-
 	configFile string
 	logLevel   string
 	logFormat  string
@@ -61,10 +57,6 @@ func Execute() {
 }
 
 func init() {
-	cobra.OnInitialize(
-		initConfig,
-		initLogging,
-	)
 	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "", "path to configuration file to use")
 	rootCmd.PersistentFlags().StringP("log-format", "L", "", "log format (json,rfc3339,basic)")
 	rootCmd.PersistentFlags().StringP("log-level", "l", "", "set verbosity of logs (info,warning,debug)")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,7 +36,11 @@ var rootCmd = &cobra.Command{
 	Use:     config.ProgName,
 	Args:    cobra.NoArgs,
 	Short:   "Command line interface for interacting with OpenCHAMI services",
-	Long:    "",
+	Long: `Command line interface for interacting with OpenCHAMI services.
+
+See ochami(1) for more details on available commands.
+See ochami-config(1) for more details on how to configure ochami using the CLI.
+See ochami-config(5) for more details on configuring the ochami config file(s).`,
 	Version: version.Version,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
@@ -69,7 +73,7 @@ func init() {
 	rootCmd.PersistentFlags().StringP("log-format", "L", "", "log format (json,rfc3339,basic)")
 	rootCmd.PersistentFlags().StringP("log-level", "l", "", "set verbosity of logs (info,warning,debug)")
 	rootCmd.PersistentFlags().StringP("cluster", "C", "", "name of cluster whose config to use for this command")
-	rootCmd.PersistentFlags().StringP("api-uri", "u", "", "base URI for OpenCHAMI services, excluding service base path")
+	rootCmd.PersistentFlags().StringP("cluster-uri", "u", "", "base URI for OpenCHAMI services, excluding service base path (overrides cluster.uri in config file)")
 	rootCmd.PersistentFlags().StringVar(&cacertPath, "cacert", "", "path to root CA certificate in PEM format")
 	rootCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "access token to present for authentication")
 	rootCmd.PersistentFlags().BoolVarP(&insecure, "insecure", "k", false, "do not verify TLS certificates")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,17 @@ See ochami(1) for more details on available commands.
 See ochami-config(1) for more details on how to configure ochami using the CLI.
 See ochami-config(5) for more details on configuring the ochami config file(s).`,
 	Version: version.Version,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// Ask the user in any child commands to create the config file
+		// if missing. If this is undesired, define PersistentPreRunE in
+		// the child command with this line overridden with:
+		//
+		//   initConfigAndLogging(cmd, false)
+		//
+		initConfigAndLogging(cmd, true)
+
+		return nil
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			printUsageHandleError(cmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,11 +44,7 @@ See ochami-config(5) for more details on configuring the ochami config file(s).`
 	Version: version.Version,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
 	},

--- a/cmd/smd-compep-delete.go
+++ b/cmd/smd-compep-delete.go
@@ -22,7 +22,9 @@ Alternatively, pass the xnames in an array of component endpoint data
 via a file with -f. If - is passed to -f, the data is read from standard
 input.
 
-This command sends a DELETE to SMD. An access token is required.`,
+This command sends a DELETE to SMD. An access token is required.
+
+See ochami-smd(1) for more details.`,
 	Example: `  ochami smd compep delete x3000c1s7b56n0 x3000c1s7b56n1
   ochami smd compep delete --all
   ochami smd compep delete -f payload.json
@@ -49,6 +51,7 @@ This command sends a DELETE to SMD. An access token is required.`,
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -60,6 +63,7 @@ This command sends a DELETE to SMD. An access token is required.`,
 		smdClient, err := smd.NewClient(smdBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new SMD client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -104,6 +108,7 @@ This command sends a DELETE to SMD. An access token is required.`,
 				} else {
 					log.Logger.Error().Err(err).Msg("failed to delete component endpoints in SMD")
 				}
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		} else {
@@ -111,6 +116,7 @@ This command sends a DELETE to SMD. An access token is required.`,
 			_, errs, err := smdClient.DeleteComponentEndpoints(token, xnameSlice...)
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to delete redfish endpoints in SMD")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 			// Since smdClient.DeleteComponentEndpoints does the deletion iteratively, we need to
@@ -129,6 +135,7 @@ This command sends a DELETE to SMD. An access token is required.`,
 			// Warn the user if any errors occurred during deletion iterations
 			if errorsOccurred {
 				log.Logger.Warn().Msg("SMD component endpoint deletion completed with errors")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}

--- a/cmd/smd-compep-delete.go
+++ b/cmd/smd-compep-delete.go
@@ -37,11 +37,7 @@ This command sends a DELETE to SMD. An access token is required.`,
 		// must be passed.
 		if len(args) == 0 {
 			if !cmd.Flag("all").Changed && !cmd.Flag("payload").Changed {
-				err := cmd.Usage()
-				if err != nil {
-					log.Logger.Error().Err(err).Msg("failed to print usage")
-					os.Exit(1)
-				}
+				printUsageHandleError(cmd)
 				os.Exit(0)
 			}
 		}

--- a/cmd/smd-compep-delete.go
+++ b/cmd/smd-compep-delete.go
@@ -30,10 +30,6 @@ This command sends a DELETE to SMD. An access token is required.`,
   echo '<json_data>' | ochami smd compep delete -f -
   echo '<yaml_data>' | ochami smd compep delete -f - --payload-format yaml`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
 		// With options, only one of:
 		// - A payload file with -f
 		// - --all

--- a/cmd/smd-compep-delete.go
+++ b/cmd/smd-compep-delete.go
@@ -29,7 +29,7 @@ This command sends a DELETE to SMD. An access token is required.`,
   ochami smd compep delete -f payload.yaml --payload-format yaml
   echo '<json_data>' | ochami smd compep delete -f -
   echo '<yaml_data>' | ochami smd compep delete -f - --payload-format yaml`,
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
@@ -46,6 +46,9 @@ This command sends a DELETE to SMD. An access token is required.`,
 			}
 		}
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-compep-delete.go
+++ b/cmd/smd-compep-delete.go
@@ -30,6 +30,10 @@ This command sends a DELETE to SMD. An access token is required.`,
   echo '<json_data>' | ochami smd compep delete -f -
   echo '<yaml_data>' | ochami smd compep delete -f - --payload-format yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// With options, only one of:
 		// - A payload file with -f
 		// - --all

--- a/cmd/smd-compep-get.go
+++ b/cmd/smd-compep-get.go
@@ -17,12 +17,16 @@ import (
 // compepGetCmd represents the smd-compep-get command
 var compepGetCmd = &cobra.Command{
 	Use:   "get [<xname>...]",
-	Short: "Get all component endpoints or one identified by an xname",
+	Short: "Get all component endpoints or a subset, identified by xname",
+	Long: `Get all component endpoints or a subset, identified by xname.
+
+See ochami-smd(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -34,6 +38,7 @@ var compepGetCmd = &cobra.Command{
 		smdClient, err := smd.NewClient(smdBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new SMD client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -50,6 +55,7 @@ var compepGetCmd = &cobra.Command{
 				} else {
 					log.Logger.Error().Err(err).Msg("failed to request component endpoints from SMD")
 				}
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 
@@ -57,10 +63,12 @@ var compepGetCmd = &cobra.Command{
 			outFmt, err := cmd.Flags().GetString("output-format")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 			if outBytes, err := client.FormatBody(httpEnv.Body, outFmt); err != nil {
 				log.Logger.Error().Err(err).Msg("failed to format output")
+				logHelpError(cmd)
 				os.Exit(1)
 			} else {
 				fmt.Printf(string(outBytes))
@@ -69,6 +77,7 @@ var compepGetCmd = &cobra.Command{
 			httpEnvs, errs, err := smdClient.GetComponentEndpoints(token, args...)
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to get component endpoints from SMD")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 			// Since smdClient.GetComponentEndpoints does the deletion iteratively, we need to
@@ -104,6 +113,7 @@ var compepGetCmd = &cobra.Command{
 
 			// Warn the user if any errors occurred during deletion iterations
 			if errorsOccurred {
+				logHelpError(cmd)
 				log.Logger.Warn().Msg("SMD redfish endpoint deletion completed with errors")
 				os.Exit(1)
 			}
@@ -112,6 +122,7 @@ var compepGetCmd = &cobra.Command{
 			cesBytes, err := json.Marshal(ces)
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to unmarshal list of component endpoints")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 
@@ -119,10 +130,12 @@ var compepGetCmd = &cobra.Command{
 			outFmt, err := cmd.Flags().GetString("output-format")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 			if outBytes, err := client.FormatBody(cesBytes, outFmt); err != nil {
 				log.Logger.Error().Err(err).Msg("failed to format output")
+				logHelpError(cmd)
 				os.Exit(1)
 			} else {
 				fmt.Printf(string(outBytes))

--- a/cmd/smd-compep-get.go
+++ b/cmd/smd-compep-get.go
@@ -18,11 +18,14 @@ import (
 var compepGetCmd = &cobra.Command{
 	Use:   "get [<xname>...]",
 	Short: "Get all component endpoints or one identified by an xname",
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-compep-get.go
+++ b/cmd/smd-compep-get.go
@@ -19,6 +19,10 @@ var compepGetCmd = &cobra.Command{
 	Use:   "get [<xname>...]",
 	Short: "Get all component endpoints or one identified by an xname",
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-compep-get.go
+++ b/cmd/smd-compep-get.go
@@ -18,13 +18,6 @@ import (
 var compepGetCmd = &cobra.Command{
 	Use:   "get [<xname>...]",
 	Short: "Get all component endpoints or one identified by an xname",
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
-		return nil
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)

--- a/cmd/smd-compep.go
+++ b/cmd/smd-compep.go
@@ -14,7 +14,9 @@ var compepCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Short: "Manage component endpoints",
 	Long: `Manage component endpoints. This is a metacommand. Commands under this one
-interact with the State Management Database (SMD).`,
+interact with the State Management Database (SMD).
+
+See ochami-smd(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			printUsageHandleError(cmd)

--- a/cmd/smd-compep.go
+++ b/cmd/smd-compep.go
@@ -5,7 +5,6 @@ package cmd
 import (
 	"os"
 
-	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/spf13/cobra"
 )
 
@@ -18,11 +17,7 @@ var compepCmd = &cobra.Command{
 interact with the State Management Database (SMD).`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
 	},

--- a/cmd/smd-component-add.go
+++ b/cmd/smd-component-add.go
@@ -31,11 +31,7 @@ This command sends a POST to SMD. An access token is required.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Check that all required args are passed
 		if len(args) == 0 && !cmd.Flag("payload").Changed {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		} else if len(args) > 2 {
 			log.Logger.Error().Msgf("expected 2 arguments (xname, nid) but got %d: %v", len(args), args)

--- a/cmd/smd-component-add.go
+++ b/cmd/smd-component-add.go
@@ -22,7 +22,9 @@ var componentAddCmd = &cobra.Command{
 mutually exclusive with the other flags of this command. If - is
 used as the argument to -f, the data is read from standard input.
 
-This command sends a POST to SMD. An access token is required.`,
+This command sends a POST to SMD. An access token is required.
+
+See ochami-smd(1) for more details.`,
 	Example: `  ochami smd component add x3000c1s7b56n0 56
   ochami smd component add --state Ready --enabled --role Compute --arch X86 x3000c1s7b56n0 56
   ochami smd component add -f payload.json
@@ -45,6 +47,7 @@ This command sends a POST to SMD. An access token is required.`,
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -56,6 +59,7 @@ This command sends a POST to SMD. An access token is required.`,
 		smdClient, err := smd.NewClient(smdBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new SMD client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -90,6 +94,7 @@ This command sends a POST to SMD. An access token is required.`,
 			} else {
 				log.Logger.Error().Err(err).Msg("failed to add component(s) to SMD")
 			}
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 	},

--- a/cmd/smd-component-add.go
+++ b/cmd/smd-component-add.go
@@ -30,10 +30,6 @@ This command sends a POST to SMD. An access token is required.`,
   echo '<json_data>' | ochami smd component add -f -
   echo '<yaml_data>' | ochami smd component add -f - --payload-format yaml`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
 		// Check that all required args are passed
 		if len(args) == 0 && !cmd.Flag("payload").Changed {
 			printUsageHandleError(cmd)

--- a/cmd/smd-component-add.go
+++ b/cmd/smd-component-add.go
@@ -3,8 +3,8 @@
 package cmd
 
 import (
-	"fmt"
 	"errors"
+	"fmt"
 	"os"
 
 	"github.com/OpenCHAMI/ochami/internal/log"

--- a/cmd/smd-component-add.go
+++ b/cmd/smd-component-add.go
@@ -3,6 +3,7 @@
 package cmd
 
 import (
+	"fmt"
 	"errors"
 	"os"
 
@@ -28,7 +29,7 @@ This command sends a POST to SMD. An access token is required.`,
   ochami smd component add -f payload.yaml --payload-format yaml
   echo '<json_data>' | ochami smd component add -f -
   echo '<yaml_data>' | ochami smd component add -f - --payload-format yaml`,
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
@@ -37,11 +38,13 @@ This command sends a POST to SMD. An access token is required.`,
 		if len(args) == 0 && !cmd.Flag("payload").Changed {
 			printUsageHandleError(cmd)
 			os.Exit(0)
-		} else if len(args) > 2 {
-			log.Logger.Error().Msgf("expected 2 arguments (xname, nid) but got %d: %v", len(args), args)
-			os.Exit(1)
+		} else if len(args) != 2 {
+			return fmt.Errorf("expected 2 arguments (xname, nid) but got %d: %v", len(args), args)
 		}
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-component-add.go
+++ b/cmd/smd-component-add.go
@@ -29,6 +29,10 @@ This command sends a POST to SMD. An access token is required.`,
   echo '<json_data>' | ochami smd component add -f -
   echo '<yaml_data>' | ochami smd component add -f - --payload-format yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Check that all required args are passed
 		if len(args) == 0 && !cmd.Flag("payload").Changed {
 			printUsageHandleError(cmd)

--- a/cmd/smd-component-delete.go
+++ b/cmd/smd-component-delete.go
@@ -21,7 +21,9 @@ or more NIDs, or a combination of both. Alternatively, specify the xnames in
 an array of component structures within a payload file and pass it to -f. If
 - is passed to -f, the data is read from standard input.
 
-This command sends a DELETE to SMD. An access token is required.`,
+This command sends a DELETE to SMD. An access token is required.
+
+See ochami-smd(1) for more details.`,
 	Example: `  ochami smd component delete x3000c1s7b56n0
   ochami smd component delete x3000c1s7b56n0 x3000c1s7b56n1
   ochami smd component delete --all

--- a/cmd/smd-component-delete.go
+++ b/cmd/smd-component-delete.go
@@ -37,11 +37,7 @@ This command sends a DELETE to SMD. An access token is required.`,
 		// must be passed.
 		if len(args) == 0 {
 			if !cmd.Flag("all").Changed && !cmd.Flag("payload").Changed {
-				err := cmd.Usage()
-				if err != nil {
-					log.Logger.Error().Err(err).Msg("failed to print usage")
-					os.Exit(1)
-				}
+				printUsageHandleError(cmd)
 				os.Exit(0)
 			}
 		}

--- a/cmd/smd-component-delete.go
+++ b/cmd/smd-component-delete.go
@@ -29,7 +29,7 @@ This command sends a DELETE to SMD. An access token is required.`,
   ochami smd component delete -f payload.yaml --payload-format yaml
   echo '<json_data>' | ochami smd component delete -f -
   echo '<yaml_data>' | ochami smd component delete -f - --payload-format yaml`,
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
@@ -46,6 +46,9 @@ This command sends a DELETE to SMD. An access token is required.`,
 			}
 		}
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-component-delete.go
+++ b/cmd/smd-component-delete.go
@@ -30,6 +30,10 @@ This command sends a DELETE to SMD. An access token is required.`,
   echo '<json_data>' | ochami smd component delete -f -
   echo '<yaml_data>' | ochami smd component delete -f - --payload-format yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// With options, only one of:
 		// - A payload file with -f
 		// - --all

--- a/cmd/smd-component-delete.go
+++ b/cmd/smd-component-delete.go
@@ -30,10 +30,6 @@ This command sends a DELETE to SMD. An access token is required.`,
   echo '<json_data>' | ochami smd component delete -f -
   echo '<yaml_data>' | ochami smd component delete -f - --payload-format yaml`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
 		// With options, only one of:
 		// - A payload file with -f
 		// - --all

--- a/cmd/smd-component-get.go
+++ b/cmd/smd-component-get.go
@@ -18,11 +18,15 @@ var componentGetCmd = &cobra.Command{
 	Use:   "get",
 	Args:  cobra.NoArgs,
 	Short: "Get all components or component identified by an xname or node ID",
+	Long: `Get all components or component by an xname or node ID.
+
+See ochami-smd(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -30,6 +34,7 @@ var componentGetCmd = &cobra.Command{
 		smdClient, err := smd.NewClient(smdBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new SMD client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -52,6 +57,7 @@ var componentGetCmd = &cobra.Command{
 			nid, err = cmd.Flags().GetInt32("nid")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("error getting nid from flag")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 			httpEnv, err = smdClient.GetComponentsNid(nid, token)
@@ -71,10 +77,12 @@ var componentGetCmd = &cobra.Command{
 		outFmt, err := cmd.Flags().GetString("output-format")
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 		if outBytes, err := client.FormatBody(httpEnv.Body, outFmt); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to format output")
+			logHelpError(cmd)
 			os.Exit(1)
 		} else {
 			fmt.Printf(string(outBytes))

--- a/cmd/smd-component-get.go
+++ b/cmd/smd-component-get.go
@@ -19,6 +19,10 @@ var componentGetCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Short: "Get all components or component identified by an xname or node ID",
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-component-get.go
+++ b/cmd/smd-component-get.go
@@ -18,13 +18,6 @@ var componentGetCmd = &cobra.Command{
 	Use:   "get",
 	Args:  cobra.NoArgs,
 	Short: "Get all components or component identified by an xname or node ID",
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
-		return nil
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)

--- a/cmd/smd-component-get.go
+++ b/cmd/smd-component-get.go
@@ -18,11 +18,14 @@ var componentGetCmd = &cobra.Command{
 	Use:   "get",
 	Args:  cobra.NoArgs,
 	Short: "Get all components or component identified by an xname or node ID",
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-component.go
+++ b/cmd/smd-component.go
@@ -5,7 +5,6 @@ package cmd
 import (
 	"os"
 
-	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/spf13/cobra"
 )
 
@@ -18,11 +17,7 @@ var componentCmd = &cobra.Command{
 interact with the State Management Database (SMD).`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
 	},

--- a/cmd/smd-component.go
+++ b/cmd/smd-component.go
@@ -14,7 +14,9 @@ var componentCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Short: "Manage components",
 	Long: `Manage components. This is a metacommand. Commands under this one
-interact with the State Management Database (SMD).`,
+interact with the State Management Database (SMD).
+
+See ochami-smd(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			printUsageHandleError(cmd)

--- a/cmd/smd-group-add.go
+++ b/cmd/smd-group-add.go
@@ -22,7 +22,9 @@ Specifying -f also is mutually exclusive with the other flags of this commands
 and its arguments. If - is used as the argument to -f, the data is read from
 standard input.
 
-This command sends a POST to SMD. An access token is required.`,
+This command sends a POST to SMD. An access token is required.
+
+See ochami-smd(1) for more details.`,
 	Example: `  ochami smd group add computes
   ochami smd group add -d "Compute group" computes
   ochami smd group add -d "Compute group" --tag tag1,tag2 --m x3000c1s7b0n1,x3000c1s7b1n1 computes
@@ -50,6 +52,7 @@ This command sends a POST to SMD. An access token is required.`,
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -61,6 +64,7 @@ This command sends a POST to SMD. An access token is required.`,
 		smdClient, err := smd.NewClient(smdBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new SMD client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -77,24 +81,28 @@ This command sends a POST to SMD. An access token is required.`,
 			if cmd.Flag("description").Changed {
 				if group.Description, err = cmd.Flags().GetString("description"); err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch description")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 			}
 			if cmd.Flag("tag").Changed {
 				if group.Tags, err = cmd.Flags().GetStringSlice("tag"); err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch tags")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 			}
 			if cmd.Flag("exclusive-group").Changed {
 				if group.ExclusiveGroup, err = cmd.Flags().GetString("exclusive-group"); err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch exclusive group name")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 			}
 			if cmd.Flag("member").Changed {
 				if group.Members.IDs, err = cmd.Flags().GetStringSlice("member"); err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch members")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 			}
@@ -105,6 +113,7 @@ This command sends a POST to SMD. An access token is required.`,
 		_, errs, err := smdClient.PostGroups(groups, token)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to add group to SMD")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 		// Since smdClient.PostGroups does the addition iteratively, we need to deal with
@@ -121,6 +130,7 @@ This command sends a POST to SMD. An access token is required.`,
 			}
 		}
 		if errorsOccurred {
+			logHelpError(cmd)
 			log.Logger.Warn().Msg("SMD group addition completed with errors")
 			os.Exit(1)
 		}

--- a/cmd/smd-group-add.go
+++ b/cmd/smd-group-add.go
@@ -38,11 +38,7 @@ This command sends a POST to SMD. An access token is required.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Check that all required args are passed
 		if len(args) == 0 && !cmd.Flag("payload").Changed {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		} else if len(args) > 1 {
 			log.Logger.Error().Msgf("expected 1 arguments (group_name) but got %d: %v", len(args), args)

--- a/cmd/smd-group-add.go
+++ b/cmd/smd-group-add.go
@@ -37,10 +37,6 @@ This command sends a POST to SMD. An access token is required.`,
   echo '<json_data>' | ochami smd group add -f -
   echo '<yaml_data>' | ochami smd group add -f - --payload-format yaml`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
 		// Check that all required args are passed
 		if len(args) == 0 && !cmd.Flag("payload").Changed {
 			printUsageHandleError(cmd)

--- a/cmd/smd-group-add.go
+++ b/cmd/smd-group-add.go
@@ -36,6 +36,10 @@ This command sends a POST to SMD. An access token is required.`,
   echo '<json_data>' | ochami smd group add -f -
   echo '<yaml_data>' | ochami smd group add -f - --payload-format yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Check that all required args are passed
 		if len(args) == 0 && !cmd.Flag("payload").Changed {
 			printUsageHandleError(cmd)

--- a/cmd/smd-group-add.go
+++ b/cmd/smd-group-add.go
@@ -15,6 +15,7 @@ import (
 // groupAddCmd represents the smd-group-add command
 var groupAddCmd = &cobra.Command{
 	Use:   "add -f <payload_file> | <group_label>",
+	Args:  cobra.MaximumNArgs(1),
 	Short: "Add new group",
 	Long: `Add new group. A group name is required unless -f is passed to read the payload file.
 Specifying -f also is mutually exclusive with the other flags of this commands
@@ -35,7 +36,7 @@ This command sends a POST to SMD. An access token is required.`,
   ochami smd group add -f payload.yaml --payload-format yaml
   echo '<json_data>' | ochami smd group add -f -
   echo '<yaml_data>' | ochami smd group add -f - --payload-format yaml`,
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
@@ -44,11 +45,11 @@ This command sends a POST to SMD. An access token is required.`,
 		if len(args) == 0 && !cmd.Flag("payload").Changed {
 			printUsageHandleError(cmd)
 			os.Exit(0)
-		} else if len(args) > 1 {
-			log.Logger.Error().Msgf("expected 1 arguments (group_name) but got %d: %v", len(args), args)
-			os.Exit(1)
 		}
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-group-delete.go
+++ b/cmd/smd-group-delete.go
@@ -21,7 +21,9 @@ Alternatively, pass the group labels in an array of group structures
 within a payload file and specify that file via -f. If - is used as
 the argument to -f, the data is read from standard input.
 
-This command sends a DELETE to SMD. An access token is required.`,
+This command sends a DELETE to SMD. An access token is required.
+
+See ochami-smd(1) for more details.`,
 	Example: `  ochami smd group delete compute
   ochami smd group delete -f payload.json
   ochami smd group delete -f payload.yaml --payload-format yaml
@@ -46,6 +48,7 @@ This command sends a DELETE to SMD. An access token is required.`,
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -57,6 +60,7 @@ This command sends a DELETE to SMD. An access token is required.`,
 		smdClient, err := smd.NewClient(smdBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new SMD client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -90,6 +94,7 @@ This command sends a DELETE to SMD. An access token is required.`,
 		_, errs, err := smdClient.DeleteGroups(token, gLabelSlice...)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to delete groups in SMD")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 		// Since smdClient.DeleteGroups does the deletion iteratively, we need to deal with
@@ -107,6 +112,7 @@ This command sends a DELETE to SMD. An access token is required.`,
 		}
 		// Warn the user if any errors occurred during deletion iterations
 		if errorsOccurred {
+			logHelpError(cmd)
 			log.Logger.Warn().Msg("SMD group deletion completed with errors")
 			os.Exit(1)
 		}

--- a/cmd/smd-group-delete.go
+++ b/cmd/smd-group-delete.go
@@ -34,11 +34,7 @@ This command sends a DELETE to SMD. An access token is required.`,
 		// must be passed.
 		if len(args) == 0 {
 			if !cmd.Flag("payload").Changed {
-				err := cmd.Usage()
-				if err != nil {
-					log.Logger.Error().Err(err).Msg("failed to print usage")
-					os.Exit(1)
-				}
+				printUsageHandleError(cmd)
 				os.Exit(0)
 			}
 		}

--- a/cmd/smd-group-delete.go
+++ b/cmd/smd-group-delete.go
@@ -28,10 +28,6 @@ This command sends a DELETE to SMD. An access token is required.`,
   echo '<json_data>' | ochami smd group delete -f -
   echo '<yaml_data>' | ochami smd group delete -f - --payload-format yaml`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
 		// With options, only one of:
 		// - A payload file with -f
 		// - A set of one or more group labels

--- a/cmd/smd-group-delete.go
+++ b/cmd/smd-group-delete.go
@@ -28,6 +28,10 @@ This command sends a DELETE to SMD. An access token is required.`,
   echo '<json_data>' | ochami smd group delete -f -
   echo '<yaml_data>' | ochami smd group delete -f - --payload-format yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// With options, only one of:
 		// - A payload file with -f
 		// - A set of one or more group labels

--- a/cmd/smd-group-delete.go
+++ b/cmd/smd-group-delete.go
@@ -27,7 +27,7 @@ This command sends a DELETE to SMD. An access token is required.`,
   ochami smd group delete -f payload.yaml --payload-format yaml
   echo '<json_data>' | ochami smd group delete -f -
   echo '<yaml_data>' | ochami smd group delete -f - --payload-format yaml`,
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
@@ -43,6 +43,9 @@ This command sends a DELETE to SMD. An access token is required.`,
 			}
 		}
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-group-get.go
+++ b/cmd/smd-group-get.go
@@ -19,6 +19,9 @@ var groupGetCmd = &cobra.Command{
 	Use:   "get",
 	Args:  cobra.NoArgs,
 	Short: "Get all groups or group(s) identified by name and/or tag",
+	Long: `Get all groups or group(s) identified by name and/or tag.
+
+See ochami-smd(1) for more details.`,
 	Example: `  ochami smd group get
   ochami smd group get --name group1
   ochami smd group get --tag group1_tag
@@ -31,6 +34,7 @@ var groupGetCmd = &cobra.Command{
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -42,6 +46,7 @@ var groupGetCmd = &cobra.Command{
 		smdClient, err := smd.NewClient(smdBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new SMD client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -56,6 +61,7 @@ var groupGetCmd = &cobra.Command{
 				s, err := cmd.Flags().GetStringSlice("name")
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch name list")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 				for _, n := range s {
@@ -66,6 +72,7 @@ var groupGetCmd = &cobra.Command{
 				s, err := cmd.Flags().GetStringSlice("tag")
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch tag list")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 				for _, t := range s {
@@ -81,6 +88,7 @@ var groupGetCmd = &cobra.Command{
 			} else {
 				log.Logger.Error().Err(err).Msg("failed to request groups from SMD")
 			}
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -88,10 +96,12 @@ var groupGetCmd = &cobra.Command{
 		outFmt, err := cmd.Flags().GetString("output-format")
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 		if outBytes, err := client.FormatBody(httpEnv.Body, outFmt); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to format output")
+			logHelpError(cmd)
 			os.Exit(1)
 		} else {
 			fmt.Printf(string(outBytes))

--- a/cmd/smd-group-get.go
+++ b/cmd/smd-group-get.go
@@ -27,6 +27,10 @@ var groupGetCmd = &cobra.Command{
   ochami smd group get --name group1,group2 --tag tag1,tag2
   ochami smd group get --name group1 --name group2 --tag tag1 --tag tag2`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-group-get.go
+++ b/cmd/smd-group-get.go
@@ -26,11 +26,14 @@ var groupGetCmd = &cobra.Command{
   ochami smd group get --name group1 --name group2
   ochami smd group get --name group1,group2 --tag tag1,tag2
   ochami smd group get --name group1 --name group2 --tag tag1 --tag tag2`,
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-group-get.go
+++ b/cmd/smd-group-get.go
@@ -26,13 +26,6 @@ var groupGetCmd = &cobra.Command{
   ochami smd group get --name group1 --name group2
   ochami smd group get --name group1,group2 --tag tag1,tag2
   ochami smd group get --name group1 --name group2 --tag tag1 --tag tag2`,
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
-		return nil
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)

--- a/cmd/smd-group-member-add.go
+++ b/cmd/smd-group-member-add.go
@@ -17,11 +17,15 @@ var groupMemberAddCmd = &cobra.Command{
 	Use:   "add <group_label> <component>...",
 	Args:  cobra.MinimumNArgs(2),
 	Short: "Add one or more components to a group",
+	Long: `Add one or more components to a group.
+
+See ochami-smd(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -33,6 +37,7 @@ var groupMemberAddCmd = &cobra.Command{
 		smdClient, err := smd.NewClient(smdBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new SMD client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -43,6 +48,7 @@ var groupMemberAddCmd = &cobra.Command{
 		_, errs, err := smdClient.PostGroupMembers(token, args[0], args[1:]...)
 		if err != nil {
 			log.Logger.Error().Err(err).Msgf("failed to add group member(s) to group %s in SMD", args[0])
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 		// Since smdClient.PostGroupMembers does the addition iteratively, we need to deal with
@@ -59,6 +65,7 @@ var groupMemberAddCmd = &cobra.Command{
 			}
 		}
 		if errorsOccurred {
+			logHelpError(cmd)
 			log.Logger.Warn().Msg("SMD group addition completed with errors")
 			os.Exit(1)
 		}

--- a/cmd/smd-group-member-add.go
+++ b/cmd/smd-group-member-add.go
@@ -17,13 +17,6 @@ var groupMemberAddCmd = &cobra.Command{
 	Use:   "add <group_label> <component>...",
 	Args:  cobra.MinimumNArgs(2),
 	Short: "Add one or more components to a group",
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
-		return nil
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)

--- a/cmd/smd-group-member-add.go
+++ b/cmd/smd-group-member-add.go
@@ -18,6 +18,10 @@ var groupMemberAddCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(2),
 	Short: "Add one or more components to a group",
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-group-member-add.go
+++ b/cmd/smd-group-member-add.go
@@ -17,11 +17,14 @@ var groupMemberAddCmd = &cobra.Command{
 	Use:   "add <group_label> <component>...",
 	Args:  cobra.MinimumNArgs(2),
 	Short: "Add one or more components to a group",
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-group-member-delete.go
+++ b/cmd/smd-group-member-delete.go
@@ -17,11 +17,15 @@ var groupMemberDeleteCmd = &cobra.Command{
 	Use:   "delete <group_label> <component>...",
 	Args:  cobra.MinimumNArgs(2),
 	Short: "Delete one or more members from a group",
+	Long: `Delete one or more members froma group.
+
+See ochami-smd(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -33,6 +37,7 @@ var groupMemberDeleteCmd = &cobra.Command{
 		smdClient, err := smd.NewClient(smdBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new SMD client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -55,6 +60,7 @@ var groupMemberDeleteCmd = &cobra.Command{
 		_, errs, err := smdClient.DeleteGroupMembers(token, args[0], args[1:]...)
 		if err != nil {
 			log.Logger.Error().Err(err).Msgf("failed to delete members from group %s in SMD", args[0])
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 		// Since smdClient.DeleteGroupMembers does the deletion iteratively, we need to deal with
@@ -72,6 +78,7 @@ var groupMemberDeleteCmd = &cobra.Command{
 		}
 		// Warn the user if any errors occurred during deletion iterations
 		if errorsOccurred {
+			logHelpError(cmd)
 			log.Logger.Warn().Msg("SMD group member deletion completed with errors")
 			os.Exit(1)
 		}

--- a/cmd/smd-group-member-delete.go
+++ b/cmd/smd-group-member-delete.go
@@ -17,13 +17,6 @@ var groupMemberDeleteCmd = &cobra.Command{
 	Use:   "delete <group_label> <component>...",
 	Args:  cobra.MinimumNArgs(2),
 	Short: "Delete one or more members from a group",
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
-		return nil
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)

--- a/cmd/smd-group-member-delete.go
+++ b/cmd/smd-group-member-delete.go
@@ -17,11 +17,14 @@ var groupMemberDeleteCmd = &cobra.Command{
 	Use:   "delete <group_label> <component>...",
 	Args:  cobra.MinimumNArgs(2),
 	Short: "Delete one or more members from a group",
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-group-member-delete.go
+++ b/cmd/smd-group-member-delete.go
@@ -18,6 +18,10 @@ var groupMemberDeleteCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(2),
 	Short: "Delete one or more members from a group",
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-group-member-get.go
+++ b/cmd/smd-group-member-get.go
@@ -18,11 +18,15 @@ var groupMemberGetCmd = &cobra.Command{
 	Use:   "get <group_label>",
 	Args:  cobra.ExactArgs(1),
 	Short: "Get members of a group",
+	Long: `Get members of a group.
+
+See ochami-smd(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -34,6 +38,7 @@ var groupMemberGetCmd = &cobra.Command{
 		smdClient, err := smd.NewClient(smdBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new SMD client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -48,6 +53,7 @@ var groupMemberGetCmd = &cobra.Command{
 			} else {
 				log.Logger.Error().Err(err).Msg("failed to request group members from SMD")
 			}
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -55,10 +61,12 @@ var groupMemberGetCmd = &cobra.Command{
 		outFmt, err := cmd.Flags().GetString("output-format")
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 		if outBytes, err := client.FormatBody(httpEnv.Body, outFmt); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to format output")
+			logHelpError(cmd)
 			os.Exit(1)
 		} else {
 			fmt.Printf(string(outBytes))

--- a/cmd/smd-group-member-get.go
+++ b/cmd/smd-group-member-get.go
@@ -18,13 +18,6 @@ var groupMemberGetCmd = &cobra.Command{
 	Use:   "get <group_label>",
 	Args:  cobra.ExactArgs(1),
 	Short: "Get members of a group",
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
-		return nil
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)

--- a/cmd/smd-group-member-get.go
+++ b/cmd/smd-group-member-get.go
@@ -18,11 +18,14 @@ var groupMemberGetCmd = &cobra.Command{
 	Use:   "get <group_label>",
 	Args:  cobra.ExactArgs(1),
 	Short: "Get members of a group",
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-group-member-get.go
+++ b/cmd/smd-group-member-get.go
@@ -19,6 +19,10 @@ var groupMemberGetCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Short: "Get members of a group",
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-group-member-set.go
+++ b/cmd/smd-group-member-set.go
@@ -22,13 +22,16 @@ in the list are set as the only members of the group. If a component
 specified is already in the group, it remains in the group. If a
 component specified is not already in te group, it is added to the
 group. If a component is in the group but not specified, it is
-removed from the group.`,
+removed from the group.
+
+See ochami-smd(1) for more details.`,
 	Example: `  ochami smd group member set compute x1000c1s7b1n0 x1000c1s7b2n0`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -40,6 +43,7 @@ removed from the group.`,
 		smdClient, err := smd.NewClient(smdBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new SMD client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -54,6 +58,7 @@ removed from the group.`,
 			} else {
 				log.Logger.Error().Err(err).Msgf("failed to set group membership for group %s in SMD", args[0])
 			}
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 	},

--- a/cmd/smd-group-member-set.go
+++ b/cmd/smd-group-member-set.go
@@ -25,6 +25,10 @@ group. If a component is in the group but not specified, it is
 removed from the group.`,
 	Example: `  ochami smd group member set compute x1000c1s7b1n0 x1000c1s7b2n0`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-group-member-set.go
+++ b/cmd/smd-group-member-set.go
@@ -24,11 +24,14 @@ component specified is not already in te group, it is added to the
 group. If a component is in the group but not specified, it is
 removed from the group.`,
 	Example: `  ochami smd group member set compute x1000c1s7b1n0 x1000c1s7b2n0`,
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-group-member-set.go
+++ b/cmd/smd-group-member-set.go
@@ -24,13 +24,6 @@ component specified is not already in te group, it is added to the
 group. If a component is in the group but not specified, it is
 removed from the group.`,
 	Example: `  ochami smd group member set compute x1000c1s7b1n0 x1000c1s7b2n0`,
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
-		return nil
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)

--- a/cmd/smd-group-member.go
+++ b/cmd/smd-group-member.go
@@ -5,7 +5,6 @@ package cmd
 import (
 	"os"
 
-	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/spf13/cobra"
 )
 
@@ -18,11 +17,7 @@ var groupMemberCmd = &cobra.Command{
 interact with the State Management Database (SMD).`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
 	},

--- a/cmd/smd-group-member.go
+++ b/cmd/smd-group-member.go
@@ -14,7 +14,9 @@ var groupMemberCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Short: "Manage group membership",
 	Long: `Mange group membership. This is a metacommand. Commands under this one
-interact with the State Management Database (SMD).`,
+interact with the State Management Database (SMD).
+
+See ochami-smd(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			printUsageHandleError(cmd)

--- a/cmd/smd-group-update.go
+++ b/cmd/smd-group-update.go
@@ -34,11 +34,7 @@ This command sends a PATCH to SMD. An access token is required.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// cmd.LocalFlags().NFlag() doesn't seem to work, so we check every flag
 		if len(args) == 0 && !cmd.Flag("description").Changed && !cmd.Flag("tag").Changed {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
 

--- a/cmd/smd-group-update.go
+++ b/cmd/smd-group-update.go
@@ -23,7 +23,9 @@ or --tag must be specified. Alternatively, pass -f to pass a file
 rules above still apply for the payload. If - is used as the
 argument to -f, the data is read from standard input.
 
-This command sends a PATCH to SMD. An access token is required.`,
+This command sends a PATCH to SMD. An access token is required.
+
+See ochami-smd(1) for more details.`,
 	Example: `  ochami smd group update --description "New description for compute" compute
   ochami smd group update --tag existing_tag --tag new_tag compute
   ochami smd group update --tag existing_tag,new_tag compute
@@ -46,6 +48,7 @@ This command sends a PATCH to SMD. An access token is required.`,
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -57,6 +60,7 @@ This command sends a PATCH to SMD. An access token is required.`,
 		smdClient, err := smd.NewClient(smdBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new SMD client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -75,12 +79,14 @@ This command sends a PATCH to SMD. An access token is required.`,
 			if cmd.Flag("description").Changed {
 				if group.Description, err = cmd.Flags().GetString("description"); err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch description")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 			}
 			if cmd.Flag("tag").Changed {
 				if group.Tags, err = cmd.Flags().GetStringSlice("tag"); err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch tags")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 			}
@@ -91,6 +97,7 @@ This command sends a PATCH to SMD. An access token is required.`,
 		_, errs, err := smdClient.PatchGroups(groups, token)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to patch group in SMD")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 		// Since smdClient.PatchGroups does the edition iteratively, we need to deal with
@@ -108,6 +115,7 @@ This command sends a PATCH to SMD. An access token is required.`,
 		}
 		if errorsOccurred {
 			log.Logger.Warn().Msg("SMD group update completed with errors")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 	},

--- a/cmd/smd-group-update.go
+++ b/cmd/smd-group-update.go
@@ -15,6 +15,7 @@ import (
 // groupUpdateCmd represents the smd-group-update command
 var groupUpdateCmd = &cobra.Command{
 	Use:   "update -f <payload_file> | ([--description <description>] [--tag <tag>]... <group_label>)",
+	Args:  cobra.MaximumNArgs(1),
 	Short: "Update the description and/or tags of a group",
 	Long: `Update the description and/or tags of a group. At least one of --description
 or --tag must be specified. Alternatively, pass -f to pass a file
@@ -31,7 +32,7 @@ This command sends a PATCH to SMD. An access token is required.`,
   ochami smd group update -f payload.yaml --payload-format yaml
   echo '<json_data>' | ochami smd group update -f -
   echo '<yaml_data>' | ochami smd group update -f - --payload-format yaml`,
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
@@ -42,6 +43,9 @@ This command sends a PATCH to SMD. An access token is required.`,
 			os.Exit(0)
 		}
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-group-update.go
+++ b/cmd/smd-group-update.go
@@ -33,10 +33,6 @@ This command sends a PATCH to SMD. An access token is required.`,
   echo '<json_data>' | ochami smd group update -f -
   echo '<yaml_data>' | ochami smd group update -f - --payload-format yaml`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
 		// cmd.LocalFlags().NFlag() doesn't seem to work, so we check every flag
 		if len(args) == 0 && !cmd.Flag("description").Changed && !cmd.Flag("tag").Changed {
 			printUsageHandleError(cmd)

--- a/cmd/smd-group-update.go
+++ b/cmd/smd-group-update.go
@@ -32,6 +32,10 @@ This command sends a PATCH to SMD. An access token is required.`,
   echo '<json_data>' | ochami smd group update -f -
   echo '<yaml_data>' | ochami smd group update -f - --payload-format yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// cmd.LocalFlags().NFlag() doesn't seem to work, so we check every flag
 		if len(args) == 0 && !cmd.Flag("description").Changed && !cmd.Flag("tag").Changed {
 			printUsageHandleError(cmd)

--- a/cmd/smd-group.go
+++ b/cmd/smd-group.go
@@ -14,7 +14,9 @@ var groupCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Short: "Manage groups of components",
 	Long: `Manage groups of components. This is a metacommand. Commands under this one
-interact with the State Management Database (SMD).`,
+interact with the State Management Database (SMD).
+
+See ochami-smd(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			printUsageHandleError(cmd)

--- a/cmd/smd-group.go
+++ b/cmd/smd-group.go
@@ -5,7 +5,6 @@ package cmd
 import (
 	"os"
 
-	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/spf13/cobra"
 )
 
@@ -18,11 +17,7 @@ var groupCmd = &cobra.Command{
 interact with the State Management Database (SMD).`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
 	},

--- a/cmd/smd-iface-add.go
+++ b/cmd/smd-iface-add.go
@@ -36,11 +36,7 @@ This command sends a POST to SMD. An access token is required.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Check that all required args are passed
 		if len(args) == 0 && !cmd.Flag("payload").Changed {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		} else if len(args) < 3 {
 			log.Logger.Error().Msgf("expected at least 3 arguments (comp_id, mac_addr, net_ip_paor) but got %d: %v", len(args), args)

--- a/cmd/smd-iface-add.go
+++ b/cmd/smd-iface-add.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"strings"
@@ -25,7 +26,9 @@ are required unless -f is passed to read from a payload file. Specifying
 its arguments. If - is used as the argument to -f, the data is read
 from standard input.
 
-This command sends a POST to SMD. An access token is required.`,
+This command sends a POST to SMD. An access token is required.
+
+See ochami-smd(1) for more details.`,
 	Example: `  ochami smd iface add x3000c1s7b55n0 de:ca:fc:0f:fe:ee NMN,172.16.0.55
   ochami smd iface add -d "Node Management for n55" x3000c1s7b55n0 de:ca:fc:0f:fe:ee NMN,172.16.0.55
   ochami smd iface add x3000c1s7b55n0 de:ca:fc:0f:fe:ee external,10.1.0.55 internal,172.16.0.55
@@ -39,8 +42,7 @@ This command sends a POST to SMD. An access token is required.`,
 			printUsageHandleError(cmd)
 			os.Exit(0)
 		} else if len(args) < 3 {
-			log.Logger.Error().Msgf("expected at least 3 arguments (comp_id, mac_addr, net_ip_paor) but got %d: %v", len(args), args)
-			os.Exit(1)
+			return fmt.Errorf("expected at least 3 arguments (comp_id, mac_addr, net_ip_paor) but got %d: %v", len(args), args)
 		}
 
 		return nil
@@ -50,6 +52,7 @@ This command sends a POST to SMD. An access token is required.`,
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -61,6 +64,7 @@ This command sends a POST to SMD. An access token is required.`,
 		smdClient, err := smd.NewClient(smdBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new SMD client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -99,6 +103,7 @@ This command sends a POST to SMD. An access token is required.`,
 		_, errs, err := smdClient.PostEthernetInterfaces(eis, token)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to add ethernet interface in SMD")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 		// Since smdClient.PostEthernetInterfaces does the addition iteratively, we need to deal with
@@ -115,6 +120,7 @@ This command sends a POST to SMD. An access token is required.`,
 			}
 		}
 		if errorsOccurred {
+			logHelpError(cmd)
 			log.Logger.Warn().Msg("SMD ethernet interface addition completed with errors")
 			os.Exit(1)
 		}

--- a/cmd/smd-iface-add.go
+++ b/cmd/smd-iface-add.go
@@ -34,10 +34,6 @@ This command sends a POST to SMD. An access token is required.`,
   echo '<json_data>' | ochami smd iface add -f -
   echo '<yaml_data>' | ochami smd iface add -f - --payload-format yaml`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
 		// Check that all required args are passed
 		if len(args) == 0 && !cmd.Flag("payload").Changed {
 			printUsageHandleError(cmd)

--- a/cmd/smd-iface-add.go
+++ b/cmd/smd-iface-add.go
@@ -34,6 +34,10 @@ This command sends a POST to SMD. An access token is required.`,
   echo '<json_data>' | ochami smd iface add -f -
   echo '<yaml_data>' | ochami smd iface add -f - --payload-format yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Check that all required args are passed
 		if len(args) == 0 && !cmd.Flag("payload").Changed {
 			printUsageHandleError(cmd)

--- a/cmd/smd-iface-add.go
+++ b/cmd/smd-iface-add.go
@@ -33,7 +33,7 @@ This command sends a POST to SMD. An access token is required.`,
   ochami smd iface add -f payload.yaml --payload-format yaml
   echo '<json_data>' | ochami smd iface add -f -
   echo '<yaml_data>' | ochami smd iface add -f - --payload-format yaml`,
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
@@ -47,6 +47,9 @@ This command sends a POST to SMD. An access token is required.`,
 			os.Exit(1)
 		}
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-iface-delete.go
+++ b/cmd/smd-iface-delete.go
@@ -38,11 +38,7 @@ This command sends a DELETE to SMD. An access token is required.`,
 		// must be passed.
 		if len(args) == 0 {
 			if !cmd.Flag("all").Changed && !cmd.Flag("payload").Changed {
-				err := cmd.Usage()
-				if err != nil {
-					log.Logger.Error().Err(err).Msg("failed to print usage")
-					os.Exit(1)
-				}
+				printUsageHandleError(cmd)
 				os.Exit(0)
 			}
 		}

--- a/cmd/smd-iface-delete.go
+++ b/cmd/smd-iface-delete.go
@@ -22,7 +22,9 @@ pass -f to pass a file (optionally specifying --payload-format, JSON by default)
 containing the payload data. If - is used as the argument to -f, the data is
 read from standard input.
 
-This command sends a DELETE to SMD. An access token is required.`,
+This command sends a DELETE to SMD. An access token is required.
+
+See ochami-smd(1) for more details.`,
 	Example: `  ochami smd iface delete decafc0ffeee
   ochami smd iface delete decafc0ffeee de:ad:be:ee:ee:ef
   ochami smd iface delete --all
@@ -50,6 +52,7 @@ This command sends a DELETE to SMD. An access token is required.`,
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -61,6 +64,7 @@ This command sends a DELETE to SMD. An access token is required.`,
 		smdClient, err := smd.NewClient(smdBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new SMD client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -105,6 +109,7 @@ This command sends a DELETE to SMD. An access token is required.`,
 				} else {
 					log.Logger.Error().Err(err).Msg("failed to delete ethernet interfaces in SMD")
 				}
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		} else {
@@ -112,6 +117,7 @@ This command sends a DELETE to SMD. An access token is required.`,
 			_, errs, err := smdClient.DeleteEthernetInterfaces(token, eIdSlice...)
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to delete ethernet interfaces in SMD")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 			// Since smdClient.DeleteEthernetInterfaces does the deletion iteratively, we need to deal
@@ -130,6 +136,7 @@ This command sends a DELETE to SMD. An access token is required.`,
 			// Warn the user if any errors occurred during deletion iterations
 			if errorsOccurred {
 				log.Logger.Warn().Msg("SMD ethernet interface deletion completed with errors")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		}

--- a/cmd/smd-iface-delete.go
+++ b/cmd/smd-iface-delete.go
@@ -30,7 +30,7 @@ This command sends a DELETE to SMD. An access token is required.`,
   ochami smd iface delete -f payload.yaml --payload-format yaml
   echo '<json_data>' | ochami smd iface delete -f -
   echo '<yaml_data>' | ochami smd iface delete -f - --payload-format yaml`,
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
@@ -47,6 +47,9 @@ This command sends a DELETE to SMD. An access token is required.`,
 			}
 		}
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-iface-delete.go
+++ b/cmd/smd-iface-delete.go
@@ -31,10 +31,6 @@ This command sends a DELETE to SMD. An access token is required.`,
   echo '<json_data>' | ochami smd iface delete -f -
   echo '<yaml_data>' | ochami smd iface delete -f - --payload-format yaml`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
 		// With options, only one of:
 		// - A payload file with -f
 		// - --all

--- a/cmd/smd-iface-delete.go
+++ b/cmd/smd-iface-delete.go
@@ -31,6 +31,10 @@ This command sends a DELETE to SMD. An access token is required.`,
   echo '<json_data>' | ochami smd iface delete -f -
   echo '<yaml_data>' | ochami smd iface delete -f - --payload-format yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// With options, only one of:
 		// - A payload file with -f
 		// - --all

--- a/cmd/smd-iface-get.go
+++ b/cmd/smd-iface-get.go
@@ -21,12 +21,15 @@ var ifaceGetCmd = &cobra.Command{
 	Short: "Get some or all ethernet interfaces",
 	Long: `Get some or all ethernet interfaces optionally based on filter(s). If no options are
 passed, all ethernet interfaces are returned. Optionally, options can be passed to limit the
-ethernet interfaces returned.`,
+ethernet interfaces returned.
+
+See ochami-smd(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -34,6 +37,7 @@ ethernet interfaces returned.`,
 		smdClient, err := smd.NewClient(smdBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new SMD client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -49,6 +53,7 @@ ethernet interfaces returned.`,
 			id, err := cmd.Flags().GetString("id")
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to get id")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 			byIP := false
@@ -62,12 +67,14 @@ ethernet interfaces returned.`,
 				} else {
 					log.Logger.Error().Err(err).Msg("failed to request ethernet interfaces by ID from SMD")
 				}
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 			fmt.Println(string(httpEnv.Body))
 			os.Exit(0)
 		} else if cmd.Flag("by-ip").Changed {
 			log.Logger.Error().Msg("--by-ip can only be used with --id")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -80,6 +87,7 @@ ethernet interfaces returned.`,
 				s, err := cmd.Flags().GetStringSlice("mac")
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch macs")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 				for _, m := range s {
@@ -90,6 +98,7 @@ ethernet interfaces returned.`,
 				s, err := cmd.Flags().GetStringSlice("ip")
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch IPs")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 				for _, i := range s {
@@ -100,6 +109,7 @@ ethernet interfaces returned.`,
 				s, err := cmd.Flags().GetStringSlice("net")
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch networks")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 				for _, n := range s {
@@ -110,6 +120,7 @@ ethernet interfaces returned.`,
 				s, err := cmd.Flags().GetStringSlice("comp-id")
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch component IDs")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 				for _, c := range s {
@@ -120,6 +131,7 @@ ethernet interfaces returned.`,
 				s, err := cmd.Flags().GetStringSlice("type")
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch type")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 				for _, t := range s {
@@ -130,6 +142,7 @@ ethernet interfaces returned.`,
 				s, err := cmd.Flags().GetString("older-than")
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch older-than timestamp")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 				values.Add("OlderThan", s)
@@ -138,6 +151,7 @@ ethernet interfaces returned.`,
 				s, err := cmd.Flags().GetString("newer-than")
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch newer-than timestamp")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 				values.Add("NewerThan", s)
@@ -150,6 +164,7 @@ ethernet interfaces returned.`,
 			} else {
 				log.Logger.Error().Err(err).Msg("failed to request ethernet interfaces from SMD")
 			}
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -157,10 +172,12 @@ ethernet interfaces returned.`,
 		outFmt, err := cmd.Flags().GetString("output-format")
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 		if outBytes, err := client.FormatBody(httpEnv.Body, outFmt); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to format output")
+			logHelpError(cmd)
 			os.Exit(1)
 		} else {
 			fmt.Printf(string(outBytes))

--- a/cmd/smd-iface-get.go
+++ b/cmd/smd-iface-get.go
@@ -23,6 +23,10 @@ var ifaceGetCmd = &cobra.Command{
 passed, all ethernet interfaces are returned. Optionally, options can be passed to limit the
 ethernet interfaces returned.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-iface-get.go
+++ b/cmd/smd-iface-get.go
@@ -22,11 +22,14 @@ var ifaceGetCmd = &cobra.Command{
 	Long: `Get some or all ethernet interfaces optionally based on filter(s). If no options are
 passed, all ethernet interfaces are returned. Optionally, options can be passed to limit the
 ethernet interfaces returned.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-iface-get.go
+++ b/cmd/smd-iface-get.go
@@ -22,13 +22,6 @@ var ifaceGetCmd = &cobra.Command{
 	Long: `Get some or all ethernet interfaces optionally based on filter(s). If no options are
 passed, all ethernet interfaces are returned. Optionally, options can be passed to limit the
 ethernet interfaces returned.`,
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
-		return nil
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)

--- a/cmd/smd-iface.go
+++ b/cmd/smd-iface.go
@@ -14,7 +14,9 @@ var ifaceCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Short: "Manage ethernet interfaces",
 	Long: `Manage ethernet interfaces. This is a metacommand. Commands under this one
-interact with the State Management Database (SMD).`,
+interact with the State Management Database (SMD).
+
+See ochami-smd(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			printUsageHandleError(cmd)

--- a/cmd/smd-iface.go
+++ b/cmd/smd-iface.go
@@ -5,7 +5,6 @@ package cmd
 import (
 	"os"
 
-	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/spf13/cobra"
 )
 
@@ -18,11 +17,7 @@ var ifaceCmd = &cobra.Command{
 interact with the State Management Database (SMD).`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
 	},

--- a/cmd/smd-rfe-add.go
+++ b/cmd/smd-rfe-add.go
@@ -24,7 +24,9 @@ unless -f is passed to read from a payload file. Specifying -f also is
 mutually exclusive with the other flags of this command and its arguments.
 If - is used as the argument to -f, the data is read from standard input.
 
-This command sends a POST to SMD. An access token is required.`,
+This command sends a POST to SMD. An access token is required.
+
+See ochami-smd(1) for more details.`,
 	Example: `  ochami smd rfe add x3000c1s7b56 bmc-node56 172.16.0.156 de:ca:fc:0f:fe:ee
   ochami smd rfe add -f payload.json
   ochami smd rfe add -f payload.yaml --payload-format yaml
@@ -46,6 +48,7 @@ This command sends a POST to SMD. An access token is required.`,
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -57,6 +60,7 @@ This command sends a POST to SMD. An access token is required.`,
 		smdClient, err := smd.NewClient(smdBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new SMD client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -78,24 +82,28 @@ This command sends a POST to SMD. An access token is required.`,
 			if cmd.Flag("domain").Changed {
 				if rfe.Domain, err = cmd.Flags().GetString("domain"); err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch domain")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 			}
 			if cmd.Flag("hostname").Changed {
 				if rfe.Hostname, err = cmd.Flags().GetString("hostname"); err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch hostname")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 			}
 			if cmd.Flag("username").Changed {
 				if rfe.User, err = cmd.Flags().GetString("username"); err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch username")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 			}
 			if cmd.Flag("password").Changed {
 				if rfe.Password, err = cmd.Flags().GetString("password"); err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch password")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 			}
@@ -106,6 +114,7 @@ This command sends a POST to SMD. An access token is required.`,
 		_, errs, err := smdClient.PostRedfishEndpoints(rfes, token)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to add redfish endpoint in SMD")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 		// Since smdClient.PostRedfishEndpoints does the addition iteratively, we need to deal with
@@ -122,6 +131,7 @@ This command sends a POST to SMD. An access token is required.`,
 			}
 		}
 		if errorsOccurred {
+			logHelpError(cmd)
 			log.Logger.Warn().Msg("SMD redfish endpoint addition completed with errors")
 			os.Exit(1)
 		}

--- a/cmd/smd-rfe-add.go
+++ b/cmd/smd-rfe-add.go
@@ -31,11 +31,7 @@ This command sends a POST to SMD. An access token is required.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Check that all required args are passed
 		if len(args) == 0 && !cmd.Flag("payload").Changed {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		} else if len(args) > 4 {
 			log.Logger.Error().Msgf("expected 4 arguments (xname, name, ip_addr, mac_addr) but got %d: %v", len(args), args)

--- a/cmd/smd-rfe-add.go
+++ b/cmd/smd-rfe-add.go
@@ -29,6 +29,10 @@ This command sends a POST to SMD. An access token is required.`,
   echo '<json_data>' | ochami smd rfe add -f -
   echo '<yaml_data>' | ochami smd rfe add -f - --payload-format yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Check that all required args are passed
 		if len(args) == 0 && !cmd.Flag("payload").Changed {
 			printUsageHandleError(cmd)

--- a/cmd/smd-rfe-add.go
+++ b/cmd/smd-rfe-add.go
@@ -31,10 +31,6 @@ This command sends a POST to SMD. An access token is required.`,
   echo '<json_data>' | ochami smd rfe add -f -
   echo '<yaml_data>' | ochami smd rfe add -f - --payload-format yaml`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
 		// Check that all required args are passed
 		if len(args) == 0 && !cmd.Flag("payload").Changed {
 			printUsageHandleError(cmd)

--- a/cmd/smd-rfe-add.go
+++ b/cmd/smd-rfe-add.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"os"
 
 	"github.com/OpenCHAMI/ochami/internal/log"
@@ -16,6 +17,7 @@ import (
 // rfeAddCmd represents the smd-rfe-add command
 var rfeAddCmd = &cobra.Command{
 	Use:   "add -f <payload_file> | (<xname> <name> <ip_addr> <mac_addr>)",
+	Args:  cobra.MaximumNArgs(4),
 	Short: "Add new redfish endpoint(s)",
 	Long: `Add new redfish endpoint(s). An xname, name, IP address, and MAC address are required
 unless -f is passed to read from a payload file. Specifying -f also is
@@ -28,7 +30,7 @@ This command sends a POST to SMD. An access token is required.`,
   ochami smd rfe add -f payload.yaml --payload-format yaml
   echo '<json_data>' | ochami smd rfe add -f -
   echo '<yaml_data>' | ochami smd rfe add -f - --payload-format yaml`,
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
@@ -38,10 +40,12 @@ This command sends a POST to SMD. An access token is required.`,
 			printUsageHandleError(cmd)
 			os.Exit(0)
 		} else if len(args) > 4 {
-			log.Logger.Error().Msgf("expected 4 arguments (xname, name, ip_addr, mac_addr) but got %d: %v", len(args), args)
-			os.Exit(1)
+			return fmt.Errorf("expected 4 arguments (xname, name, ip_addr, mac_addr) but got %d: %v", len(args), args)
 		}
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-rfe-delete.go
+++ b/cmd/smd-rfe-delete.go
@@ -21,7 +21,9 @@ Alternatively, use -f to read the payload data from a file (optionally
 specifying --payload-format, JSON by default). If - is used as the
 argument to -f, the data is read from standard input.
 
-This command sends a DELETE to SMD. An access token is required.`,
+This command sends a DELETE to SMD. An access token is required.
+
+See ochami-smd(1) for more details.`,
 	Example: `  ochami smd rfe delete x3000c1s7b56
   ochami smd rfe delete x3000c1s7b56 x3000c1s7b56
   ochami smd rfe delete --all
@@ -49,6 +51,7 @@ This command sends a DELETE to SMD. An access token is required.`,
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -60,6 +63,7 @@ This command sends a DELETE to SMD. An access token is required.`,
 		smdClient, err := smd.NewClient(smdBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new SMD client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -104,6 +108,7 @@ This command sends a DELETE to SMD. An access token is required.`,
 				} else {
 					log.Logger.Error().Err(err).Msg("failed to delete redfish endpoints in SMD")
 				}
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 		} else {
@@ -111,6 +116,7 @@ This command sends a DELETE to SMD. An access token is required.`,
 			_, errs, err := smdClient.DeleteRedfishEndpoints(token, xnameSlice...)
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to delete redfish endpoints in SMD")
+				logHelpError(cmd)
 				os.Exit(1)
 			}
 			// Since smdClient.DeleteRedfishEndpoints does the deletion iteratively, we need to deal with
@@ -130,6 +136,7 @@ This command sends a DELETE to SMD. An access token is required.`,
 			if errorsOccurred {
 				log.Logger.Warn().Msg("SMD redfish endpoint deletion completed with errors")
 				os.Exit(1)
+				logHelpError(cmd)
 			}
 		}
 	},

--- a/cmd/smd-rfe-delete.go
+++ b/cmd/smd-rfe-delete.go
@@ -37,11 +37,7 @@ This command sends a DELETE to SMD. An access token is required.`,
 		// must be passed.
 		if len(args) == 0 {
 			if !cmd.Flag("all").Changed && !cmd.Flag("payload").Changed {
-				err := cmd.Usage()
-				if err != nil {
-					log.Logger.Error().Err(err).Msg("failed to print usage")
-					os.Exit(1)
-				}
+				printUsageHandleError(cmd)
 				os.Exit(0)
 			}
 		}

--- a/cmd/smd-rfe-delete.go
+++ b/cmd/smd-rfe-delete.go
@@ -30,10 +30,6 @@ This command sends a DELETE to SMD. An access token is required.`,
   echo '<json_data>' | ochami smd rfe delete -f -
   echo '<yaml_data>' | ochami smd rfe delete -f - --payload-format yaml`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
 		// With options, only one of:
 		// - A payload file with -f
 		// - --all

--- a/cmd/smd-rfe-delete.go
+++ b/cmd/smd-rfe-delete.go
@@ -29,7 +29,7 @@ This command sends a DELETE to SMD. An access token is required.`,
   ochami smd rfe delete -f payload.yaml --payload-format yaml
   echo '<json_data>' | ochami smd rfe delete -f -
   echo '<yaml_data>' | ochami smd rfe delete -f - --payload-format yaml`,
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
@@ -46,6 +46,9 @@ This command sends a DELETE to SMD. An access token is required.`,
 			}
 		}
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-rfe-delete.go
+++ b/cmd/smd-rfe-delete.go
@@ -30,6 +30,10 @@ This command sends a DELETE to SMD. An access token is required.`,
   echo '<json_data>' | ochami smd rfe delete -f -
   echo '<yaml_data>' | ochami smd rfe delete -f - --payload-format yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// With options, only one of:
 		// - A payload file with -f
 		// - --all

--- a/cmd/smd-rfe-get.go
+++ b/cmd/smd-rfe-get.go
@@ -21,12 +21,15 @@ var rfeGetCmd = &cobra.Command{
 	Short: "Get all redfish endpoints or some based on filter(s)",
 	Long: `Get all redfish endpoints or some based on filter(s). If no options are passed,
 all redfish endpoints are returned. Optionally, options can be passed to limit the redfish
-endpoints returned.`,
+endpoints returned.
+
+See ochami-smd(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -38,6 +41,7 @@ endpoints returned.`,
 		smdClient, err := smd.NewClient(smdBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new SMD client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -53,6 +57,7 @@ endpoints returned.`,
 				s, err := cmd.Flags().GetStringSlice("xname")
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch xname list")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 				for _, x := range s {
@@ -63,6 +68,7 @@ endpoints returned.`,
 				s, err := cmd.Flags().GetStringSlice("mac")
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch mac list")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 				for _, m := range s {
@@ -73,6 +79,7 @@ endpoints returned.`,
 				s, err := cmd.Flags().GetStringSlice("ip")
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch ip list")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 				for _, i := range s {
@@ -83,6 +90,7 @@ endpoints returned.`,
 				s, err := cmd.Flags().GetStringSlice("fqdn")
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch fqdn list")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 				for _, f := range s {
@@ -93,6 +101,7 @@ endpoints returned.`,
 				s, err := cmd.Flags().GetStringSlice("type")
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch type list")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 				for _, t := range s {
@@ -103,6 +112,7 @@ endpoints returned.`,
 				s, err := cmd.Flags().GetStringSlice("uuid")
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("unable to fetch uuid list")
+					logHelpError(cmd)
 					os.Exit(1)
 				}
 				for _, u := range s {
@@ -118,6 +128,7 @@ endpoints returned.`,
 			} else {
 				log.Logger.Error().Err(err).Msg("failed to request redfish endpoints from SMD")
 			}
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -125,10 +136,12 @@ endpoints returned.`,
 		outFmt, err := cmd.Flags().GetString("output-format")
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 		if outBytes, err := client.FormatBody(httpEnv.Body, outFmt); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to format output")
+			logHelpError(cmd)
 			os.Exit(1)
 		} else {
 			fmt.Printf(string(outBytes))

--- a/cmd/smd-rfe-get.go
+++ b/cmd/smd-rfe-get.go
@@ -22,11 +22,14 @@ var rfeGetCmd = &cobra.Command{
 	Long: `Get all redfish endpoints or some based on filter(s). If no options are passed,
 all redfish endpoints are returned. Optionally, options can be passed to limit the redfish
 endpoints returned.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-rfe-get.go
+++ b/cmd/smd-rfe-get.go
@@ -23,6 +23,10 @@ var rfeGetCmd = &cobra.Command{
 all redfish endpoints are returned. Optionally, options can be passed to limit the redfish
 endpoints returned.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-rfe-get.go
+++ b/cmd/smd-rfe-get.go
@@ -22,13 +22,6 @@ var rfeGetCmd = &cobra.Command{
 	Long: `Get all redfish endpoints or some based on filter(s). If no options are passed,
 all redfish endpoints are returned. Optionally, options can be passed to limit the redfish
 endpoints returned.`,
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
-		return nil
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)

--- a/cmd/smd-rfe.go
+++ b/cmd/smd-rfe.go
@@ -14,7 +14,9 @@ var rfeCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Short: "Manage redfish endpoints",
 	Long: `Manage redfish endpoints. This is a metacommand. Commands under this one
-interact with the State Management Database (SMD).`,
+interact with the State Management Database (SMD).
+
+See ochami-smd(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			printUsageHandleError(cmd)

--- a/cmd/smd-rfe.go
+++ b/cmd/smd-rfe.go
@@ -5,7 +5,6 @@ package cmd
 import (
 	"os"
 
-	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/spf13/cobra"
 )
 
@@ -18,11 +17,7 @@ var rfeCmd = &cobra.Command{
 interact with the State Management Database (SMD).`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
 	},

--- a/cmd/smd-status.go
+++ b/cmd/smd-status.go
@@ -17,12 +17,16 @@ import (
 var smdStatusCmd = &cobra.Command{
 	Use:   "status",
 	Args:  cobra.NoArgs,
-	Short: "Get status of SMD service",
+	Short: "Get status of the State Management Database (SMD)",
+	Long: `Get status of the State Management Database (SMD).
+
+See ochami-smd(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -30,6 +34,7 @@ var smdStatusCmd = &cobra.Command{
 		smdClient, err := smd.NewClient(smdBaseURI, insecure)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("error creating new SMD client")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -49,6 +54,7 @@ var smdStatusCmd = &cobra.Command{
 			} else {
 				log.Logger.Error().Err(err).Msg("failed to get SMD status")
 			}
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 
@@ -56,10 +62,12 @@ var smdStatusCmd = &cobra.Command{
 		outFmt, err := cmd.Flags().GetString("output-format")
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+			logHelpError(cmd)
 			os.Exit(1)
 		}
 		if outBytes, err := client.FormatBody(httpEnv.Body, outFmt); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to format output")
+			logHelpError(cmd)
 			os.Exit(1)
 		} else {
 			fmt.Printf(string(outBytes))

--- a/cmd/smd-status.go
+++ b/cmd/smd-status.go
@@ -18,11 +18,14 @@ var smdStatusCmd = &cobra.Command{
 	Use:   "status",
 	Args:  cobra.NoArgs,
 	Short: "Get status of SMD service",
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// First and foremost, make sure config is loaded and logging
 		// works.
 		initConfigAndLogging(cmd, true)
 
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-status.go
+++ b/cmd/smd-status.go
@@ -19,6 +19,10 @@ var smdStatusCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Short: "Get status of SMD service",
 	Run: func(cmd *cobra.Command, args []string) {
+		// First and foremost, make sure config is loaded and logging
+		// works.
+		initConfigAndLogging(cmd, true)
+
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
 		if err != nil {

--- a/cmd/smd-status.go
+++ b/cmd/smd-status.go
@@ -18,13 +18,6 @@ var smdStatusCmd = &cobra.Command{
 	Use:   "status",
 	Args:  cobra.NoArgs,
 	Short: "Get status of SMD service",
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// First and foremost, make sure config is loaded and logging
-		// works.
-		initConfigAndLogging(cmd, true)
-
-		return nil
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)

--- a/cmd/smd.go
+++ b/cmd/smd.go
@@ -5,7 +5,6 @@ package cmd
 import (
 	"os"
 
-	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/spf13/cobra"
 )
 
@@ -16,11 +15,7 @@ var smdCmd = &cobra.Command{
 	Short: "Communicate with the State Management Database (SMD)",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			err := cmd.Usage()
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to print usage")
-				os.Exit(1)
-			}
+			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
 	},

--- a/cmd/smd.go
+++ b/cmd/smd.go
@@ -13,6 +13,9 @@ var smdCmd = &cobra.Command{
 	Use:   "smd",
 	Args:  cobra.NoArgs,
 	Short: "Communicate with the State Management Database (SMD)",
+	Long: `Communicate with the State Management Database (SMD).
+
+See ochami-smd(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			printUsageHandleError(cmd)

--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -43,28 +43,32 @@ log:
 #
 # The cluster block can contain the following keys:
 #
-# api-uri - The URI of an API gateway behind which the OpenCHAMI services are
-#           listening. ochami will append to this URI the base path for the
-#           service being communicated with as well as the endpoint being used.
-#           If any '<service>-uri' options are specified, this behavior changes
-#           (see '<service>-uri' below).
+# uri - The base URI of all OpenCHAMI services. ochami will append the base path
+#       and endpoint to this URI. If uri is specified in any of the <service>
+#       configs below, this behavior changes (see '<service>' below).
 #
-#           If api-uri is not specified, then <service>-uri directives must be
-#           specified for each <service>.
+#       If uri is not specified, then <service>.uri directives must be specified
+#       for each <service>.
 #
-# <service>-uri - (OPTIONAL) Override the base path for <service> or replace its
-#                 base URI entirely. If the value is a relative path (e.g.
-#                 "/smd"), this path replaces <service>'s default base path,
-#                 which is appended to api-uri when communicating with
-#                 <service>. If the value is an absolute URI (e.g https://...),
-#                 then this value replaces that of api-uri for this service. In
-#                 otherwords, the value becomes the base URI specifically for
-#                 <service>.
+# <service> - (OPTIONAL) Set specific service options for <service>. <service>
+#             is the name of an OpenCHAMI service in lower case, e.g. 'bss',
+#             'cloud-init'.
 #
-#                 Specifying this option is optional if api-uri is specified,
-#                 but mandatory if not. If api-uri is specified, this can be
-#                 used to override either the base path or the entire base URI
-#                 of <service>.
+#             Keys include:
+#
+#             uri - Override the service's base path or replace its base URI
+#                   entirely. If the value is a relative path (e.g. "/smd"),
+#                   this path replace the service's default base path, which is
+#                   what is appended to cluster.uri when communicating with the
+#                   service. If the value is an absolute URI (e.g. https://...),
+#                   then this value replaces that of the appendix of cluster.api
+#                   and the service base path. In other words, the value becomes
+#                   the base URI specifically for this service.
+#
+#                   Specifying this option is optional if cluster.uri is
+#                   specified, but mandatory for each service if not. If
+#                   cluster.uri is specified, this can be used to override
+#                   either the base path or entire base URI for this service.
 #
 # Below is an example of a clusters block, commented out in case this
 # file is used as an actual config.
@@ -72,10 +76,10 @@ log:
 #clusters:
 #    - name: foobar
 #      cluster:
-#        api-uri: https://foobar.openchami.cluster
+#        uri: https://foobar.openchami.cluster
 #    - name: local
 #      cluster:
-#        api-uri: https://local.openchami.cluster:8443
+#        uri: https://local.openchami.cluster:8443
 #
 # An example of overriding the SMD path from the default /hsm/v2 to /smd and
 # overriding the entire URI for BSS (all other services are left to their
@@ -84,18 +88,24 @@ log:
 #clusters:
 #    - name: foobar
 #      cluster:
-#        api-uri: https://foobar.openchami.cluster:8443
-#        smd-uri: /smd
-#        bss-uri: https://bss.my.cluster/boot/v1
+#        uri: https://foobar.openchami.cluster:8443
+#        smd:
+#          uri: /smd
+#        bss:
+#          uri: https://bss.my.cluster/boot/v1
 #
-# Another example omitting api-uri entirely, using separate <service>-uri
+# Another example omitting cluster.uri entirely, using separate <service>.uri
 # directives:
 #
 #clusters:
 #    - name: foobar
 #      cluster:
-#        smd-uri: https://localhost:27779/hsm/v2
-#        bss-uri: https://localhost:27778/boot/v1
-#        cloud-init-uri: https://localhost:27777/cloud-init
-#        pcs-uri: https://localhost:28007
+#        smd:
+#          uri: https://localhost:27779/hsm/v2
+#        bss:
+#          uri: https://localhost:27778/boot/v1
+#        cloud-init:
+#          uri: https://localhost:27777/cloud-init
+#        pcs:
+#          uri: https://localhost:28007
 clusters: []

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,12 +1,14 @@
 package config
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
 	"os"
 	"os/user"
 	"path/filepath"
+	"strings"
 
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/go-viper/mapstructure/v2"
@@ -82,17 +84,45 @@ type ConfigLog struct {
 	Level  string `yaml:"level,omitempty"`
 }
 
+// ConfigCluster is a "wrapper" around an individual cluster configuration. It
+// contains the cluster's name, as well as the actual configuration structure.
 type ConfigCluster struct {
 	Name    string              `yaml:"name,omitempty"`
 	Cluster ConfigClusterConfig `yaml:"cluster,omitempty"`
 }
 
+// ConfigClusterConfig is the actual structure for an individual cluster
+// configuration.
 type ConfigClusterConfig struct {
-	APIURI       string `yaml:"api-uri,omitempty"`
-	BSSURI       string `yaml:"bss-uri,omitempty"`
-	CloudInitURI string `yaml:"cloud-init-uri,omitempty"`
-	PCSURI       string `yaml:"pcs-uri,omitempty"`
-	SMDURI       string `yaml:"smd-uri,omitempty"`
+	URI       string                 `yaml:"uri,omitempty"`
+	BSS       ConfigClusterBSS       `yaml:"bss,omitempty"`
+	CloudInit ConfigClusterCloudInit `yaml:"cloud-init,omitempty"`
+	PCS       ConfigClusterPCS       `yaml:"pcs,omitempty"`
+	SMD       ConfigClusterSMD       `yaml:"smd,omitempty"`
+}
+
+// ConfigClusterBSS represents configuration specifically for the Boot Script
+// Service.
+type ConfigClusterBSS struct {
+	URI string `yaml:"uri,omitempty"`
+}
+
+// ConfigClusterCloudInit represents configuration specifically for the
+// cloud-init service.
+type ConfigClusterCloudInit struct {
+	URI string `yaml:"uri,omitempty"`
+}
+
+// ConfigClusterPCS represents configuration specifically for the Power Control
+// Service.
+type ConfigClusterPCS struct {
+	URI string `yaml:"uri,omitempty"`
+}
+
+// ConfigClusterSMD represents configuration specifically for the State
+// Management Database service.
+type ConfigClusterSMD struct {
+	URI string `yaml:"uri,omitempty"`
 }
 
 // MergeURIConfig takes a ConfigClusterConfig and returns a ConfigClusterConfig
@@ -106,43 +136,56 @@ func (ccc *ConfigClusterConfig) MergeURIConfig(c ConfigClusterConfig) ConfigClus
 		}
 		return oldStr
 	}
-	newCCC := ConfigClusterConfig{
-		APIURI:       compare(ccc.APIURI, c.APIURI),
-		BSSURI:       compare(ccc.BSSURI, c.BSSURI),
-		CloudInitURI: compare(ccc.CloudInitURI, c.CloudInitURI),
-		PCSURI:       compare(ccc.PCSURI, c.PCSURI),
-		SMDURI:       compare(ccc.SMDURI, c.SMDURI),
+	newCCC := ConfigClusterConfig{URI: compare(ccc.URI, c.URI)}
+	if ccc.BSS == (ConfigClusterBSS{}) {
+		newCCC.BSS = ConfigClusterBSS{URI: c.BSS.URI}
+	} else {
+		newCCC.BSS.URI = compare(ccc.BSS.URI, c.BSS.URI)
+	}
+	if ccc.CloudInit == (ConfigClusterCloudInit{}) {
+		newCCC.CloudInit = ConfigClusterCloudInit{URI: c.CloudInit.URI}
+	} else {
+		newCCC.BSS.URI = compare(ccc.CloudInit.URI, c.CloudInit.URI)
+	}
+	if ccc.PCS == (ConfigClusterPCS{}) {
+		newCCC.PCS = ConfigClusterPCS{URI: c.PCS.URI}
+	} else {
+		newCCC.PCS.URI = compare(ccc.PCS.URI, c.PCS.URI)
+	}
+	if ccc.SMD == (ConfigClusterSMD{}) {
+		newCCC.SMD = ConfigClusterSMD{URI: c.PCS.URI}
+	} else {
+		newCCC.SMD.URI = compare(ccc.SMD.URI, c.SMD.URI)
 	}
 
 	return newCCC
 }
 
 // GetServiceBaseURI returns a URI string for the service identified by svcName
-// based on URI values set in the ConfigClusterConfig. At least one of APIURI or
-// one of the URI for a service must be set in the ConfigClusterConfig,
-// otherwise an ErrMissingURI error is returned. If svcName is unknown, an
-// ErrUnknownService is returned. If the API URI is invalid or the service URI
-// is invalid, an ErrInvalidAPIURI or ErrINvalidServiceURI is returned,
-// respectively.
+// based on URI values set in the ConfigClusterConfig. At least one of URI or
+// the URI for a service must be set in the ConfigClusterConfig, otherwise an
+// ErrMissingURI error is returned. If svcName is unknown, an ErrUnknownService
+// is returned. If the cluster URI is invalid or the service URI is invalid, an
+// ErrInvalidURI or ErrInvalidServiceURI is returned, respectively.
 //
-// The API URI must be an absolute URI: proto://host[:port][/path]
+// The cluster URI must be an absolute URI: proto://host[:port][/path]
 // The service URI can be a relative path (/path) or an absolute URI.
 func (ccc *ConfigClusterConfig) GetServiceBaseURI(svcName ServiceName) (string, error) {
 	var (
 		serviceBaseURI string
-		apiURI         *url.URL
+		uri            *url.URL
 	)
-	// If the API URI is set, parse and verify it.
-	if ccc.APIURI != "" {
+	// If the cluster's URI is set, parse and verify it.
+	if ccc.URI != "" {
 		var err error
-		apiURI, err = url.Parse(ccc.APIURI)
+		uri, err = url.Parse(ccc.URI)
 		if err != nil {
-			return "", ErrInvalidAPIURI{Err: err}
+			return "", ErrInvalidURI{Err: err}
 		}
-		if apiURI.Opaque != "" || apiURI.Scheme == "" || apiURI.Host == "" {
-			return "", ErrInvalidAPIURI{Err: fmt.Errorf("unknown URI format (must be \"proto://host[:port][/path]\")")}
+		if uri.Opaque != "" || uri.Scheme == "" || uri.Host == "" {
+			return "", ErrInvalidURI{Err: fmt.Errorf("unknown URI format (must be \"proto://host[:port][/path]\")")}
 		}
-		serviceBaseURI = apiURI.String()
+		serviceBaseURI = uri.String()
 	}
 
 	// Parse service URI for ConfigClusterConfig field based on passed
@@ -151,38 +194,38 @@ func (ccc *ConfigClusterConfig) GetServiceBaseURI(svcName ServiceName) (string, 
 	var err error
 	switch svcName {
 	case ServiceBSS:
-		if ccc.APIURI == "" && ccc.BSSURI == "" {
+		if ccc.URI == "" && ccc.BSS.URI == "" {
 			return "", ErrMissingURI{Service: svcName}
 		}
-		if ccc.BSSURI != "" {
-			svcURI, err = url.Parse(ccc.BSSURI)
+		if ccc.BSS.URI != "" {
+			svcURI, err = url.Parse(ccc.BSS.URI)
 		} else {
 			svcURI, err = url.Parse(DefaultBasePathBSS)
 		}
 	case ServiceCloudInit:
-		if ccc.APIURI == "" && ccc.CloudInitURI == "" {
+		if ccc.URI == "" && ccc.CloudInit.URI == "" {
 			return "", ErrMissingURI{Service: svcName}
 		}
-		if ccc.CloudInitURI != "" {
-			svcURI, err = url.Parse(ccc.CloudInitURI)
+		if ccc.CloudInit.URI != "" {
+			svcURI, err = url.Parse(ccc.CloudInit.URI)
 		} else {
 			svcURI, err = url.Parse(DefaultBasePathCloudInit)
 		}
 	case ServicePCS:
-		if ccc.APIURI == "" && ccc.PCSURI == "" {
+		if ccc.URI == "" && ccc.PCS.URI == "" {
 			return "", ErrMissingURI{Service: svcName}
 		}
-		if ccc.PCSURI != "" {
-			svcURI, err = url.Parse(ccc.PCSURI)
+		if ccc.PCS.URI != "" {
+			svcURI, err = url.Parse(ccc.PCS.URI)
 		} else {
 			svcURI, err = url.Parse(DefaultBasePathPCS)
 		}
 	case ServiceSMD:
-		if ccc.APIURI == "" && ccc.SMDURI == "" {
+		if ccc.URI == "" && ccc.SMD.URI == "" {
 			return "", ErrMissingURI{Service: svcName}
 		}
-		if ccc.SMDURI != "" {
-			svcURI, err = url.Parse(ccc.SMDURI)
+		if ccc.SMD.URI != "" {
+			svcURI, err = url.Parse(ccc.SMD.URI)
 		} else {
 			svcURI, err = url.Parse(DefaultBasePathSMD)
 		}
@@ -205,14 +248,14 @@ func (ccc *ConfigClusterConfig) GetServiceBaseURI(svcName ServiceName) (string, 
 		} else if svcURI.Path != "" {
 			// Service URI is a relative path. Append it to API URI.
 			var newURI *url.URL
-			if apiURI != nil {
-				newURI = apiURI.JoinPath(svcURI.Path)
+			if uri != nil {
+				newURI = uri.JoinPath(svcURI.Path)
 			} else {
-				return "", ErrInvalidServiceURI{Service: svcName, Err: fmt.Errorf("%s-uri is a relative path but api-uri not set", svcName)}
+				return "", ErrInvalidServiceURI{Service: svcName, Err: fmt.Errorf("%s.uri is a relative path but cluster.uri not set", svcName)}
 			}
 			serviceBaseURI = newURI.String()
 		} else {
-			return "", ErrInvalidServiceURI{Service: svcName, Err: fmt.Errorf("%s-uri is neither an absolute URI nor has a path component", svcName)}
+			return "", ErrInvalidServiceURI{Service: svcName, Err: fmt.Errorf("%s.uri is neither an absolute URI nor has a path component", svcName)}
 		}
 	}
 
@@ -386,6 +429,112 @@ func ModifyConfig(path, key string, value interface{}) error {
 	return nil
 }
 
+// ModifyConfigCluster sets or modifies a single key for a single cluster,
+// identified by name, in a config file located at path. If dflt is true,
+// default-cluster is set to the specified cluster. If cluster does not already
+// exist, it is added. If key is "name", the cluster is renamed but setting the
+// name to an existing cluster name is not allowed. If the default cluster's
+// name is changed, default-cluster is set to the new name, regardless of dflt.
+//
+// This function works similarly to ModifyConfig in that it loads the
+// configuration into a koanf instance, sets the key, then unmarhalls back into
+// a struct, where it can be written back to the config file.
+func ModifyConfigCluster(path, cluster, key string, dflt bool, value interface{}) error {
+	// Open file for writing
+	cfg, err := ReadConfig(path)
+	if err != nil {
+		return fmt.Errorf("failed to read %s for modification: %w", path, err)
+	}
+
+	// Make sure that if setting the cluster name, a cluster with that name
+	// doesn't already exist.
+	if key == "name" {
+		for _, cl := range cfg.Clusters {
+			if cl.Name == value.(string) {
+				return fmt.Errorf("cluster with name %q already exists", cl.Name)
+			}
+		}
+	}
+
+	// Determine if a new cluster needs to be added or an existing cluster
+	// needs to be modified.
+	var clusterToMod *ConfigCluster
+	newCluster := true
+	for cidx, cl := range cfg.Clusters {
+		if cl.Name == cluster || (key == "name" && cl.Name == value.(string)) {
+			// Existing cluster found, set pointer to it
+			clusterToMod = &(cfg.Clusters[cidx])
+			newCluster = false
+			break
+		}
+	}
+	ko := koanf.NewWithConf(kConfig)
+	kuc := kUnmarshalConf
+	if newCluster {
+		// Adding a new cluster; create it and append to list
+		nCl := ConfigCluster{Name: cluster}
+		if err := ko.Load(structs.Provider(nCl, "yaml"), nil); err != nil {
+			return fmt.Errorf("failed to load config for new cluster %s: %w", cluster, err)
+		}
+
+		// Modify key for new cluster
+		if err := ko.Set(key, value); err != nil {
+			return fmt.Errorf("failed to set key %s to value %v for new cluster %s: %w", key, value, cluster, err)
+		}
+		kuc.DecoderConfig.Result = &nCl
+		if err := ko.UnmarshalWithConf("", nil, kuc); err != nil {
+			return fmt.Errorf("failed to modify config for new cluster %s: %w", cluster, err)
+		}
+
+		// Add new cluster to cluster list
+		cfg.Clusters = append(cfg.Clusters, nCl)
+	} else {
+		// Modifying existing cluster; modify directly in cluster list
+		// Make sure there is a cluster to modify
+		if clusterToMod == nil {
+			return fmt.Errorf("unknown error finding existing cluster %s in %s", cluster, path)
+		}
+		if err := ko.Load(structs.Provider(*clusterToMod, "yaml"), nil); err != nil {
+			return fmt.Errorf("failed to load config for existing cluster %s: %w", cluster, err)
+		}
+
+		// Modify key for existing cluster
+		if err := ko.Set(key, value); err != nil {
+			return fmt.Errorf("failed to set key %s to value %v for existing cluster %s: %w", key, value, cluster, err)
+		}
+		kuc.DecoderConfig.Result = clusterToMod
+		if err := ko.UnmarshalWithConf("", nil, kuc); err != nil {
+			return fmt.Errorf("failed to modify config for existing cluster %s: %w", cluster, err)
+		}
+	}
+
+	// If default is set, set default-cluster to cluster name.
+	if dflt {
+		if key == "name" {
+			// If key was "name", set default-cluster to "name"
+			// instead of cluster specified in arg.
+			cfg.DefaultCluster = value.(string)
+		} else {
+			// If any other key, set default-cluster to cluster
+			// specified in arg.
+			cfg.DefaultCluster = cluster
+		}
+	} else if cfg.DefaultCluster == cluster && key == "name" {
+		// Even if default is not set, if the current default cluster
+		// matches cluster specified in arg and key is "name", change
+		// default-cluster to the new name after changing the cluster
+		// name so it doesn't point to a non-existent cluster.
+		cfg.DefaultCluster = value.(string)
+	}
+
+	// Write modified config back to file
+	if err := WriteConfig(path, cfg); err != nil {
+		return fmt.Errorf("failed to write modified config to %s: %w", path, err)
+	}
+
+	return nil
+}
+
 // DeleteConfig deletes a key from a config file. It does this by reading in the
 // config file at path and loading it into a koanf instance, then using that
 // koanf instance to delete the key. It then unmarshals the config to a config
@@ -420,6 +569,221 @@ func DeleteConfig(path, key string) error {
 	}
 
 	return nil
+}
+
+// DeleteConfigCluster deletes a key from the specified cluster from a config
+// file. It does by loading the cluster config into a koanf instance, deleting
+// the key, then unmarshalling it back into a ConfigCluster struct before
+// writing the config back to the config file. An error is thrown if the cluster
+// doesn't exist or "name" is the key.
+func DeleteConfigCluster(path, cluster, key string) error {
+	// Open file for writing
+	cfg, err := ReadConfig(path)
+	if err != nil {
+		return fmt.Errorf("failed to read %s for modification: %w", path, err)
+	}
+
+	if key == "name" {
+		return fmt.Errorf("cannot unset name of cluster")
+	}
+
+	// Find cluster to modify
+	var clusterToMod *ConfigCluster
+	for cidx, cl := range cfg.Clusters {
+		if cl.Name == cluster {
+			clusterToMod = &(cfg.Clusters[cidx])
+			break
+		}
+	}
+	if clusterToMod == nil {
+		return fmt.Errorf("cluster %q not found", cluster)
+	}
+
+	// Perform deletion
+	ko := koanf.NewWithConf(kConfig)
+	if err := ko.Load(structs.Provider(*clusterToMod, "yaml"), nil); err != nil {
+		return fmt.Errorf("failed to load config for cluster %s: %w", cluster, err)
+	}
+	ko.Delete(key)
+	var tmpCluster ConfigCluster
+	kuc := kUnmarshalConf
+	kuc.DecoderConfig.Result = &tmpCluster
+	if err := ko.UnmarshalWithConf("", nil, kuc); err != nil {
+		return fmt.Errorf("failed to unset key %s from config for cluster %s: %w", key, cluster, err)
+	}
+	*clusterToMod = tmpCluster
+
+	// Write modified config back to file
+	if err := WriteConfig(path, cfg); err != nil {
+		return fmt.Errorf("failed to write modified config to %s: %w", path, err)
+	}
+
+	return nil
+}
+
+// GetConfig returns the config value of key for a Config struct, returning an
+// error if loading the config into koanf errs. If key is empty, the whole
+// config is returned. This function _only_ retrieves global config options and
+// errs if the key begins with "clusters*" ("*" is one or more characters), i.e.
+// an individual cluster config is trying to be retrieved. To get an individual
+// cluster config, use GetConfigCluster.
+func GetConfig(cfg Config, key string) (interface{}, error) {
+	// Do not try to get individual cluster config. Use GetConfigCluster for
+	// that.
+	if strings.HasPrefix(key, "clusters") && len(key) > len("clusters") {
+		return nil, fmt.Errorf("cannot get individual cluster config with global get command")
+	}
+
+	// Load config into koanf so the key can be used to get config.
+	var val interface{}
+	ko := koanf.NewWithConf(kConfig)
+	if err := ko.Load(structs.Provider(cfg, "yaml"), nil); err != nil {
+		return nil, fmt.Errorf("failed to load global config: %w", err)
+	}
+	if key != "" {
+		val = ko.Get(key)
+	} else {
+		// No key specified, return whole config
+		kuc := kUnmarshalConf
+		kuc.DecoderConfig.Result = &val
+		if err := ko.UnmarshalWithConf("", nil, kuc); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal config from struct: %w", err)
+		}
+	}
+	return val, nil
+}
+
+// GetConfigFromFile is like GetConfig except that it reads the config from the
+// file at path instead of a Config struct.
+func GetConfigFromFile(path, key string) (interface{}, error) {
+	// Read in config file
+	cfg, err := ReadConfig(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file %s: %w", path, err)
+	}
+
+	return GetConfig(cfg, key)
+}
+
+// GetConfigString wraps GetConfig and returns a string representation of the
+// value of key, using format to determine how to marshal the value.
+// Currently-supported formats are yaml, json, and json-pretty.
+func GetConfigString(cfg Config, key, format string) (string, error) {
+	val, err := GetConfig(cfg, key)
+	if err != nil {
+		return "", err
+	}
+	if val == nil {
+		return "", nil
+	}
+	switch val.(type) {
+	case map[string]interface{}, []interface{}:
+		var err error
+		var valBytes []byte
+		switch format {
+		case "yaml":
+			valBytes, err = yaml.Marshal(val)
+		case "json":
+			valBytes, err = json.Marshal(val)
+		case "json-pretty":
+			valBytes, err = json.MarshalIndent(val, "", "\t")
+		default:
+			return "", fmt.Errorf("unknown format: %s", format)
+		}
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal value for key %q: %w", key, err)
+		}
+		return string(valBytes), nil
+	default:
+		return fmt.Sprintf("%v", val), nil
+	}
+}
+
+// GetConfigStringFromFile is like GetConfigString except that it wraps
+// GetConfigFromFile.
+func GetConfigStringFromFile(path, key, format string) (string, error) {
+	// Read in config file
+	cfg, err := ReadConfig(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read config file %s: %w", path, err)
+	}
+
+	return GetConfigString(cfg, key, format)
+}
+
+// GetConfigCluster returns the config value of key for a ConfigCluster struct,
+// returning an error if loading the config into koanf errs. If key is empty,
+// the whole config is returned. This function _only_ retrieves confiog options
+// for a cluster. To get global config, use GetConfig.
+func GetConfigCluster(cluster ConfigCluster, key string) (interface{}, error) {
+	// Load config into koanf so the key can be used to get config.
+	var val interface{}
+	ko := koanf.NewWithConf(kConfig)
+	if err := ko.Load(structs.Provider(cluster, "yaml"), nil); err != nil {
+		return nil, fmt.Errorf("failed to load cluster config: %w", err)
+	}
+	if key != "" {
+		val = ko.Get(key)
+	} else {
+		// No key specified, return whole config
+		kuc := kUnmarshalConf
+		kuc.DecoderConfig.Result = &val
+		if err := ko.UnmarshalWithConf("", nil, kuc); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal cluster config from struct: %w", err)
+		}
+	}
+	return val, nil
+}
+
+// GetConfigClusterFromFile is like GetConfigCluster except that it reads the
+// config from the file at path instead of a ConfigCluster struct.
+func GetConfigClusterFromFile(path, cluster, key string) (interface{}, error) {
+	// Read in config file
+	cfg, err := ReadConfig(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file %s: %w", path, err)
+	}
+
+	for _, cl := range cfg.Clusters {
+		if cl.Name == cluster {
+			return GetConfigCluster(cl, key)
+		}
+	}
+	return nil, fmt.Errorf("cluster %q not found in %s", cluster, path)
+}
+
+// GetConfigClusterString wraps GetConfigCluster and returns a string
+// representation of the value of key, using format to determine how to marshal
+// the value. Currently-supported formats are yaml, json, and json-pretty.
+func GetConfigClusterString(cluster ConfigCluster, key, format string) (string, error) {
+	val, err := GetConfigCluster(cluster, key)
+	if err != nil {
+		return "", err
+	}
+	if val == nil {
+		return "", nil
+	}
+	switch val.(type) {
+	case map[string]interface{}, []interface{}:
+		var err error
+		var valBytes []byte
+		switch format {
+		case "yaml":
+			valBytes, err = yaml.Marshal(val)
+		case "json":
+			valBytes, err = json.Marshal(val)
+		case "json-pretty":
+			valBytes, err = json.MarshalIndent(val, "", "\t")
+		default:
+			return "", fmt.Errorf("unknown format: %s", format)
+		}
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal value for key %q: %w", key, err)
+		}
+		return string(valBytes), nil
+	default:
+		return fmt.Sprintf("%v", val), nil
+	}
 }
 
 // ReadConfig opens the config file at path and loads it into koanf to check for

--- a/internal/config/errors.go
+++ b/internal/config/errors.go
@@ -6,30 +6,30 @@ import (
 	"fmt"
 )
 
-// ErrMissingURI represents an error that occurs when neither the api-uri nor
-// the <service>-uri config values are set for a service. Service is the name of
-// the service whose config value is being checked.
+// ErrMissingURI represents an error that occurs when neither the cluster.uri
+// nor the <service>.uri config values are set for a service. Service is the
+// name of the service whose config value is being checked.
 type ErrMissingURI struct {
 	Service ServiceName
 }
 
 func (emu ErrMissingURI) Error() string {
-	return fmt.Sprintf("base URI for %s not found (neither api-uri nor %s-uri specified)", emu.Service, emu.Service)
+	return fmt.Sprintf("base URI for %s not found (neither cluster.uri nor %s.uri specified)", emu.Service, emu.Service)
 }
 
-// ErrInvalidAPIURI represents an error that occurs when the api-uri is invalid,
-// i.e. is not a valid absolute URI (proto://host[:port][/path]). Err contains
-// the specific error representing the problem.
-type ErrInvalidAPIURI struct {
+// ErrInvalidURI represents an error that occurs when the cluster URI is
+// invalid, i.e. is not a valid absolute URI (proto://host[:port][/path]). Err
+// contains the specific error representing the problem.
+type ErrInvalidURI struct {
 	Err error
 }
 
-func (eiu ErrInvalidAPIURI) Error() string {
-	return fmt.Sprintf("invalid API URI: %v", eiu.Err)
+func (eiu ErrInvalidURI) Error() string {
+	return fmt.Sprintf("invalid URI: %v", eiu.Err)
 }
 
-// ErrInvalidServiceURI represents an error that occurs when the <service>-uri
-// is invalid, i.e. is neither a valid absolute URI (proto://host[:port][/path])
+// ErrInvalidServiceURI represents an error that occurs when a service's URI is
+// invalid, i.e. is neither a valid absolute URI (proto://host[:port][/path])
 // nor a valid relative path (/path).
 type ErrInvalidServiceURI struct {
 	Err     error

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -59,7 +59,7 @@ func mergeSlices(srcSlice, dstSlice *[]interface{}, mergeKey string) {
 	if srcSlice == nil || dstSlice == nil {
 		return
 	}
-	for _, sval := range *srcSlice {
+	for skey, sval := range *srcSlice {
 		exists := false
 		switch sv := sval.(type) {
 		// Source item is a map
@@ -76,6 +76,8 @@ func mergeSlices(srcSlice, dstSlice *[]interface{}, mergeKey string) {
 			}
 			if !exists {
 				*dstSlice = append(*dstSlice, sv)
+			} else {
+				(*dstSlice)[skey] = sv
 			}
 		// Source item is not a map
 		default:
@@ -93,6 +95,8 @@ func mergeSlices(srcSlice, dstSlice *[]interface{}, mergeKey string) {
 			}
 			if !exists {
 				*dstSlice = append(*dstSlice, sv)
+			} else {
+				(*dstSlice)[skey] = sv
 			}
 		}
 	}

--- a/man/ochami-bss.1.sc
+++ b/man/ochami-bss.1.sc
@@ -21,6 +21,23 @@ The data structure for sending and receiving data with subcommands under the
 }
 ```
 
+# GLOBAL FLAGS
+
+*--uri* _uri_
+	Specify either the absolute base URI for the service (e.g.
+	_https://foobar.openchami.cluster:8443/hsm/v2_) or a relative base path for
+	the service (e.g. _/hsm/v2_). If an absolute URI is specified, this
+	completely overrides any value set with the *--cluster-uri* flag or
+	*cluster.uri* in the config file for the cluster. If using an absolute URI,
+	it should contain the desired service's base path. If a relative path is
+	specified (with or without the leading forward slash), then this value
+	overrides the service's default base path and is appended to the cluster's
+	base URI (set with the *--cluster-uri* flag or the *cluster.uri* cluster
+	config option), which is required to be set if a relative path is used here.
+
+	See *ochami*(1) for *--cluster-uri* and *ochami-config*(5) for details on
+	cluster configuration options.
+
 # COMMANDS
 
 ## boot params
@@ -456,6 +473,10 @@ This command accepts the following options:
 # AUTHOR
 
 Written by Devon T. Bautista and maintained by the OpenCHAMI developers.
+
+# SEE ALSO
+
+*ochami*(1)
 
 ; Vim modeline settings
 ; vim: set tw=80 noet sts=4 ts=4 sw=4 syntax=scdoc:

--- a/man/ochami-cloud-init.1.sc
+++ b/man/ochami-cloud-init.1.sc
@@ -58,6 +58,21 @@ The *cloud-init* command accepts the following global flags:
 	Use the secure cloud-init endpoint instead of the open one. A token is
 	required.
 
+*--uri* _uri_
+	Specify either the absolute base URI for the service (e.g.
+	_https://foobar.openchami.cluster:8443/hsm/v2_) or a relative base path for
+	the service (e.g. _/hsm/v2_). If an absolute URI is specified, this
+	completely overrides any value set with the *--cluster-uri* flag or
+	*cluster.uri* in the config file for the cluster. If using an absolute URI,
+	it should contain the desired service's base path. If a relative path is
+	specified (with or without the leading forward slash), then this value
+	overrides the service's default base path and is appended to the cluster's
+	base URI (set with the *--cluster-uri* flag or the *cluster.uri* cluster
+	config option), which is required to be set if a relative path is used here.
+
+	See *ochami*(1) for *--cluster-uri* and *ochami-config*(5) for details on
+	cluster configuration options.
+
 # COMMANDS
 
 ## config
@@ -196,6 +211,10 @@ Subcommands for this command are as follows:
 # AUTHOR
 
 Written by Devon T. Bautista and maintained by the OpenCHAMI developers.
+
+# SEE ALSO
+
+*ochami*(1)
 
 ; Vim modeline settings
 ; vim: set tw=80 noet sts=4 ts=4 sw=4 syntax=scdoc:

--- a/man/ochami-config.1.sc
+++ b/man/ochami-config.1.sc
@@ -6,11 +6,47 @@ ochami-config - Manage configuration for ochami CLI
 
 # SYNOPSIS
 
-ochami config cluster delete _cluster_name_++
-ochami config cluster set [-u _base_uri_] [-d] _cluster_name_++
-ochami config set [--user | --system | --config _path_] _key_ _value_++
-ochami config show [-f _format_]++
-ochami config unset [--user | --system | --config _path_] _key_
+ochami config [GLOBALOPTS] cluster delete _cluster_name_++
+ochami config [GLOBALOPTS] cluster set [-d] _cluster_name_ _key_ _value_++
+ochami config [GLOBALOPTS] cluster show [-p] [-f _format_] _cluster_name_ [_key_]++
+ochami config [GLOBALOPTS] cluster unset _cluster_name_ _key_++
+ochami config [GLOBALOPTS] set _key_ _value_++
+ochami config [GLOBALOPTS] show [-f _format_] [_key_]++
+ochami config [GLOBALOPTS] unset _key_
+
+# GLOBAL OPTIONS
+
+*--config* _path_
+	Use the configuration file at _path_.
+
+*--system*
+	Use the system-wide configuration file. (See *FILES* below.)
+
+*--user*
+	Use the user-level configuration file. (See *FILES* below.)
+
+# DESCRIPTION
+
+The *config* metacommand is used for printing and modifying configuration
+options for *ochami* within its configuration files (see *FILES* below). If
+neither *--config*, *--system*, nor *--user* (mutually exclusive) are specified,
+*ochami* uses the user-level configuration file for modification commands and
+uses the resulting config of merging the user-level config with the system-wide
+config (the former preceding the latter) for printing commands.
+
+The format of _key_ uses a period (*.*) to delimit subkeys, following a
+*<superkey>.<subkey>* syntax. For example, in order to reference the *format*
+key under the *log* key, the key reference path would be *log.format*.
+
+For global commands (e.g. any command not under *cluster*), only global keys are
+allowed to be referenced. In other words, the key may not begin with *clusters*.
+For example, *log.level* is allowed but *clusters[0].name* or
+*clusters[0].cluster.uri* are not allowed. See *ochami-config*(5) for details on
+available keys.
+
+For *cluster* commands, only cluster-specific keys are allowed to be referenced.
+For example, *cluster.uri* or *name* are allowed, but *log.format* is not. See
+*ochami-config*(5) for details on available keys.
 
 # COMMANDS
 
@@ -23,21 +59,42 @@ Subcommands for this command are as follows:
 *delete* _cluster_name_
 	Delete _cluster_name_ configuration from config file.
 
-*set* [--base-uri _base_uri_] [--default] _cluster_name_
+*set* [-d] _cluster_name_ _key_ _value_
 	Add or set configuration for a cluster.
 
+	If _cluster_name_ does not exist in the configuration file, it is created.
+	_key_ can be a top-level cluster key (e.g. *name*) or a cluster config
+	option (e.g. *cluster.uri*). When changing a cluster's name, if that cluster
+	is the default cluster, then *default-cluster* will be changed to the
+	cluster's new name. Changing a cluster's name to an existing cluster name is
+	not allowed.
+
 	This command accepts the following options:
-
-	*-u, --base-uri* _base_uri_
-		Specify the base URI of OpenCHAMI services for the cluster.
-
-		*ochami* will use this to concatenate endpoint information to when
-		communicating with this cluster's OpenCHAMI services.
 
 	*-d, --default*
 		Set this cluster as the default cluster. This means that if *--cluster*
 		is not specified on the command line, this cluster's configuration is
 		used.
+
+*show* [-p] [-f _format_] _cluster_name_ [_key_]
+	Show the configuration for _cluster_name_. If _key_ is not specified, show
+	the whole configuration.
+
+	This command accepts the following options:
+
+	*-f, --format* _format_
+		Format of config output.
+
+		Default: *json*
+		Supported:
+		- _json_
+		- _yaml_
+
+	*-p, --pretty*
+		Indent JSON output. Requires *-f json*.
+
+*unset* _cluster_name_ _key_
+	Unset the _key_ configuration option from _cluster_name_
 
 ## set
 
@@ -45,31 +102,29 @@ Set configuration option for ochami CLI.
 
 The format of this command is:
 
-*set* [--user | --system | --config _path_] _key_ _value_
+*set* _key_ _value_
 
-This command sets configuration values for configuration files for the ochami
-CLI. It sets the _key_ in the file to _value_. By default, or if *--user* is
-specified, the user configuration file is modified. If *--system* is specified,
-the system configuration file is modified. Otherwise, if *--config* is specified
-(this is the same flag that is available to all commands), _path_ is modified.
-See the *FILES* section in *ochami*(1) for details on the user and system files.
-
-This command accepts the following options:
-
-*--config* _path_
-	Modify the config file at _path_. The *--config* flag is the same one that
-	is global to all commands and is not unique to this command.
-
-*--system*
-	Modify the system config file.
-
-*--user*
-	Modify the user config file (the default).
+This command sets global configuration values for *ochami*. It sets the _key_ in
+the file to _value_.
 
 ## show
 
-Show the current configuration. This command can be used to generate a
-configuration file populated with the default values.
+Show the *ochami* configuration.
+
+The format of this command is:
+
+*show* [-p] [-f _format_] [_key_]
+
+Print the known *ochami* configuration. An optional _key_ can be passed to print
+a specific global config option, otherwise the whole configuration is printed.
+By default, the config that is used is that merged from the user-level config
+file and the system-wide config file, with the former preceding the latter. This
+is unless any of the config file options are passed. In that case, only the
+config from the relevant file is read.
+
+This command only deals with global configuration options, and not with
+individual cluster configurations, though the cluster list can be shown. Use
+*ochami config cluster show* to view individual cluster configuration.
 
 This command accepts the following options:
 
@@ -81,30 +136,24 @@ This command accepts the following options:
 	- _json_
 	- _yaml_
 
+*-p, --pretty*
+	Indent JSON output. Requires *-f json*.
+
 ## unset
 
-Unset configuration option for ochami CLI.
+Unset global configuration option.
 
 The format of this command is:
 
-*unset* [--user | --system | --config _path_] _key_
+*unset* _key_
 
-This commands unsets configuration key _key_ for configuration files for the
-ochami CLI, in effect deleting it. By default, or if *--user* is specified, the
-user configuration file is modified. If *--system* is specified, the system
-configuration file is modified. Otherwise, if *--config* is specified (this is
-the same flag that is available to all command), _path_ is modified. See the
-*FILES* section in *ochami*(1) for details on the user and system files.
+# FILES
 
-*--config* _path_
-	Modify the config file at _path_. The *--config* flag is the same one that
-	is global to all commands and is not unique to this command.
+_/etc/ochami/config.yaml_
+	The system-wide configuration file for *ochami*.
 
-*--system*
-	Modify the system config file.
-
-*--user*
-	Modify the user config file (the default).
+_~/.config/ochami/config.yaml_
+	The user-level configuration file for *ochami*.
 
 # AUTHOR
 
@@ -112,7 +161,7 @@ Written by Devon T. Bautista and maintained by the OpenCHAMI developers.
 
 # SEE ALSO
 
-*ochami-config*(5)
+*ochami*(1), *ochami-config*(5)
 
 ; Vim modeline settings
 ; vim: set tw=80 noet sts=4 ts=4 sw=4 syntax=scdoc:

--- a/man/ochami-config.1.sc
+++ b/man/ochami-config.1.sc
@@ -8,7 +8,7 @@ ochami-config - Manage configuration for ochami CLI
 
 ochami config [GLOBALOPTS] cluster delete _cluster_name_++
 ochami config [GLOBALOPTS] cluster set [-d] _cluster_name_ _key_ _value_++
-ochami config [GLOBALOPTS] cluster show [-p] [-f _format_] _cluster_name_ [_key_]++
+ochami config [GLOBALOPTS] cluster show [-f _format_] [_cluster_name_] [_key_]++
 ochami config [GLOBALOPTS] cluster unset _cluster_name_ _key_++
 ochami config [GLOBALOPTS] set _key_ _value_++
 ochami config [GLOBALOPTS] show [-f _format_] [_key_]++
@@ -76,9 +76,10 @@ Subcommands for this command are as follows:
 		is not specified on the command line, this cluster's configuration is
 		used.
 
-*show* [-p] [-f _format_] _cluster_name_ [_key_]
-	Show the configuration for _cluster_name_. If _key_ is not specified, show
-	the whole configuration.
+*show* [-f _format_] [_cluster_name_] [_key_]
+	Show the configuration for _cluster_name_ or all clusters if _cluster_name_
+	is unspecified. If _key_ is not specified, show the whole configuration for
+	_cluster_name_, otherwise show the value for _key_.
 
 	This command accepts the following options:
 
@@ -88,10 +89,8 @@ Subcommands for this command are as follows:
 		Default: *json*
 		Supported:
 		- _json_
+		- _json-pretty_
 		- _yaml_
-
-	*-p, --pretty*
-		Indent JSON output. Requires *-f json*.
 
 *unset* _cluster_name_ _key_
 	Unset the _key_ configuration option from _cluster_name_
@@ -113,7 +112,7 @@ Show the *ochami* configuration.
 
 The format of this command is:
 
-*show* [-p] [-f _format_] [_key_]
+*show* [-f _format_] [_key_]
 
 Print the known *ochami* configuration. An optional _key_ can be passed to print
 a specific global config option, otherwise the whole configuration is printed.
@@ -134,10 +133,8 @@ This command accepts the following options:
 	Default: *json*
 	Supported:
 	- _json_
+	- _json-pretty_
 	- _yaml_
-
-*-p, --pretty*
-	Indent JSON output. Requires *-f json*.
 
 ## unset
 

--- a/man/ochami-config.5.sc
+++ b/man/ochami-config.5.sc
@@ -6,15 +6,34 @@ config.yaml - ochami CLI configuration file
 
 # DESCRIPTION
 
-*ochami* supports different config file formats including _yaml_, _json_, and
-_toml_, but YAML is the default. Configuration options can be set via the
-*ochami config* command.
+*ochami* uses the YAML format for its configuration files. Configuration options
+can be set via the *ochami config* command.
 
-# CONFIGURATION
-
-## Global Options
+# GLOBAL CONFIGURATION OPTIONS
 
 These configuration options are global configuration options.
+
+*clusters*
+	The list of cluster configurations. Each cluster configuration is a block
+	that has a *name* field that contains a string uniquely identifying the cluster,
+	as well as a *cluster* field that contains the cluster configuration.
+
+	Importantly, the value of *name* is used when determining the environment
+	variable to read when presenting a token for the cluster. The value is made
+	upper case, hyphens are converted to underscores, and the result is
+	prepended to *\_ACCESS_TOKEN*. For instance, the token environment variable
+	for a cluster named *my-cluster* would be *MY_CLUSTER_ACCESS_TOKEN*.
+
+	See *CLUSTER CONFIGURATION* below for details on cluster configuration.
+
+	The format is:
+
+	```
+	clusters:
+	- name: foobar
+	  cluster:
+	    <cluster_config>
+	```
 
 *default-cluster:* _cluster_name_
 	The name of the default cluster to use when *--cluster* is not specified on
@@ -29,6 +48,7 @@ These configuration options are global configuration options.
 
 		Default: *json*
 		Supported:
+
 		- _basic_
 		- _json_
 		- _rfc3339_
@@ -38,62 +58,66 @@ These configuration options are global configuration options.
 
 		Default: *warning*
 		Supported:
+
 		- _info_
 		- _warning_
 		- _debug_
 
-## Cluster Configuration
+# CLUSTER CONFIGURATION
 
 These configuration options apply only to cluster configuration, i.e. under the
 *clusters* key. The value for the *cluster* key is an array with each item in
 the array containing the below configuration options.
 
-*cluster*
-	The key containing cluster configuration subkeys.
+*name:* _cluster_name_
+	The name of the cluster. This is what *--cluster* and the *default-cluster*
+	key use to identify the cluster.
 
-	*api-uri:* _absolute_uri_
-		The base URI for the OpenCHAMI services for the cluster. This is
-		normally used when most or all of the OpenCHAMI services are behind a
-		single base URI (e.g. _https://foobar.openchami.cluster:8443_), and
-		*ochami* will append the service base path (e.g. _/hsm/v2_) as well as
-		the request endpoint onto this to fulfill the request for the specific
-		service. If one or more OpenCHAMI services is running either with a
-		custom base path or a custom URI altogether (e.g.  running on localhost
-		under different ports), then *<service>-uri* can be used to override
-		either the service base path or the entire URI.
+*<service>*
+	The service-specific configuration for *<service>*. Currently recognized
+	values of *<service>* are:
 
-		Thus, either *api-uri* must be specified with optional *<service>-uri*
-		directives for overrides, or a *<service>-uri* must be specified for
-		each *<service>*.
+	- _bss_ (Boot Script Service)
+	- _cloud-init_ (cloud-init)
+	- _pcs_ (Power Control Service)
+	- _smd_ (State Management Database)
 
-	*<service>-uri:* _absolute_uri_or_relative_path_
-		Specify either the absolute base URI for an OpenCHAMI *<service>* (e.g.
+	Each service config can have the following configuration options:
+
+	*uri:* _absolute_uri_or_relative_path_
+		Specify either the absolute base URI for the service (e.g.
 		_https://foobar.openchami.cluster:8443/hsm/v2_) or a relative base path
 		for the service (e.g. _/hsm/v2_). If an absolute URI is specified, this
-		completely overrides any value set for *api-uri* and the absolute URI
-		should also contain the desired service's base path. If a relative path
-		is specified (with or without the leading forward slash), then this
+		completely overrides any value set for *cluster.uri* and the absolute
+		URI should also contain the desired service's base path. If a relative
+		path is specified (with or without the leading forward slash), then this
 		value overrides the service's default base path and is appended to
-		*api-uri*, which is required to be set if a relative path is used here.
+		*cluster.uri*, which is required to be set if a relative path is used
+		here.
 
 		This option should be used when either one or more of the OpenCHAMI
 		services is using a custom base path or when it/they have an entirely
 		different URI, as when running bare metal on localhost with different
 		ports. *ochami* determines the base URI to use for each service by
-		checking *api-uri* and then if an override is set by a *<service>-uri*
-		directive for the *<service>*, so at least one of these need to be set.
-		Otherwise, the base URI is not able to be determined for that service.
+		checking *cluster.uri* and then if an override is set by a
+		*cluster.<service>.uri* directive for the *<service>*, so at least one
+		of these need to be set.  Otherwise, the base URI is not able to be
+		determined for that service.
 
-		Values of *<service>* can be:
+*uri:* _absolute_uri_
+	The base URI for the OpenCHAMI services for the cluster. This is
+	normally used when most or all of the OpenCHAMI services are behind a
+	single base URI (e.g. _https://foobar.openchami.cluster:8443_), and
+	*ochami* will append the service base path (e.g. _/hsm/v2_) as well as
+	the request endpoint onto this to fulfill the request for the specific
+	service. If one or more OpenCHAMI services is running either with a
+	custom base path or a custom URI altogether (e.g.  running on localhost
+	under different ports), then *cluster.<service>.uri* can be used to override
+	either the service base path or the entire URI.
 
-		- _bss_
-		- _cloud-init_
-		- _pcs_
-		- _smd_
-
-*name:* _cluster_name_
-	The name of the cluster. This is what *--cluster* and the *default-cluster*
-	key use to identify the cluster.
+	Thus, either *cluster.uri* must be specified with optional
+	*cluster.<service>.uri* directives for overrides, or a
+	*cluster.<service>.uri* must be specified for each *<service>*.
 
 # EXAMPLES
 
@@ -104,7 +128,7 @@ the array containing the below configuration options.
 ```
 clusters:
     - cluster:
-        api-uri: https://foobar.openchami.cluster
+        uri: https://foobar.openchami.cluster
       name: foobar
 default-cluster: foobar
 log:
@@ -117,10 +141,14 @@ log:
 ```
 clusters:
     - cluster:
-        bss-uri: https://localhost:27778/boot/v1
-        cloud-init-uri: https://localhost:27777/cloud-init
-        pcs-uri: https://localhost:28007/
-		smd-uri: https://localhost:27779/hsm/v2
+        bss:
+		  uri: https://localhost:27778/boot/v1
+        cloud-init:
+		  uri: https://localhost:27777/cloud-init
+        pcs:
+		  uri: https://localhost:28007/
+        smd:
+		  uri: https://localhost:27779/hsm/v2
       name: foobar
 default-cluster: foobar
 log:
@@ -133,8 +161,9 @@ log:
 ```
 clusters:
     - cluster:
-        api-uri: https://foobar.openchami.cluster
-		smd-uri: /smd
+        uri: https://foobar.openchami.cluster
+        smd:
+          uri: /smd
       name: foobar
 default-cluster: foobar
 log:
@@ -147,8 +176,9 @@ log:
 ```
 clusters:
     - cluster:
-        api-uri: https://foobar.openchami.cluster
-		smd-uri: https://smd.foobar.openchami.cluster/hsm/v2
+        uri: https://foobar.openchami.cluster
+        smd:
+          uri: https://smd.foobar.openchami.cluster/hsm/v2
       name: foobar
 default-cluster: foobar
 log:
@@ -167,7 +197,7 @@ Written by Devon T. Bautista and maintained by the OpenCHAMI developers.
 
 # SEE ALSO
 
-*ochami-config*(1)
+*ochami*(1), *ochami-config*(1)
 
 ; Vim modeline settings
 ; vim: set tw=80 noet sts=4 ts=4 sw=4 syntax=scdoc:

--- a/man/ochami-discover.1.sc
+++ b/man/ochami-discover.1.sc
@@ -123,5 +123,9 @@ information on xnames: https://github.com/Cray-HPE/hms-xname
 
 Written by Devon T. Bautista and maintained by the OpenCHAMI developers.
 
+# SEE ALSO
+
+*ochami*(1)
+
 ; Vim modeline settings
 ; vim: set tw=80 noet sts=4 ts=4 sw=4 syntax=scdoc:

--- a/man/ochami-pcs.1.sc
+++ b/man/ochami-pcs.1.sc
@@ -22,6 +22,23 @@ The data structure for sending and receiving data with subcommands under the
 }
 ```
 
+# GLOBAL FLAGS
+
+*--uri* _uri_
+	Specify either the absolute base URI for the service (e.g.
+	_https://foobar.openchami.cluster:8443/hsm/v2_) or a relative base path for
+	the service (e.g. _/hsm/v2_). If an absolute URI is specified, this
+	completely overrides any value set with the *--cluster-uri* flag or
+	*cluster.uri* in the config file for the cluster. If using an absolute URI,
+	it should contain the desired service's base path. If a relative path is
+	specified (with or without the leading forward slash), then this value
+	overrides the service's default base path and is appended to the cluster's
+	base URI (set with the *--cluster-uri* flag or the *cluster.uri* cluster
+	config option), which is required to be set if a relative path is used here.
+
+	See *ochami*(1) for *--cluster-uri* and *ochami-config*(5) for details on
+	cluster configuration options.
+
 # COMMANDS
 
 ## status
@@ -58,6 +75,10 @@ This command accepts the following options:
 # AUTHOR
 
 Written by Chris Harris and maintained by the OpenCHAMI developers.
+
+# SEE ALSO
+
+*ochami*(1)
 
 ; Vim modeline settings
 ; vim: set tw=80 noet sts=4 ts=4 sw=4 syntax=scdoc:

--- a/man/ochami-smd.1.sc
+++ b/man/ochami-smd.1.sc
@@ -211,6 +211,23 @@ structure contains a single *RedfishEndpoints* object containing an array.
 }
 ```
 
+# GLOBAL FLAGS
+
+*--uri* _uri_
+	Specify either the absolute base URI for the service (e.g.
+	_https://foobar.openchami.cluster:8443/hsm/v2_) or a relative base path for
+	the service (e.g. _/hsm/v2_). If an absolute URI is specified, this
+	completely overrides any value set with the *--cluster-uri* flag or
+	*cluster.uri* in the config file for the cluster. If using an absolute URI,
+	it should contain the desired service's base path. If a relative path is
+	specified (with or without the leading forward slash), then this value
+	overrides the service's default base path and is appended to the cluster's
+	base URI (set with the *--cluster-uri* flag or the *cluster.uri* cluster
+	config option), which is required to be set if a relative path is used here.
+
+	See *ochami*(1) for *--cluster-uri* and *ochami-config*(5) for details on
+	cluster configuration options.
+
 # COMMANDS
 
 ## compep
@@ -605,6 +622,10 @@ Subcommands for this command are as follows:
 # AUTHOR
 
 Written by Devon T. Bautista and maintained by the OpenCHAMI developers.
+
+# SEE ALSO
+
+*ochami*(1)
 
 ; Vim modeline settings
 ; vim: set tw=80 noet sts=4 ts=4 sw=4 syntax=scdoc:

--- a/man/ochami.1.sc
+++ b/man/ochami.1.sc
@@ -54,7 +54,7 @@ cluster configuration will need to be specified. Both can be done with the
 following command:
 
 ```
-ochami config --user cluster set --default --base-uri https://foobar.openchami.cluster foobar
+ochami config --user cluster set --default foobar cluster.uri https://foobar.openchami.cluster
 ```
 
 This will create a cluster called _foobar_ and set its base URI to
@@ -85,10 +85,6 @@ _foobar_.
 
 # GLOBAL OPTIONS
 
-*-u, --base-uri* _uri_
-	Specify the base URI to use when contacting OpenCHAMI services. Overrides
-	the base URI specified in a config file.
-
 *--cacert* _cacert_
 	Specify the path to a certificate authority (CA) certificate file to use to
 	verify TLS certificates. Must be PEM-formatted.
@@ -96,6 +92,17 @@ _foobar_.
 *-C, --cluster* _cluster_name_
 	Specify the name of a cluster to use. The cluster corresponding to the
 	passed cluster name must exist in a config file.
+
+*-u, --cluster-uri* _uri_
+	Specify cluster base URI to use. This is required to be an absolute URI
+	since the base path of the service(s) being communicated with will be
+	appended to this URI. Using the *--uri* flag on a service command or
+	*cluster.<service>.uri* in the config file for a cluster can override this
+	value for the specific service. The *--cluster-uri* flag overrides the
+	*cluster.uri* config file option for the cluster.
+
+	See *ochami-config*(5) for details on cluster config options, as well as the
+	manual pages for the services in *ochami*(1) for details on *--uri*.
 
 *-c, --config* _config_file_
 	Specify the path to a config file to use. By default, the configuration is
@@ -137,19 +144,14 @@ _foobar_.
 _/usr/share/doc/ochami/config.example.yaml_
 	An example configuration file that can be used for reference.
 
-_/etc/ochami/config.yaml_
-	The system-wide ochami CLI configuration file.
-
-_~/.config/ochami/config.yaml_
-	The user-level ochami CLI configuration file.
-
 # AUTHOR
 
 Written by Devon T. Bautista and maintained by the OpenCHAMI developers.
 
 # SEE ALSO
 
-*ochami-bss*(1), *ochami-config*(1), *ochami-discover*(1), *ochami-smd*(1)
+*ochami-bss*(1), *ochami-cloud-init*(1), *ochami-config*(1),
+*ochami-discover*(1), *ochami-smd*(1), *ochami-config*(5)
 
 ; Vim modeline settings
 ; vim: set tw=80 noet sts=4 ts=4 sw=4 syntax=scdoc:


### PR DESCRIPTION
Resolves #6 

The linked issue addresses improving `ochami`'s configuration mechanism to support a variety of deployments. Improvement in the `config` subcommands goes a long with that since it allows one to easily modify their configuration file. This PR makes these changes, as well as improves some additional behavior.

# Usage

See `man/ochami-config.1.sc` for more.

```
ochami config [GLOBALOPTS] cluster delete cluster_name
ochami config [GLOBALOPTS] cluster set [-d] cluster_name key value
ochami config [GLOBALOPTS] cluster show [-f format] [cluster_name] [key]
ochami config [GLOBALOPTS] cluster unset cluster_name key
ochami config [GLOBALOPTS] set key value
ochami config [GLOBALOPTS] show [-f format] [key]
ochami config [GLOBALOPTS] unset key
```

GLOBALOPTS:
- `--config <path>` - Use custom config file path
- `--system` - Use system-wide config (`/etc/ochami/config.yaml`)
- `--user` - Use user config (`~/.config/ochami/config.yaml`)

# Changes

## Features

- Move from flags (e.g. `--api-uri`) to keys (e.g. `cluster.api-uri`) in `config` commands for clusters and global config. (Also update manual pages.)

  This allows the available config options to grow without having to add a flag for each option to the various `config` commands.

- Add `config cluster unset` command for unsetting cluster config keys.
- Add `config cluster show` command for showing cluster configuration, for all/individual clusters and all/individual config keys

## Fixes

- Properly make mutually exclusive the `--config`, `--system`, and `--user` options.

   There was an issue making these mutually exclusive in the root command since `--config` is a persistent root flag while `--system` and `--user` are persistent `config` flags. This fix moves this functionality from the root command to each `config` subcommand. It's a bit more verbose than before, but works a lot better.

- Don't ask to create a missing config file if unnecessary.

   For instance, if showing a config value for a specific config file that doesn't exist, it doesn't make sense to create it. However, if setting a config value in a nonexistent config file, it does make sense to create it. Before, `ochami` would ask for _every_ command.

## Refactorization

- Move usage printing with error handling to separate function.
- Use `configFile` variable that the `--config` flag writes to instead of calling `cmd.Flag("config").Value.String()`