### PR TITLE
feat!: make data/format flags more consistent

### DIFF
--- a/cmd/bss-boot-params-delete.go
+++ b/cmd/bss-boot-params-delete.go
@@ -23,25 +23,36 @@ var bootParamsDeleteCmd = &cobra.Command{
 This command can delete boot parameters by config (kernel URI,
 initrd URI, or kernel command line) or by component (--xname,
 --mac, or --nid). The user will be asked for confirmation before
-deletion unless --force is passed. Alternatively, pass -f to pass
-a file (optionally specifying --payload-format, JSON by default),
-but the rules above still apply for the payload. If the specified
-file path is -, the data is read from standard input.
+deletion unless --force is passed. Alternatively, pass -d to pass
+raw payload data or (if flag argument starts with @) a file containing
+the payload data. -f can be specified to change the format of the
+input payload data ('json' by default), but the rules above still
+apply for the payload. If "-" is used as the input payload filename,
+the data is read from standard input.
 
 This command sends a DELETE to BSS. An access token is required.
 
 See ochami-bss(1) for more details.`,
-	Example: `  ochami bss boot params delete --kernel https://example.com/kernel
+	Example: `  # Delete boot parameters using CLI flags
+  ochami bss boot params delete --kernel https://example.com/kernel
   ochami bss boot params delete --kernel https://example.com/kernel --initrd https://example.com/initrd
-  ochami bss boot params delete -f payload.json
-  ochami bss boot params delete -f payload.yaml --payload-format yaml
-  echo '<json_data>' | ochami bss boot params delete -f -
-  echo '<yaml_data>' | ochami bss boot params delete -f - --payload-format yaml`,
+
+  # Delete boot parameters using input payload data
+  ochami bss boot params delete -d '{"macs":["00:de:ad:be:ef:00"]}'
+  ochami bss boot params delete -d '{"kernel":"https://example.com/kernel"}'
+
+  # Delete boot parameters using input payload data
+  ochami bss boot params delete -d @payload.json
+  ochami bss boot params delete -d @payload.yaml -f yaml
+
+  # Delete boot parameters using data from standard input
+  echo '<json_data>' | ochami bss boot params delete -d @-
+  echo '<yaml_data>' | ochami bss boot params delete -d @- -f yaml`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// cmd.LocalFlags().NFlag() doesn't seem to work, so we check every flag
 		if len(args) == 0 &&
 			!cmd.Flag("xname").Changed && !cmd.Flag("nid").Changed && !cmd.Flag("mac").Changed &&
-			!cmd.Flag("kernel").Changed && !cmd.Flag("initrd").Changed && !cmd.Flag("payload").Changed {
+			!cmd.Flag("kernel").Changed && !cmd.Flag("initrd").Changed && !cmd.Flag("data").Changed {
 			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
@@ -168,12 +179,12 @@ func init() {
 	bootParamsDeleteCmd.Flags().StringSliceP("xname", "x", []string{}, "one or more xnames whose boot parameters to delete")
 	bootParamsDeleteCmd.Flags().StringSliceP("mac", "m", []string{}, "one or more MAC addresses whose boot parameters to delete")
 	bootParamsDeleteCmd.Flags().Int32SliceP("nid", "n", []int32{}, "one or more node IDs whose boot parameters to delete")
-	bootParamsDeleteCmd.Flags().StringP("payload", "f", "", "file containing the request payload; JSON format unless --payload-format specified")
-	bootParamsDeleteCmd.Flags().StringP("payload-format", "F", defaultPayloadFormat, "format of payload file (yaml,json) passed with --payload")
+	bootParamsDeleteCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
+	bootParamsDeleteCmd.Flags().StringP("format-input", "f", defaultInputFormat, "format of input payload data (json,yaml)")
 	bootParamsDeleteCmd.Flags().Bool("force", false, "do not ask before attempting deletion")
 
 	// We can delete either by component or by boot parameters
-	bootParamsDeleteCmd.MarkFlagsOneRequired("xname", "mac", "nid", "kernel", "initrd", "params", "payload")
+	bootParamsDeleteCmd.MarkFlagsOneRequired("xname", "mac", "nid", "kernel", "initrd", "params", "data")
 
 	bootParamsCmd.AddCommand(bootParamsDeleteCmd)
 }

--- a/cmd/bss-boot-params-get.go
+++ b/cmd/bss-boot-params-get.go
@@ -105,9 +105,9 @@ See ochami-bss(1) for more details.`,
 			os.Exit(1)
 		}
 
-		outFmt, err := cmd.Flags().GetString("output-format")
+		outFmt, err := cmd.Flags().GetString("format-output")
 		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+			log.Logger.Error().Err(err).Msg("failed to get value for --format-output")
 			logHelpError(cmd)
 			os.Exit(1)
 		}
@@ -125,6 +125,6 @@ func init() {
 	bootParamsGetCmd.Flags().StringSliceP("xname", "x", []string{}, "one or more xnames whose boot parameters to get")
 	bootParamsGetCmd.Flags().StringSliceP("mac", "m", []string{}, "one or more MAC addresses whose boot parameters to get")
 	bootParamsGetCmd.Flags().Int32SliceP("nid", "n", []int32{}, "one or more node IDs whose boot parameters to get")
-	bootParamsGetCmd.Flags().StringP("output-format", "F", defaultOutputFormat, "format of output printed to standard output")
+	bootParamsGetCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,yaml)")
 	bootParamsCmd.AddCommand(bootParamsGetCmd)
 }

--- a/cmd/bss-boot-params-update.go
+++ b/cmd/bss-boot-params-update.go
@@ -20,27 +20,37 @@ var bootParamsUpdateCmd = &cobra.Command{
 	Short: "Update some or all boot parameters for one or more components",
 	Long: `Update some or all boot parameters for one or more components. At least one of
 --kernel, initrd, or --params must be specified as well as at least
-one of --xname, --mac, or --nid. Alternatively, pass -f to pass a
-file (optionally specifying --payload-format, JSON by default), but
-the rules above still apply for the payload. If the specified file
-path is -, the data is read from standard input.
+one of --xname, --mac, or --nid. Alternatively, pass -d to pass raw
+payload data or (if flag argument starts with @) a file containing
+the payload data. -f can be specified to change the format of the
+input payload data ('json' by default), but the rules above still
+apply for the payload. If "-" is used as the input payload filename,
+the data is read from standard input.
 
 This command sends a PATCH to BSS. An access token is required.
 
 See ochami-bss(1) for details.`,
-	Example: `  ochami bss boot params update --xname x1000c1s7b0 --kernel https://example.com/kernel
+	Example: `  # Update boot parameters using CLI flags
+  ochami bss boot params update --xname x1000c1s7b0 --kernel https://example.com/kernel
   ochami bss boot params update --xname x1000c1s7b0,x1000c1s7b1 --kernel https://example.com/kernel
   ochami bss boot params update --xname x1000c1s7b0 --xname x1000c1s7b1 --kernel https://example.com/kernel
   ochami bss boot params update --xname x1000c1s7b0 --nid 1 --mac 00:c0:ff:ee:00:00 --params 'quiet nosplash'
-  ochami bss boot params update -f payload.json
-  ochami bss boot params update -f payload.yaml --payload-format yaml
-  echo '<json_data>' | ochami bss boot params update -f -
-  echo '<yaml_data>' | ochami bss boot params update -f - --payload-format yaml`,
+
+  # Update boot parameters using input payload data
+  ochami bss boot params update -d '{"macs":["00:de:ad:be:ef:00"],"kernel":"https://example.com/kernel"}'
+
+  # Update boot parameters using input payload file
+  ochami bss boot params update -d @payload.json
+  ochami bss boot params update -d @payload.yaml -f yaml
+
+  # Update boot parameters using data from standard input
+  echo '<json_data>' | ochami bss boot params update -d @-
+  echo '<yaml_data>' | ochami bss boot params update -d @- -f yaml`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// cmd.LocalFlags().NFlag() doesn't seem to work, so we check every flag
 		if len(args) == 0 &&
 			!cmd.Flag("xname").Changed && !cmd.Flag("nid").Changed && !cmd.Flag("mac").Changed &&
-			!cmd.Flag("kernel").Changed && !cmd.Flag("initrd").Changed && !cmd.Flag("payload").Changed {
+			!cmd.Flag("kernel").Changed && !cmd.Flag("initrd").Changed && !cmd.Flag("data").Changed {
 			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
@@ -155,11 +165,11 @@ func init() {
 	bootParamsUpdateCmd.Flags().StringSliceP("xname", "x", []string{}, "one or more xnames whose boot parameters to update")
 	bootParamsUpdateCmd.Flags().StringSliceP("mac", "m", []string{}, "one or more MAC addresses whose boot parameters to update")
 	bootParamsUpdateCmd.Flags().Int32SliceP("nid", "n", []int32{}, "one or more node IDs whose boot parameters to update")
-	bootParamsUpdateCmd.Flags().StringP("payload", "f", "", "file containing the request payload; JSON format unless --payload-format specified")
-	bootParamsUpdateCmd.Flags().StringP("payload-format", "F", defaultPayloadFormat, "format of payload file (yaml,json) passed with --payload")
+	bootParamsUpdateCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
+	bootParamsUpdateCmd.Flags().StringP("format-input", "f", defaultInputFormat, "format of input payload data (json,yaml)")
 
-	bootParamsUpdateCmd.MarkFlagsOneRequired("xname", "mac", "nid", "payload")
-	bootParamsUpdateCmd.MarkFlagsOneRequired("kernel", "initrd", "params", "payload")
+	bootParamsUpdateCmd.MarkFlagsOneRequired("xname", "mac", "nid", "data")
+	bootParamsUpdateCmd.MarkFlagsOneRequired("kernel", "initrd", "params", "data")
 
 	bootParamsCmd.AddCommand(bootParamsUpdateCmd)
 }

--- a/cmd/bss-dumpstate.go
+++ b/cmd/bss-dumpstate.go
@@ -55,10 +55,10 @@ See ochami-bss(1) for more details.`,
 
 		// Print output
 		fmt.Println(string(httpEnv.Body))
-		outFmt, err := cmd.Flags().GetString("output-format")
+		outFmt, err := cmd.Flags().GetString("format-output")
 		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
 			logHelpError(cmd)
+			log.Logger.Error().Err(err).Msg("failed to get value for --format-output")
 			os.Exit(1)
 		}
 		if outBytes, err := client.FormatBody(httpEnv.Body, outFmt); err != nil {
@@ -72,6 +72,6 @@ See ochami-bss(1) for more details.`,
 }
 
 func init() {
-	bssDumpStateCmd.Flags().StringP("output-format", "F", defaultOutputFormat, "format of output printed to standard output")
+	bssDumpStateCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,yaml)")
 	bssCmd.AddCommand(bssDumpStateCmd)
 }

--- a/cmd/bss-history.go
+++ b/cmd/bss-history.go
@@ -80,9 +80,9 @@ See ochami-bss(1) for more details.`,
 		}
 
 		// Print output
-		outFmt, err := cmd.Flags().GetString("output-format")
+		outFmt, err := cmd.Flags().GetString("format-output")
 		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+			log.Logger.Error().Err(err).Msg("failed to get value for --format-output")
 			logHelpError(cmd)
 			os.Exit(1)
 		}
@@ -99,6 +99,6 @@ See ochami-bss(1) for more details.`,
 func init() {
 	bssHistoryCmd.Flags().String("xname", "", "filter by xname")
 	bssHistoryCmd.Flags().String("endpoint", "", "filter by endpoint")
-	bssHistoryCmd.Flags().StringP("output-format", "F", defaultOutputFormat, "format of output printed to standard output")
+	bssHistoryCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,yaml)")
 	bssCmd.AddCommand(bssHistoryCmd)
 }

--- a/cmd/bss-hosts-get.go
+++ b/cmd/bss-hosts-get.go
@@ -89,9 +89,9 @@ See ochami-bss(1) for more details.`,
 		}
 
 		// Print output
-		outFmt, err := cmd.Flags().GetString("output-format")
+		outFmt, err := cmd.Flags().GetString("format-output")
 		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+			log.Logger.Error().Err(err).Msg("failed to get value for --format-output")
 			logHelpError(cmd)
 			os.Exit(1)
 		}
@@ -109,6 +109,6 @@ func init() {
 	bssHostsGetCmd.Flags().StringP("xname", "x", "", "xname whose host information to get")
 	bssHostsGetCmd.Flags().StringP("mac", "m", "", "MAC address whose boot parameters to get")
 	bssHostsGetCmd.Flags().Int32P("nid", "n", 0, "node ID whose host information to get")
-	bssHostsGetCmd.Flags().StringP("output-format", "F", defaultOutputFormat, "format of output printed to standard output")
+	bssHostsGetCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,yaml)")
 	bssHostsCmd.AddCommand(bssHostsGetCmd)
 }

--- a/cmd/bss-status.go
+++ b/cmd/bss-status.go
@@ -65,9 +65,9 @@ See ochami-bss(1) for more details.`,
 		}
 
 		// Print output
-		outFmt, err := cmd.Flags().GetString("output-format")
+		outFmt, err := cmd.Flags().GetString("format-output")
 		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+			log.Logger.Error().Err(err).Msg("failed to get value for --format-output")
 			logHelpError(cmd)
 			os.Exit(1)
 		}
@@ -89,6 +89,6 @@ func init() {
 
 	bssStatusCmd.MarkFlagsMutuallyExclusive("all", "storage", "smd", "version")
 
-	bssStatusCmd.Flags().StringP("output-format", "F", defaultOutputFormat, "format of output printed to standard output")
+	bssStatusCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,yaml)")
 	bssCmd.AddCommand(bssStatusCmd)
 }

--- a/cmd/cloud_init-config-get.go
+++ b/cmd/cloud_init-config-get.go
@@ -71,9 +71,9 @@ See ochami-cloud-init(1) for more details.`,
 		}
 
 		// Format output
-		outFmt, err := cmd.Flags().GetString("output-format")
+		outFmt, err := cmd.Flags().GetString("format-output")
 		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+			log.Logger.Error().Err(err).Msg("failed to get value for --format-output")
 			logHelpError(cmd)
 			os.Exit(1)
 		}
@@ -88,6 +88,6 @@ See ochami-cloud-init(1) for more details.`,
 }
 
 func init() {
-	cloudInitConfigGetCmd.Flags().StringP("output-format", "F", defaultOutputFormat, "format of output printed to standard output")
+	cloudInitConfigGetCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,yaml)")
 	cloudInitConfigCmd.AddCommand(cloudInitConfigGetCmd)
 }

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -16,14 +16,14 @@ import (
 
 // discoverCmd represents the discover command
 var discoverCmd = &cobra.Command{
-	Use:   "discover -f <payload_file> [--payload-format <format>] [--overwrite]",
+	Use:   "discover (-d (<payload_data> | @<payload_file>)) [-f <format>] [--overwrite]",
 	Args:  cobra.NoArgs,
 	Short: "Populate SMD with data",
 	Long: `Populate SMD with data. Currently, this command performs "fake" discovery,
 whereby data from a payload file is used to create the SMD structures.
 In this way, the command does not perform dynamic discovery like Magellan,
-but statically populates SMD using a file. If - is used as the argument to
--f, the payload data is read from standard input.
+but statically populates SMD using a file. If @- is used as the argument to
+-d, the payload data is read from standard input.
 
 The format of the payload file is an array of node specifications. In YAML,
 each node entry would look something like:
@@ -53,7 +53,7 @@ nodes:
 See ochami-discover(1) for more details.`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// Check that all required args are passed
-		if len(args) == 0 && !cmd.Flag("payload").Changed {
+		if len(args) == 0 && !cmd.Flag("data").Changed {
 			printUsageHandleError(cmd)
 			os.Exit(0)
 		}
@@ -456,11 +456,11 @@ See ochami-discover(1) for more details.`,
 }
 
 func init() {
-	discoverCmd.Flags().StringP("payload", "f", "", "file containing the request payload; JSON format unless --payload-format specified")
-	discoverCmd.Flags().StringP("payload-format", "F", defaultPayloadFormat, "format of payload file (yaml,json) passed with --payload")
+	discoverCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
+	discoverCmd.Flags().StringP("format-input", "f", defaultInputFormat, "format of input payload data (json,yaml)")
 	discoverCmd.Flags().Bool("overwrite", false, "overwrite any existing information instead of failing")
 
-	discoverCmd.MarkFlagRequired("payload")
+	discoverCmd.MarkFlagRequired("data")
 
 	rootCmd.AddCommand(discoverCmd)
 }

--- a/cmd/lib.go
+++ b/cmd/lib.go
@@ -392,15 +392,15 @@ func setTokenFromEnvVar(cmd *cobra.Command) {
 	logHelpError(cmd)
 }
 
-// handlePayload unmarshals a payload file into data for command cmd if
-// --payload and, optionally, --payload-format, are passed.
-func handlePayload(cmd *cobra.Command, data any) {
-	if cmd.Flag("payload").Changed {
-		dFile := cmd.Flag("payload").Value.String()
-		dFormat := cmd.Flag("payload-format").Value.String()
-		err := client.ReadPayload(dFile, dFormat, data)
+// handlePayload unmarshals a payload file into v for command cmd if --data
+// and, optionally, --format-input, are passed.
+func handlePayload(cmd *cobra.Command, v any) {
+	if cmd.Flag("data").Changed {
+		data := cmd.Flag("data").Value.String()
+		dFormat := cmd.Flag("format-input").Value.String()
+		err := client.ReadPayload(data, dFormat, v)
 		if err != nil {
-			log.Logger.Error().Err(err).Msg("unable to read payload for request")
+			log.Logger.Error().Err(err).Msg("unable to read payload data or file")
 			logHelpError(cmd)
 			os.Exit(1)
 		}

--- a/cmd/pcs-status.go
+++ b/cmd/pcs-status.go
@@ -190,9 +190,9 @@ See ochami-pcs(1) for more details.`,
 		}
 
 		// Print output
-		outFmt, err := cmd.Flags().GetString("output-format")
+		outFmt, err := cmd.Flags().GetString("format-output")
 		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+			log.Logger.Fatal().Err(err).Msg("failed to get value for --format-output")
 			logHelpError(cmd)
 			os.Exit(1)
 		}
@@ -221,6 +221,6 @@ func init() {
 		pcsStatusCmd.MarkFlagsMutuallyExclusive("all", flags[i])
 	}
 
-	pcsStatusCmd.Flags().StringP("output-format", "F", defaultOutputFormat, "format of output printed to standard output")
+	pcsStatusCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,yaml)")
 	pcsCmd.AddCommand(pcsStatusCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	defaultPayloadFormat = "json"
-	defaultOutputFormat  = "json"
+	defaultInputFormat  = "json"
+	defaultOutputFormat = "json"
 )
 
 var (
@@ -29,9 +29,9 @@ var (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:     config.ProgName,
-	Args:    cobra.NoArgs,
-	Short:   "Command line interface for interacting with OpenCHAMI services",
+	Use:   config.ProgName,
+	Args:  cobra.NoArgs,
+	Short: "Command line interface for interacting with OpenCHAMI services",
 	Long: `Command line interface for interacting with OpenCHAMI services.
 
 See ochami(1) for more details on available commands.

--- a/cmd/smd-compep-get.go
+++ b/cmd/smd-compep-get.go
@@ -60,9 +60,9 @@ See ochami-smd(1) for more details.`,
 			}
 
 			// Print output
-			outFmt, err := cmd.Flags().GetString("output-format")
+			outFmt, err := cmd.Flags().GetString("format-output")
 			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+				log.Logger.Error().Err(err).Msg("failed to get value for --format-output")
 				logHelpError(cmd)
 				os.Exit(1)
 			}
@@ -127,9 +127,9 @@ See ochami-smd(1) for more details.`,
 			}
 
 			// Print output
-			outFmt, err := cmd.Flags().GetString("output-format")
+			outFmt, err := cmd.Flags().GetString("format-output")
 			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+				log.Logger.Error().Err(err).Msg("failed to get value for --format-output")
 				logHelpError(cmd)
 				os.Exit(1)
 			}
@@ -145,6 +145,6 @@ See ochami-smd(1) for more details.`,
 }
 
 func init() {
-	compepGetCmd.Flags().StringP("output-format", "F", defaultOutputFormat, "format of output printed to standard output")
+	compepGetCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,yaml)")
 	compepCmd.AddCommand(compepGetCmd)
 }

--- a/cmd/smd-component-delete.go
+++ b/cmd/smd-component-delete.go
@@ -14,23 +14,35 @@ import (
 
 // componentDeleteCmd represents the smd-component-delete command
 var componentDeleteCmd = &cobra.Command{
-	Use:   "delete -f <payload_file> | --all | <xname>...",
+	Use:   "delete (-d (<payload_data> | @<payload_file>)) | --all | <xname>...",
 	Short: "Delete one or more components",
 	Long: `Delete one or more components. These can be specified by one or more xnames, one
-or more NIDs, or a combination of both. Alternatively, specify the xnames in
-an array of component structures within a payload file and pass it to -f. If
-- is passed to -f, the data is read from standard input.
+or more NIDs, or a combination of both. Alternatively,
+pass -d to pass raw payload data or (if flag argument
+starts with @) a file containing the payload data. -f
+can be specified to change the format of the input
+payload data ('json' by default), but the rules above
+still apply for the payload. If "-" is used as the input
+payload filename, the data is read from standard input.
 
 This command sends a DELETE to SMD. An access token is required.
 
 See ochami-smd(1) for more details.`,
-	Example: `  ochami smd component delete x3000c1s7b56n0
+	Example: `  # Delete components using CLI flags
+  ochami smd component delete x3000c1s7b56n0
   ochami smd component delete x3000c1s7b56n0 x3000c1s7b56n1
   ochami smd component delete --all
-  ochami smd component delete -f payload.json
-  ochami smd component delete -f payload.yaml --payload-format yaml
-  echo '<json_data>' | ochami smd component delete -f -
-  echo '<yaml_data>' | ochami smd component delete -f - --payload-format yaml`,
+
+  # Delete components using input payload data
+  ochami smd component delete -d '{"Components":[{"ID"x3000c1s7b56n0"},{"ID":"x3000c1s7b56n1"}]}'
+
+  # Delete components using input payload file
+  ochami smd component delete -d @payload.json
+  ochami smd component delete -d @payload.yaml -f yaml
+
+  # Delete components using data from standard input
+  echo '<json_data>' | ochami smd component delete -d @-
+  echo '<yaml_data>' | ochami smd component delete -d @- -f yaml`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// With options, only one of:
 		// - A payload file with -f
@@ -38,7 +50,7 @@ See ochami-smd(1) for more details.`,
 		// - A set of one or more xnames
 		// must be passed.
 		if len(args) == 0 {
-			if !cmd.Flag("all").Changed && !cmd.Flag("payload").Changed {
+			if !cmd.Flag("all").Changed && !cmd.Flag("data").Changed {
 				printUsageHandleError(cmd)
 				os.Exit(0)
 			}
@@ -88,7 +100,7 @@ See ochami-smd(1) for more details.`,
 		// Create list of xnames to delete
 		var compSlice smd.ComponentSlice
 		var xnameSlice []string
-		if cmd.Flag("payload").Changed {
+		if cmd.Flag("data").Changed {
 			// Use payload file if passed
 			handlePayload(cmd, &compSlice)
 		} else {
@@ -139,8 +151,8 @@ See ochami-smd(1) for more details.`,
 
 func init() {
 	componentDeleteCmd.Flags().BoolP("all", "a", false, "delete all components in SMD")
-	componentDeleteCmd.Flags().StringP("payload", "f", "", "file containing the request payload; JSON format unless --payload-format specified")
-	componentDeleteCmd.Flags().StringP("payload-format", "F", defaultPayloadFormat, "format of payload file (yaml,json) passed with --payload")
+	componentDeleteCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
+	componentDeleteCmd.Flags().StringP("format-input", "f", defaultInputFormat, "format of input payload data (json,yaml)")
 	componentDeleteCmd.Flags().Bool("force", false, "do not ask before attempting deletion")
 
 	componentCmd.AddCommand(componentDeleteCmd)

--- a/cmd/smd-component-get.go
+++ b/cmd/smd-component-get.go
@@ -74,9 +74,9 @@ See ochami-smd(1) for more details.`,
 		}
 
 		// Print output
-		outFmt, err := cmd.Flags().GetString("output-format")
+		outFmt, err := cmd.Flags().GetString("format-output")
 		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+			log.Logger.Error().Err(err).Msg("failed to get value for --format-output")
 			logHelpError(cmd)
 			os.Exit(1)
 		}
@@ -93,7 +93,7 @@ See ochami-smd(1) for more details.`,
 func init() {
 	componentGetCmd.Flags().StringP("xname", "x", "", "xname whose Component to fetch")
 	componentGetCmd.Flags().Int32P("nid", "n", 0, "node ID whose Component to fetch")
-	componentGetCmd.Flags().StringP("output-format", "F", defaultOutputFormat, "format of output printed to standard output")
+	componentGetCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,yaml)")
 
 	componentGetCmd.MarkFlagsMutuallyExclusive("xname", "nid")
 

--- a/cmd/smd-group-get.go
+++ b/cmd/smd-group-get.go
@@ -93,9 +93,9 @@ See ochami-smd(1) for more details.`,
 		}
 
 		// Print output
-		outFmt, err := cmd.Flags().GetString("output-format")
+		outFmt, err := cmd.Flags().GetString("format-output")
 		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+			log.Logger.Error().Err(err).Msg("failed to get value for --format-output")
 			logHelpError(cmd)
 			os.Exit(1)
 		}
@@ -112,6 +112,6 @@ See ochami-smd(1) for more details.`,
 func init() {
 	groupGetCmd.Flags().StringSlice("name", []string{}, "filter groups by name")
 	groupGetCmd.Flags().StringSlice("tag", []string{}, "filter groups by tag")
-	groupGetCmd.Flags().StringP("output-format", "F", defaultOutputFormat, "format of output printed to standard output")
+	groupGetCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,yaml)")
 	groupCmd.AddCommand(groupGetCmd)
 }

--- a/cmd/smd-group-member-add.go
+++ b/cmd/smd-group-member-add.go
@@ -20,6 +20,7 @@ var groupMemberAddCmd = &cobra.Command{
 	Long: `Add one or more components to a group.
 
 See ochami-smd(1) for more details.`,
+	Example: `  ochami smd group member add compute x3000c1s7b56n0`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)

--- a/cmd/smd-group-member-delete.go
+++ b/cmd/smd-group-member-delete.go
@@ -20,6 +20,7 @@ var groupMemberDeleteCmd = &cobra.Command{
 	Long: `Delete one or more members froma group.
 
 See ochami-smd(1) for more details.`,
+	Example: `  ochami smd group member delete compute x3000c1s7b56n0`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)

--- a/cmd/smd-group-member-get.go
+++ b/cmd/smd-group-member-get.go
@@ -21,6 +21,7 @@ var groupMemberGetCmd = &cobra.Command{
 	Long: `Get members of a group.
 
 See ochami-smd(1) for more details.`,
+	Example: `  ochami smd group member get compute`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Without a base URI, we cannot do anything
 		smdBaseURI, err := getBaseURISMD(cmd)
@@ -58,9 +59,9 @@ See ochami-smd(1) for more details.`,
 		}
 
 		// Print output
-		outFmt, err := cmd.Flags().GetString("output-format")
+		outFmt, err := cmd.Flags().GetString("format-output")
 		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+			log.Logger.Error().Err(err).Msg("failed to get value for --format-output")
 			logHelpError(cmd)
 			os.Exit(1)
 		}
@@ -75,6 +76,6 @@ See ochami-smd(1) for more details.`,
 }
 
 func init() {
-	groupMemberGetCmd.Flags().StringP("output-format", "F", defaultOutputFormat, "format of output printed to standard output")
+	groupMemberGetCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,yaml)")
 	groupMemberCmd.AddCommand(groupMemberGetCmd)
 }

--- a/cmd/smd-iface-get.go
+++ b/cmd/smd-iface-get.go
@@ -169,9 +169,9 @@ See ochami-smd(1) for more details.`,
 		}
 
 		// Print output
-		outFmt, err := cmd.Flags().GetString("output-format")
+		outFmt, err := cmd.Flags().GetString("format-output")
 		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+			log.Logger.Error().Err(err).Msg("failed to get value for --format-output")
 			logHelpError(cmd)
 			os.Exit(1)
 		}
@@ -195,7 +195,7 @@ func init() {
 	ifaceGetCmd.Flags().StringSlice("type", []string{}, "filter ethernet interfaces by type")
 	ifaceGetCmd.Flags().String("older-than", "", "filter ethernet interfaces by update time older than specified time (RFC3339-formatted)")
 	ifaceGetCmd.Flags().String("newer-than", "", "filter ethernet interfaces by update time older than specified time (RFC3339-formatted)")
-	ifaceGetCmd.Flags().StringP("output-format", "F", defaultOutputFormat, "format of output printed to standard output")
+	ifaceGetCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,yaml)")
 
 	ifaceGetCmd.MarkFlagsMutuallyExclusive("id", "mac")
 	ifaceGetCmd.MarkFlagsMutuallyExclusive("id", "ip")

--- a/cmd/smd-rfe-add.go
+++ b/cmd/smd-rfe-add.go
@@ -16,25 +16,48 @@ import (
 
 // rfeAddCmd represents the smd-rfe-add command
 var rfeAddCmd = &cobra.Command{
-	Use:   "add -f <payload_file> | (<xname> <name> <ip_addr> <mac_addr>)",
+	Use:   "add (-d (<payload_data> | @<payload_file>)) | (<xname> <name> <ip_addr> <mac_addr>)",
 	Args:  cobra.MaximumNArgs(4),
 	Short: "Add new redfish endpoint(s)",
-	Long: `Add new redfish endpoint(s). An xname, name, IP address, and MAC address are required
-unless -f is passed to read from a payload file. Specifying -f also is
-mutually exclusive with the other flags of this command and its arguments.
-If - is used as the argument to -f, the data is read from standard input.
+	Long: `Add new redfish endpoint(s). An xname, name, IP address, and MAC
+address are required. Alternatively, pass -d to pass raw
+payload data or (if flag argument starts with @) a file
+containing the payload data. -f can be specified to change
+the format of the input payload data ('json' by default),
+but the rules above still apply for the payload. If "-" is
+used as the input payload filename, the data is read from
+standard input.
 
 This command sends a POST to SMD. An access token is required.
 
 See ochami-smd(1) for more details.`,
-	Example: `  ochami smd rfe add x3000c1s7b56 bmc-node56 172.16.0.156 de:ca:fc:0f:fe:ee
-  ochami smd rfe add -f payload.json
-  ochami smd rfe add -f payload.yaml --payload-format yaml
-  echo '<json_data>' | ochami smd rfe add -f -
-  echo '<yaml_data>' | ochami smd rfe add -f - --payload-format yaml`,
+	Example: `  # Add redfish endpoint using CLI flags
+  ochami smd rfe add x3000c1s7b56 bmc-node56 172.16.0.156 de:ca:fc:0f:fe:ee
+
+  # Add redfish endpoints using input payload data
+  ochami smd rfe add -d '{
+    "RedfishEndpoints": [
+      {
+        "ID": "x3000c1s7b56",
+	"Type": "NodeBMC",
+	"Name": "bmc-node56",
+	"IPAddress": "172.16.0.156",
+	"MACAddr": "de:ca:fc:0f:fe:ee",
+	"Enabled": true
+      }
+    ]
+  }'
+
+  # Add redfish endpoints using input payload file
+  ochami smd rfe add -f @payload.json
+  ochami smd rfe add -f @payload.yaml -f yaml
+
+  # Add redfish endpoints using data from standard input
+  echo '<json_data>' | ochami smd rfe add -d @-
+  echo '<yaml_data>' | ochami smd rfe add -d @- -f yaml`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// Check that all required args are passed
-		if len(args) == 0 && !cmd.Flag("payload").Changed {
+		if len(args) == 0 && !cmd.Flag("data").Changed {
 			printUsageHandleError(cmd)
 			os.Exit(0)
 		} else if len(args) > 4 {
@@ -68,7 +91,7 @@ See ochami-smd(1) for more details.`,
 		useCACert(smdClient.OchamiClient)
 
 		var rfes smd.RedfishEndpointSlice
-		if cmd.Flag("payload").Changed {
+		if cmd.Flag("data").Changed {
 			// Use payload file if passed
 			handlePayload(cmd, &rfes.RedfishEndpoints)
 		} else {
@@ -143,13 +166,13 @@ func init() {
 	rfeAddCmd.Flags().String("hostname", "", "hostname of redfish endpoint's FQDN")
 	rfeAddCmd.Flags().String("username", "", "username to use when interrogating endpoint")
 	rfeAddCmd.Flags().String("password", "", "password to use when interrogating endpoint")
-	rfeAddCmd.Flags().StringP("payload", "f", "", "file containing the request payload; JSON format unless --payload-format specified")
-	rfeAddCmd.Flags().StringP("payload-format", "F", defaultPayloadFormat, "format of payload file (yaml,json) passed with --payload")
+	rfeAddCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
+	rfeAddCmd.Flags().StringP("format-input", "f", defaultInputFormat, "format of input payload data (json,yaml)")
 
-	rfeAddCmd.MarkFlagsMutuallyExclusive("domain", "payload")
-	rfeAddCmd.MarkFlagsMutuallyExclusive("hostname", "payload")
-	rfeAddCmd.MarkFlagsMutuallyExclusive("username", "payload")
-	rfeAddCmd.MarkFlagsMutuallyExclusive("password", "payload")
+	rfeAddCmd.MarkFlagsMutuallyExclusive("domain", "data")
+	rfeAddCmd.MarkFlagsMutuallyExclusive("hostname", "data")
+	rfeAddCmd.MarkFlagsMutuallyExclusive("username", "data")
+	rfeAddCmd.MarkFlagsMutuallyExclusive("password", "data")
 
 	rfeCmd.AddCommand(rfeAddCmd)
 }

--- a/cmd/smd-rfe-get.go
+++ b/cmd/smd-rfe-get.go
@@ -133,9 +133,9 @@ See ochami-smd(1) for more details.`,
 		}
 
 		// Print output
-		outFmt, err := cmd.Flags().GetString("output-format")
+		outFmt, err := cmd.Flags().GetString("format-output")
 		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+			log.Logger.Error().Err(err).Msg("failed to get value for --format-output")
 			logHelpError(cmd)
 			os.Exit(1)
 		}
@@ -156,6 +156,6 @@ func init() {
 	rfeGetCmd.Flags().StringSlice("uuid", []string{}, "filter redfish endpoints by UUID")
 	rfeGetCmd.Flags().StringSliceP("mac", "m", []string{}, "filter redfish endpoints by MAC address")
 	rfeGetCmd.Flags().StringSliceP("ip", "i", []string{}, "filter redfish endpoints by IP address")
-	rfeGetCmd.Flags().StringP("output-format", "F", defaultOutputFormat, "format of output printed to standard output")
+	rfeGetCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,yaml)")
 	rfeCmd.AddCommand(rfeGetCmd)
 }

--- a/cmd/smd-status.go
+++ b/cmd/smd-status.go
@@ -59,9 +59,9 @@ See ochami-smd(1) for more details.`,
 		}
 
 		// Print output
-		outFmt, err := cmd.Flags().GetString("output-format")
+		outFmt, err := cmd.Flags().GetString("format-output")
 		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get value for --output-format")
+			log.Logger.Error().Err(err).Msg("failed to get value for --format-output")
 			logHelpError(cmd)
 			os.Exit(1)
 		}
@@ -78,6 +78,6 @@ See ochami-smd(1) for more details.`,
 func init() {
 	smdStatusCmd.Flags().Bool("all", false, "print all status data from SMD")
 
-	smdStatusCmd.Flags().StringP("output-format", "F", defaultOutputFormat, "format of output printed to standard output")
+	smdStatusCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,yaml)")
 	smdCmd.AddCommand(smdStatusCmd)
 }

--- a/man/ochami-bss.1.sc
+++ b/man/ochami-bss.1.sc
@@ -6,7 +6,8 @@ ochami-bss - Communicate with the Boot Script Service (BSS)
 
 # SYNOPSIS
 
-ochami bss [OPTIONS] COMMAND
+ochami bss boot params (add | delete | get | set | update) [OPTIONS]
+ochami bss boot script get [OPTIONS]
 
 # DATA STRUCTURE
 
@@ -47,8 +48,9 @@ Manage boot parameters for components.
 Subcommands for this command are as follows:
 
 *add* ([--mac _mac_,...] [--nid _nid_,...] [--xname _xname_,...]) ([--initrd _initrd_] [--kernel _kernel_])++
-*add* -f _file_ [-F _format_]++
-*add* -f _-_ [-F _format_] < _file_
+*add* -d _data_ [-f _format_]++
+*add* -d @_file_ [-f _format_]++
+*add* -d @- [-f _format_] < _file_
 	Add new boot parameters for one or more components. If boot parameters
 	already exist for the specified components, this command will fail.
 
@@ -60,24 +62,28 @@ Subcommands for this command are as follows:
 	flag multiple times (e.g. *--mac* _mac1_ *--mac* _mac2_) or by using one
 	flag and separating each argument by commas (e.g. *--mac* _mac1_,_mac2_).
 
-	In the second form of the command, a file containing the payload data is
+	In the second form of the command, raw data is passed as an argument to be
+	the payload.
+
+	In the third form of the command, a file containing the payload data is
 	passed. This is convenient in cases of dealing with many components at once.
 
-	In the third form of the command, the payload data is read from standard
+	In the fourth form of the command, the payload data is read from standard
 	input.
 
 	This command sends a POST request to BSS's /bootparameters endpoint.
 
 	This command accepts the following options:
 
-	*-f, --payload* _file_
-		Specify a file containing the data to send to BSS. The format of this
-		file depends on _-F_ and is _json_ by default. If *-* is used as the
-		argument to _-f_, the command reads the payload data from standard
-		input.
+	*-d, --data* (_data_ | @_path_ | @-)
+		Specify raw _data_ to send, the _path_ to a file to read payload data
+		from, or to read the data from standard input (@-). The format of data
+		read in any of these forms is JSON by default unless *-f* is specified
+		to change it.
 
-	*-F, --payload-format* _format_
-		Format of the file used with _-f_. Supported formats are:
+	*-f, --format-input* _format_
+		Format of raw data being used by *-d* as the payload. Supported formats
+		are:
 
 		- _json_ (default)
 		- _yaml_
@@ -108,8 +114,9 @@ Subcommands for this command are as follows:
 		Command line arguments to pass to kernel for components.
 
 *delete* [--force] ([--mac, _mac_,...] [--nid, _nid_,...] [--xname _xname_,...] [--kernel _kernel_] [--initrd _initrd_])++
-*delete* [--force] -f _file_ [-F _format_]++
-*delete* [--force] -f _-_ [-F _format_]
+*delete* [--force] -d _data_ [-f _format_]++
+*delete* [--force] -d @_file_ [-f _format_]++
+*delete* [--force] -d @- [-f _format_]
 	Delete boot parameters for one or more components. Which boot parameters are
 	deleted are determined by passed filters, which can be passed via CLI flag
 	or within a payload file. Unless *--force* is passed, the user is asked to
@@ -122,27 +129,31 @@ Subcommands for this command are as follows:
 	times (e.g. *--mac* _mac1_ *--mac* _mac2_) or by using one flag and
 	separating each argument by commas (e.g. *--mac* _mac1_,_mac2_).
 
-	In the second form of the command, a file containing the payload data is
+	In the second form of the command, raw data is passed as an argument to be
+	the payload.
+
+	In the third form of the command, a file containing the payload data is
 	passed. This is convenient in cases of dealing with many components at once.
 
-	In the third form of the command, the payload data is read from standard
+	In the fourth form of the command, the payload data is read from standard
 	input.
 
 	This command sends a DELETE request to BSS's /bootparameters endoint.
 
 	This command accepts the following options:
 
+	*-d, --data* (_data_ | @_path_ | @-)
+		Specify raw _data_ to send, the _path_ to a file to read payload data
+		from, or to read the data from standard input (@-). The format of data
+		read in any of these forms is JSON by default unless *-f* is specified
+		to change it.
+
 	*--force*
 		Do not ask the user to confirm deletion. Use with caution.
 
-	*-f, --payload* _file_
-		Specify a file containing the data to send to BSS. The format of this
-		file depends on _-F_ and is _json_ by default. If *-* is used as the
-		argument to _-f_, the command reads the payload data from standard
-		input.
-
-	*-F, --payload-format* _format_
-		Format of the file used with _-f_. Supported formats are:
+	*-f, --format-input* _format_
+		Format of raw data being used by *-d* as the payload. Supported formats
+		are:
 
 		- _json_ (default)
 		- _yaml_
@@ -172,7 +183,7 @@ Subcommands for this command are as follows:
 	*--params* _kernel_params_
 		Command line arguments to pass to kernel for components.
 
-*get* [--output-format _format_] [--mac _mac_,...] [--nid _nid_,...] [--xname _xname_,...]
+*get* [-F _format_] [--mac _mac_,...] [--nid _nid_,...] [--xname _xname_,...]
 	Get boot parameters for all components or a subset of components, filtered
 	by MAC address, node ID, and/or xname.
 
@@ -180,7 +191,7 @@ Subcommands for this command are as follows:
 
 	This command accepts the following options:
 
-	*-F, --output-format* _format_
+	*-F, --format-output* _format_
 		Output response data in specified _format_. Supported values are:
 
 		- _json_ (default)
@@ -203,8 +214,9 @@ Subcommands for this command are as follows:
 		specified once and multiple xnames, separated by commas.
 
 *set* ([--mac _mac_,...] [--nid _nid_,...] [--xname _xname_,...]) ([--initrd _initrd_] [--kernel _kernel_])++
-*set* -f _file_ [-F _format_]++
-*set* -f _-_ [-F _format_] < _file_
+*set* -d _data_ [-f _format_]++
+*set* -d @_file_ [-f _format_]++
+*set* -d @- [-f _format_] < _file_
 	Set boot parameters for one or more components, even if boot parameters
 	already exist for said components. This is handy if one knows what boot
 	parameters to set for which components, but isn't sure if boot parameters
@@ -218,26 +230,30 @@ Subcommands for this command are as follows:
 	flag multiple times (e.g. *--mac* _mac1_ *--mac* _mac2_) or by using one
 	flag and separating each argument by commas (e.g. *--mac* _mac1_,_mac2_).
 
-	In the second form of the command, a file containing the payload data is
+	In the second form of the command, raw data is passed as an argument to be
+	the payload.
+
+	In the third form of the command, a file containing the payload data is
 	passed. This is convenient in cases of dealing with many components at once.
 
-	In the third form of the command, the payload data is read from standard
+	In the fourth form of the command, the payload data is read from standard
 	input.
 
 	This command sends a PUT request to BSS's /bootparameters endpoint.
 
 	This command accepts the following options:
 
-	*-f, --payload* _file_
-		Specify a file containing the data to send to BSS. The format of this
-		file depends on _-F_ and is _json_ by default. If *-* is used as the
-		argument to _-f_, the command reads the payload data from standard
-		input.
+	*-d, --data* (_data_ | @_path_ | @-)
+		Specify raw _data_ to send, the _path_ to a file to read payload data
+		from, or to read the data from standard input (@-). The format of data
+		read in any of these forms is JSON by default unless *-f* is specified
+		to change it.
 
-	*-F, --payload-format* _format_
-		Format of the file used with _-f_. If unspecified, the payload format is
-		_json_ by default. Supported formats are:
+	*-f, --format-input* _format_
+		Format of raw data being used by *-d* as the payload. Supported formats
+		are:
 
+		- _json_ (default)
 		- _yaml_
 
 	*-m, --mac* _mac_addr_,...
@@ -266,8 +282,9 @@ Subcommands for this command are as follows:
 		Command line arguments to pass to kernel for components.
 
 *update* ([--mac _mac_,...] [--nid _nid_,...] [--xname _xname_,...]) ([--initrd _initrd_] [--kernel _kernel_])++
-*update* -f _file_ [-F _format_]++
-*update* -f _-_ [-F _format_] < _file_
+*update* -d _data_ [-f _format_]++
+*update* -d @_file_ [-f _format_]++
+*update* -d @- [-f _format_] < _file_
 	Update boot parameters for existing components.
 
 	In the first form of the command, one or more of *--mac*, *--nid*, or
@@ -278,26 +295,30 @@ Subcommands for this command are as follows:
 	the flag multiple times (e.g. *--mac* _mac1_ *--mac* _mac2_) or by using one
 	flag and separating each argument by commas (e.g. *--mac* _mac1_,_mac2_).
 
-	In the second form of the command, a file containing the payload data is
+	In the second form of the command, raw data is passed as an argument to be
+	the payload.
+
+	In the third form of the command, a file containing the payload data is
 	passed. This is convenient in cases of dealing with many components at once.
 
-	In the third form of the command, the payload data is read from standard
+	In the fourth form of the command, the payload data is read from standard
 	input.
 
 	This command sends a PUT request to BSS's /bootparameters endpoint.
 
 	This command accepts the following options:
 
-	*-f, --payload* _file_
-		Specify a file containing the data to send to BSS. The format of this
-		file depends on _-F_ and is _json_ by default. If *-* is used as the
-		argument to _-f_, the command reads the payload data from standard
-		input.
+	*-d, --data* (_data_ | @_path_ | @-)
+		Specify raw _data_ to send, the _path_ to a file to read payload data
+		from, or to read the data from standard input (@-). The format of data
+		read in any of these forms is JSON by default unless *-f* is specified
+		to change it.
 
-	*-F, --payload-format* _format_
-		Format of the file used with _-f_. If unspecified, the payload format is
-		_json_ by default. Supported formats are:
+	*-f, --format-input* _format_
+		Format of raw data being used by *-d* as the payload. Supported formats
+		are:
 
+		- _json_ (default)
 		- _yaml_
 
 	*-m, --mac* _mac_addr_,...
@@ -358,13 +379,13 @@ components list.
 
 The format of this command is:
 
-*dumpstate* [--output-format _format_]
+*dumpstate* [-F _format_]
 
 This command sends a GET to BSS's /dumpstate endpoint.
 
 This command accepts the following options:
 
-*-F, --output-format* _format_
+*-F, --format-output* _format_
 	Output response data in specified _format_. Supported values are:
 
 	- _json_ (default)
@@ -378,13 +399,13 @@ to BSS endpoints with UNIX timestamps. Output can be filtered by component name
 
 The format of the command is:
 
-*history* [--output-format _format_] [--xname _xname_,...] [--endpoint _endpoint_,...]
+*history* [-F _format_] [--xname _xname_,...] [--endpoint _endpoint_,...]
 
 This command sends a GET to BSS's /endpoint-history endpoint.
 
 This command accepts the following options:
 
-*-F, --output-format* _format_
+*-F, --format-output* _format_
 	Output response data in specified _format_. Supported values are:
 
 	- _json_ (default)
@@ -407,7 +428,7 @@ Work with hosts in BSS.
 
 Subcommands for this command are as follows:
 
-*get* [--output-format _format_ ] [--mac _mac_,...] [--nid _nid_,...] [--xname _xname_,...]
+*get* [-F _format_ ] [--mac _mac_,...] [--nid _nid_,...] [--xname _xname_,...]
 	Get a list of hosts that BSS knows about that are in SMD. These results can
 	be optionally filtered by MAC address, node ID, or xname. If no filters are
 	specified, all results are returned.
@@ -416,7 +437,7 @@ Subcommands for this command are as follows:
 
 	This command accepts the following options:
 
-	*-F, --output-format* _format_
+	*-F, --format-output* _format_
 		Output response data in specified _format_. Supported values are:
 
 		- _json_ (default)
@@ -445,7 +466,7 @@ connected to SMD, or checking the storage backend type/connection status.
 
 The format of this command is:
 
-*status* [--output-format _format_] [--all | --smd | --storage | --version]
+*status* [-F _format_] [--all | --smd | --storage | --version]
 
 This command sends a GET to endpoints under BSS's /service endpoint.
 
@@ -454,7 +475,7 @@ This command accepts the following options:
 *--all*
 	Print out all of the status information BSS knows about.
 
-*-F, --output-format* _format_
+*-F, --format-output* _format_
 	Output response data in specified _format_. Supported values are:
 
 	- _json_ (default)

--- a/man/ochami-cloud-init.1.sc
+++ b/man/ochami-cloud-init.1.sc
@@ -6,11 +6,11 @@ ochami-cloud-init - Communicate with the cloud-init server
 
 # SYNOPSIS
 
-ochami cloud-init [--secure] config add [OPTIONS] (-f _payload_file_ | -d _json_data_)++
-ochami cloud-init [--secure] config delete [OPTIONS] [--force] _id_...++
-ochami cloud-init [--secure] config get [OPTIONS] [-F _format_] [_id_...]++
-ochami cloud-init [--secure] config add [OPTIONS] (-f _payload_file_ | -d _json_data_)++
-ochami cloud-init [--secure] data get [OPTIONS] [--meta | --user | --vendor] _id_...
+ochami cloud-init [--secure] config add [OPTIONS] -d (_payload_data_ | @_payload_file_ | @-)++
+ochami cloud-init [--secure] config delete [OPTIONS] _id_...++
+ochami cloud-init [--secure] config get [OPTIONS] [_id_...]++
+ochami cloud-init [--secure] config add [OPTIONS] -d (_payload_data_ | @_payload_file_ | @-)++
+ochami cloud-init [--secure] data get [OPTIONS] _id_...
 
 # DATA STRUCTURE
 
@@ -82,9 +82,9 @@ data to serve to which clients.
 
 Subcommands for this command are as follows:
 
-*add* --payload _payload_file_ [-F _format_]++
-*add* --payload _-_ [-F _format_] < _file_++
-*add* --data _raw_data_
+*add* -d @_file_ [-f _format_]++
+*add* -d @- [-f _format_] < _file_++
+*add* -d _data_
 	Add cloud-init configuration for one or more IDs. This command only accepts
 	payload data and uses the *name* field to determine which ID to add the data
 	for.
@@ -104,18 +104,15 @@ Subcommands for this command are as follows:
 
 	This command accepts the following options:
 
-	*-d, --data* _raw_data_
-		Pass the payload as raw data on the command line. Data is provided to
-		the server exactly as passed on the command line.
+	*-d, --data* (_data_ | @_path_ | @-)
+		Specify raw _data_ to send, the _path_ to a file to read payload data
+		from, or to read the data from standard input (@-). The format of data
+		read in any of these forms is JSON by default unless *-f* is specified
+		to change it.
 
-	*-f, --payload* _file_
-		Specify a file containing the data to send to cloud-init. The format of
-		this file depends on _-F_ and is _json_ by default. If *-* is used as
-		the argument to _-f_, the command reads the payload data from standard
-		input.
-
-	*F, --payload-format* _format_
-		Format of the file used with _-f_. Supported formats are:
+	*-f, --format-input* _format_
+		Format of raw data being used by *-d* as the payload. Supported formats
+		are:
 
 		- _json_ (default)
 		- _yaml_
@@ -131,7 +128,7 @@ Subcommands for this command are as follows:
 	*--force*
 		Do not ask the user to confirm deletion. Use with caution.
 
-*get* [--output-format _format_] [_id_...]
+*get* [--format-output _format_] [_id_...]
 	Get cloud-init configuration for one or more _id_. If no IDs are specified,
 	all cloud-init configurations are retrieved.
 
@@ -140,7 +137,7 @@ Subcommands for this command are as follows:
 
 	This command accepts the following options:
 
-	*-F, --output-format* _format_
+	*-F, --format-output* _format_
 		Format the response output as _format_.
 
 		Supported values are:
@@ -148,9 +145,9 @@ Subcommands for this command are as follows:
 		- _json_ (default)
 		- _yaml_
 
-*update* --payload _payload_file_ [-F _format_]++
-*update* --payload _-_ [-F _format_] < _file_++
-*update* --data _raw_data_
+*update* -d @_file_ [-f _format_]++
+*update* -d @- [-f _format_] < _file_++
+*update* -d _data_
 	Update one or more existing cloud-init configurations. This command only
 	accepts payload data and uses the *name* field to determine which ID to
 	update.
@@ -170,18 +167,15 @@ Subcommands for this command are as follows:
 
 	This command accepts the following options:
 
-	*-d, --data* _raw_data_
-		Pass the payload as raw data on the command line. Data is provided to
-		the server exactly as passed on the command line.
+	*-d, --data* (_data_ | @_path_ | @-)
+		Specify raw _data_ to send, the _path_ to a file to read payload data
+		from, or to read the data from standard input (@-). The format of data
+		read in any of these forms is JSON by default unless *-f* is specified
+		to change it.
 
-	*-f, --payload* _file_
-		Specify a file containing the data to send to cloud-init. The format of
-		this file depends on _-F_ and is _json_ by default. If *-* is used as
-		the argument to _-f_, the command reads the payload data from standard
-		input.
-
-	*-F, --payload-format* _format_
-		Format of the file used with _-f_. Supported formats are:
+	*-f, --format-input* _format_
+		Format of raw data being used by *-d* as the payload. Supported formats
+		are:
 
 		- _json_ (default)
 		- _yaml_
@@ -195,7 +189,8 @@ client when requesting its data. There are three types of data: *user-data*,
 Subcommands for this command are as follows:
 
 *get* [--meta | --user | --vendor] _id_...
-	Get cloud-init data for one or more _id_. By default, or if *--user* is passed, cloud-init user-data is retrieved.
+	Get cloud-init data for one or more _id_. By default, or if *--user* is
+	passed, cloud-init user-data is retrieved.
 
 	This command accepts the following options:
 

--- a/man/ochami-discover.1.sc
+++ b/man/ochami-discover.1.sc
@@ -6,7 +6,7 @@ ochami-discover - Populate SMD using a file
 
 # SYNOPSIS
 
-ochami discover [OPTIONS] -f _file_ [-F _format_]
+ochami discover [OPTIONS] -d (_data_ | @_file_ | @-) [-f _format_]
 
 # DESCRIPTION
 
@@ -28,22 +28,23 @@ node's BMC which corresponds to each RedfishEndpoint created.
 
 This command accepts the following options:
 
-*--overwrite*
-	Instead of failing if data already exists, overwrite it with new data
-	contained in the payload.
-
-*-f, --payload* _file_
+*-d, --data* (_data_ | @_path_ | @-)
 	This option is mandatory.
 
-	Specify a file containing the data to send to SMD. The format of this
-	file depends on _-F_ and is _json_ by default. If *-* is used as the
-	argument to _-f_, the command reads the payload data from standard input.
+	Specify raw _data_ to send, the _path_ to a file to read payload data from,
+	or to read the data from standard input (@-). The format of data read in any
+	of these forms is JSON by default unless *-f* is specified to change it.
 
-*-F, --payload-format* _format_
-	Format of the file used with _-f_. Supported formats are:
+*-f, --format-input* _format_
+	Format of raw data being used by *-d* as the payload. Supported formats
+	are:
 
 	- _json_ (default)
 	- _yaml_
+
+*--overwrite*
+	Instead of failing if data already exists, overwrite it with new data
+	contained in the payload.
 
 # DATA STRUCTURE
 

--- a/man/ochami-pcs.1.sc
+++ b/man/ochami-pcs.1.sc
@@ -48,7 +48,7 @@ connected to SMD, or checking the storage backend connection status.
 
 The format of this command is:
 
-*status* [--output-format _format_] [--all | --smd | --storage | --vault]
+*status* [-F _format_] [--all | --smd | --storage | --vault]
 
 This command sends a GET to PCS's /readiness or /health endpoints.
 
@@ -57,7 +57,7 @@ This command accepts the following options:
 *--all*
 	Print out all of the status information PCS knows about.
 
-*-F, --output-format* _format_
+*-F, --format-output* _format_
 	Output response data in specified _format_. Supported values are:
 
 	- _json_ (default)

--- a/man/ochami-smd.1.sc
+++ b/man/ochami-smd.1.sc
@@ -238,8 +238,9 @@ Subcommands for this command are as follows:
 
 *delete* [--force] --all++
 *delete* [--force] _xname_...++
-*delete* [--force] -f _file_ [-F _format_]++
-*delete* [--force] -f _-_ [-F _format_]
+*delete* [--force] -d _data_ [-f _format_]++
+*delete* [--force] -d @_file_ [-f _format_]++
+*delete* [--force] -d @- [-f _format_]
 	Delete one or more component endpoints. Unless *--force* is passed, the user
 	is asked to confirm deletion.
 
@@ -249,11 +250,14 @@ Subcommands for this command are as follows:
 	In the second form of the command, one or more xnames identifying the
 	component(s) whose component endpoint(s) to delete is/are specified.
 
-	In the third form of the command, a file containing the payload data (see
+	In the third form of the command, raw data is passed as an argument to be
+	the payload.
+
+	In the fourth form of the command, a file containing the payload data (see
 	the *ComponentEndpoint* data structure above) is passed. This is convenient
 	in cases of dealing with many component endpoints at once.
 
-	In the fourth form of the command, the payload data is read from standard
+	In the fifth form of the command, the payload data is read from standard
 	input.
 
 	This command sends one or more DELETE requests to SMD's /ComponentEndpoints
@@ -264,22 +268,23 @@ Subcommands for this command are as follows:
 	*-a, --all*
 		Delete *all* component endpoints in SMD. *BE CAREFUL!*
 
+	*-d, --data* (_data_ | @_path_ | @-)
+		Specify raw _data_ to send, the _path_ to a file to read payload data
+		from, or to read the data from standard input (@-). The format of data
+		read in any of these forms is JSON by default unless *-f* is specified
+		to change it.
+
 	*--force*
 		Do not ask the user to confirm deletion. Use with caution.
 
-	*-f, --payload* _file_
-		Specify a file containing the data to send to SMD. The format of this
-		file depends on _-F_ and is _json_ by default. If *-* is used as the
-		argument to _-f_, the command reads the payload data from standard
-		input.
-
-	*-F, --payload-format* _format_
-		Format of the file used with _-f_. Supported formats are:
+	*-f, --format-input* _format_
+		Format of raw data being used by *-d* as the payload. Supported formats
+		are:
 
 		- _json_ (default)
 		- _yaml_
 
-*get* [--output-format _format_] [_xname_]...
+*get* [-F _format_] [_xname_]...
 	Get all or a subset of component endpoints.
 
 	If no arguments are passed, all component endpoints are returned. Otherwise,
@@ -289,7 +294,7 @@ Subcommands for this command are as follows:
 
 	This command accepts the following options:
 
-	*-F, --output-format* _format_
+	*-F, --format-output* _format_
 		Output response data in specified _format_. Supported values are:
 
 		- _json_ (default)
@@ -302,8 +307,9 @@ Manage components.
 Subcommands for this command are as follows:
 
 *add* [--arch _arch_] [--enabled] [--role _role_] [--state _state_] _xname_ _node_id_++
-*add* -f _file_ [-F _format_]++
-*add* -f _-_ [-F _format_]
+*add* -d _data_ [-f _format_]++
+*add* -d @_file_ [-f _format_]++
+*add* -d @- [-f _format_]
 	Add one or more new components to SMD. If a component already exists with
 	the same xname, this command will fail.
 
@@ -312,10 +318,13 @@ Subcommands for this command are as follows:
 	*--role*, or *--state* can optionally be specified to specify details of the
 	component.
 
-	In the second form of the command, a file containing the payload data is
+	In the second form of the command, raw data is passed as an argument to be
+	the payload.
+
+	In the third form of the command, a file containing the payload data is
 	passed. This is convenient in cases of dealing with many components at once.
 
-	In the third form of the command, the payload data is read from standard
+	In the fourth form of the command, the payload data is read from standard
 	input.
 
 	This command sends a POST request to SMD's /Components endpoint.
@@ -327,19 +336,20 @@ Subcommands for this command are as follows:
 
 		Default: *X86*
 
+	*-d, --data* (_data_ | @_path_ | @-)
+		Specify raw _data_ to send, the _path_ to a file to read payload data
+		from, or to read the data from standard input (@-). The format of data
+		read in any of these forms is JSON by default unless *-f* is specified
+		to change it.
+
 	*--enabled*
 		Specify if component is shows up as enabled in SMD.
 
 		Default: *true*
 
-	*-f, --payload* _file_
-		Specify a file containing the data to send to SMD. The format of this
-		file depends on _-F_ and is _json_ by default. If *-* is used as the
-		argument to _-f_, the command reads the payload data from standard
-		input.
-
-	*-F, --payload-format* _format_
-		Format of the file used with _-f_. Supported formats are:
+	*-f, --format-input* _format_
+		Format of raw data being used by *-d* as the payload. Supported formats
+		are:
 
 		- _json_ (default)
 		- _yaml_
@@ -356,8 +366,9 @@ Subcommands for this command are as follows:
 
 *delete* --all++
 *delete* _xname_...++
-*delete* -f _file_ [-F _format_]++
-*delete* -f _-_ [-F _format_]
+*delete* -d _data_ [-f _format_]++
+*delete* -d @_file_ [-f _format_]++
+*delete* -d @- [-f _format_]
 	Delete one or more components in SMD. Unless *--force* is passed, the user
 	is asked to confirm deletion.
 
@@ -366,11 +377,14 @@ Subcommands for this command are as follows:
 	In the second form of the command, one or more xnames identifying the
 	component(s) to delete is/are specified.
 
-	In the third form of the command, a file containing the payload data (see
+	In the third form of the command, raw data is passed as an argument to be
+	the payload.
+
+	In the fourth form of the command, a file containing the payload data (see
 	the *Component* data structure above) is passed. This is convenient in cases
 	of dealing with many components at once.
 
-	In the fourth form of the command, the payload is read from standard input.
+	In the fifth form of the command, the payload is read from standard input.
 
 	This command sends one or more DELETE requests to SMD's /Components
 	endpoint.
@@ -380,22 +394,23 @@ Subcommands for this command are as follows:
 	*-a, --all*
 		Delete *all* components in SMD. *BE CAREFUL!*
 
+	*-d, --data* (_data_ | @_path_ | @-)
+		Specify raw _data_ to send, the _path_ to a file to read payload data
+		from, or to read the data from standard input (@-). The format of data
+		read in any of these forms is JSON by default unless *-f* is specified
+		to change it.
+
 	*--force*
 		Do not ask the user to confirm deletion. Use with caution.
 
-	*-f, --payload* _file_
-		Specify a file containing the data to send to SMD. The format of this
-		file depends on _-F_ and is _json_ by default. If *-* is used as the
-		argument to _-f_, the command reads the payload data from standard
-		input.
-
-	*-F, --payload-format* _format_
-		Format of the file used with _-f_. Supported formats are:
+	*-f, --format-input* _format_
+		Format of raw data being used by *-d* as the payload. Supported formats
+		are:
 
 		- _json_ (default)
 		- _yaml_
 
-*get* [--output-format _format_] [--nid _nid_] [--xname _xname_]
+*get* [-F _format_] [--nid _nid_] [--xname _xname_]
 	Get all components or one identified by xname or node ID.
 
 	If no filter flags are passed, all components are returned. Otherwise, the
@@ -405,7 +420,7 @@ Subcommands for this command are as follows:
 
 	This command accepts the following options:
 
-	*-f, --output-format* _format_
+	*-F, --format-output* _format_
 		Output response data in specified _format_. Supported values are:
 
 		- _json_ (default)
@@ -428,8 +443,9 @@ Manage SMD groups. For managing group membership, see *group member* below.
 Subcommands for this command are as follows:
 
 *add* [--description _desc_] [--tag _tag_,...] [--member _xname_,...] [--exclusive-group _group_] _group_name_++
-*add* -f _file_ [-F _format_]++
-*add* -f _-_ [-F _format_]
+*add* -d _data_ [-f _format_]++
+*add* -d @_file_ [-f _format_]++
+*add* -d @- [-f _format_]
 	Add a new group to SMD, optionally specifying members to add to the group.
 
 	In the first form of the command, a _group_name_ is required to create the
@@ -439,17 +455,26 @@ Subcommands for this command are as follows:
 	passing *--tag*. Finally, the group can be set to be mutually exclusive with
 	another group by passing *--exclusive-group*.
 
-	In the second form of the command, a file containing the payload data is
+	In the second form of the command, raw data is passed as an argument to be
+	the payload.
+
+	In the third form of the command, a file containing the payload data is
 	passed. This is convenient in cases of dealing with many groups at once.
 
-	In the third form of the command, the payload data is read from standard
+	In the fourth form of the command, the payload data is read from standard
 	input.
 
 	This command sends one or more POST requests to SMD's /groups endpoint.
 
 	This command accepts the following options:
 
-	*-d, --description* _description_
+	*-d, --data* (_data_ | @_path_ | @-)
+		Specify raw _data_ to send, the _path_ to a file to read payload data
+		from, or to read the data from standard input (@-). The format of data
+		read in any of these forms is JSON by default unless *-f* is specified
+		to change it.
+
+	*-D, --description* _description_
 		Specify a brief description of the group.
 
 		Default: *The <group_name> group*
@@ -459,23 +484,18 @@ Subcommands for this command are as follows:
 		exclusive with. In other words, components in this group cannot also be
 		a member of the specified exclusive group.
 
+	*-f, --format-input* _format_
+		Format of raw data being used by *-d* as the payload. Supported formats
+		are:
+
+		- _json_ (default)
+		- _yaml_
+
 	*-m, --member* _xname_,...
 		One or more component IDs (xnames) to add to the group. For multiple
 		components, either this flag can be specified multiple times or this
 		flag can be specified once and multiple component IDs can be specified,
 		separated by commas.
-
-	*-f, --payload* _file_
-		Specify a file containing the data to send to SMD. The format of this
-		file depends on _-F_ and is _json_ by default. If *-* is used as the
-		argument to _-f_, the command reads the payload data from standard
-		input.
-
-	*-F, --payload-format* _format_
-		Format of the file used with _-f_. Supported formats are:
-
-		- _json_ (default)
-		- _yaml_
 
 	*--tag* _tag_,...
 		One or more tags to assign to the group. For multiple tags, either this
@@ -483,40 +503,45 @@ Subcommands for this command are as follows:
 		and multiple tags can be specified, separated by commas.
 
 *delete* [--force] _group_name_...++
-*delete* [--force] -f _file_ [-F _format_]++
-*delete* [--force] -f _-_ [-F _format_]
+*delete* [--force] -d _data_ [-f _format_]++
+*delete* [--force] -d @_file_ [-f _format_]++
+*delete* [--force] -d @- [-f _format_]
 	Delete one or more groups in SMD. Unless *--force* is passed, the user is
 	asked to confirm deletion.
 
 	In the first form of the command, one or more group labels can be specified
 	to delete one or more groups.
 
-	In the second form of the command, a file containing the payload data is
+	In the second form of the command, raw data is passed as an argument to be
+	the payload.
+
+	In the third form of the command, a file containing the payload data is
 	passed. This is convenient in cases of dealing with many groups at once.
 
-	In the third form of the command, the payload data is read from standard
+	In the fourth form of the command, the payload data is read from standard
 	input.
 
 	This command sends one or more DELETE requests to SMD's /groups endpoint.
 
 	This command accepts the following options:
 
+	*-d, --data* (_data_ | @_path_ | @-)
+		Specify raw _data_ to send, the _path_ to a file to read payload data
+		from, or to read the data from standard input (@-). The format of data
+		read in any of these forms is JSON by default unless *-f* is specified
+		to change it.
+
 	*--force*
 		Do not ask the user to confirm deletion. Use with caution.
 
-	*-f, --payload* _file_
-		Specify a file containing the data to send to SMD. The format of this
-		file depends on _-F_ and is _json_ by default. If *-* is used as the
-		argument to _-f_, the command reads the payload data from standard
-		input.
-
-	*-F, --payload-format* _format_
-		Format of the file used with _-f_. Supported formats are:
+	*-f, --format-input* _format_
+		Format of raw data being used by *-d* as the payload. Supported formats
+		are:
 
 		- _json_ (default)
 		- _yaml_
 
-*get* [--output-format _format_] [--name _name_,...] [--tag _tag_,...]
+*get* [-F _format_] [--name _name_,...] [--tag _tag_,...]
 	Get group information for all groups in SMD or for a subset, specified by
 	filters.
 
@@ -524,7 +549,7 @@ Subcommands for this command are as follows:
 
 	This command accepts the following options:
 
-	*-f, --output-format* _format_
+	*-F, --format-output* _format_
 		Output response data in specified _format_. Supported values are:
 
 		- _json_ (default)
@@ -542,34 +567,40 @@ Subcommands for this command are as follows:
 		and multiple tags can be specified, separated by commas.
 
 *update* [--description _description_] [--tag _tag_,...] _group_name_++
-*update* -f _file_ [-F _format_]
+*update* -d _data_ [-f _format_]++
+*update* -d @_file_ [-f _format_]++
+*update* -d @- [-f _format_] < _file_
 	Update one or more existing groups in SMD. If the group does not already
 	exist, this command will fail.
 
 	In the first form of the command, a _group_name_ is required as well as at
 	least one of *--description* or *--tag*.
 
-	In the second form of the command, a file containing the payload data is
+	In the second form of the command, raw data is passed as an argument to be
+	the payload.
+
+	In the third form of the command, a file containing the payload data is
 	passed. This is convenient in cases of dealing with many groups at once.
 
-	In the third form of the command, the payload data is read from standard
+	In the fourth form of the command, the payload data is read from standard
 	input.
 
 	This command sends a PATCH  request to SMD's /groups endpoint.
 
 	This command accepts the following options:
 
-	*-d, --description* _description_
+	*-d, --data* (_data_ | @_path_ | @-)
+		Specify raw _data_ to send, the _path_ to a file to read payload data
+		from, or to read the data from standard input (@-). The format of data
+		read in any of these forms is JSON by default unless *-f* is specified
+		to change it.
+
+	*-D, --description* _description_
 		Specify a brief description of the group.
 
-	*-f, --payload* _file_
-		Specify a file containing the data to send to SMD. The format of this
-		file depends on _-F_ and is _json_ by default. If *-* is used as the
-		argument to _-f_, the command reads the payload data from standard
-		input.
-
-	*-F, --payload-format* _format_
-		Format of the file used with _-f_. Supported formats are:
+	*-f, --format-input* _format_
+		Format of raw data being used by *-d* as the payload. Supported formats
+		are:
 
 		- _json_ (default)
 		- _yaml_
@@ -599,7 +630,7 @@ Subcommands for this command are as follows:
 	This command sends one or more DELETE requests to the members subendpoint
 	under SMD's /groups endpoint.
 
-*get* [--output-format _format_] _group_name_
+*get* [-F _format_] _group_name_
 	Get members of an SMD group.
 
 	This command sends a GET request to the members subendpoint under SMD's
@@ -607,7 +638,7 @@ Subcommands for this command are as follows:
 
 	This command accepts the following options:
 
-	*-f, --output-format* _format_
+	*-F, --format-output* _format_
 		Output response data in specified _format_. Supported values are:
 
 		- _json_ (default)


### PR DESCRIPTION
This PR updates the flags for specifying payload data and format to be more consistent so that, no matter the command, the flags will be the same. It also updates the flag for reading the payload data to be more flexible and intuitive, following the style of cURL. Finally, the command examples in their usage messages are updated and expanded to include comments stating what the command examples do.

The `-f` flag was being used to pass the path to a file to read the payload from while `-F` was being used either to specify an input payload format or an output format, depending on the command. This can be a bit confusing, and having consistent and intuitive flag meanings would be desired.

Now, instead of:

```
-f/--payload --- Path to payload file
-F/--format  --- Format of payload file (POST/PUT/PATCH) or format of outpout (GET)
```

the flags are now:

```
-d/--data          --- Raw payload data or path to payload file
-f/--format-input  --- Format of input payload data
-F/--format-output --- Format of output data
```

The `-d` flag follows the curl paradigm of prepending the flag argument with `@` to denote that it is being passed a file path, which can be `-` to tell `ochami` to read the data from standard input. Importantly, input and output format are differentiated in the case that a command requires both.

**Example usage:**

Specifying input payload:

```
# Add components using input payload data
ochami smd component add -d '{
  "Components":[
    {
      "ID": "x3000c1s7b56n0",
      "NID": 56,
      "State": "Ready",
      "Role": "Compute",
      "Enabled": "True",
      "Arch": "X86"
    }
  ]
}'

# Add components using input payload file
ochami smd component add -d @payload.json
ochami smd component add -d @payload.yaml -f yaml

# Add components using data from standard input
echo '<json_data>' | ochami smd component add -d @-
echo '<yaml_data>' | ochami smd component add -d @- -f yaml
```

Specifying output format:

```
# Get components formatted as YAML instead of JSON
ochami smd component get -F yaml
```

BREAKING CHANGE: `-f/--payload` changed to `-d/--data`, format flags are now `-f/--format-input` and `-F/--format-output`