### PR TITLE
ci: use GitHub release notes and release as draft

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,10 @@ jobs:
         with:
           fetch-tags: 1
           fetch-depth: 0
+      - name: Generate release notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" -F tag_name="${{ github.ref_name }}" --jq .body > ../notes.md
       - name: Set build environment variables
         run: |
           echo GOVERSION=$(go env GOVERSION) >> $GITHUB_ENV
@@ -39,11 +43,11 @@ jobs:
       - name: Release with goreleaser
         uses: goreleaser/goreleaser-action@v6
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AUR_SSH_KEY: ${{ secrets.AUR_PRIVATE_KEY }}
         with:
           version: '~> v2'
-          args: release --clean
+          args: release --clean --release-notes ../notes.md
         id: goreleaser
       - name: Process goreleaser output
         id: process_goreleaser_output

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -187,30 +187,12 @@ docker_manifests:
 checksum:
   name_template: checksums.txt
 
-changelog:
-  sort: asc
-  use: github
-  groups:
-    - title: Features
-      regexp: '^.*?feat(\([[:print:]]+\))??!?:.+$'
-      order: 0
-    - title: Fixes
-      regexp: '^.*?fix(\([[:print:]]+\))??!?:.+$'
-      order: 1
-    - title: Documentation
-      regexp: '^.*?docs(\([[:print:]]+\))??!?:.+$'
-      order: 2
-    - title: Build System
-      regexp: '^.*?(build|ci)(\([[:print:]]+\))??!?:.+$'
-      order: 3
-    - title: Other
-      order: 999
-
 snapshot:
   version_template: "{{ incpatch .Version }}-next"
 
 release:
   github:
+  draft: true
   name_template: "v{{ .Version }}"
   prerelease: auto
   mode: replace


### PR DESCRIPTION
GitHub release notes seem to be more flexible and extensive than Goreleaser's, and includes additional features such as listing new contributors. Instead of the raw commit message `Merge pull request # from <branch>` being listed as a changelog item, the title of the PR is used with the link to the PR and author, which is more descriptive.

Also, push the release as a draft so it can be reviewed before actual release, adding editions as necessary.