### PR TITLE
fix: various fixes/refactoring in preparation for cloud-init changes

### DIFF
--- a/cmd/bss-boot-params-add.go
+++ b/cmd/bss-boot-params-add.go
@@ -168,8 +168,9 @@ func init() {
 	bootParamsAddCmd.Flags().StringSliceP("mac", "m", []string{}, "one or more MAC addresses whose boot parameters to add")
 	bootParamsAddCmd.Flags().Int32SliceP("nid", "n", []int32{}, "one or more node IDs whose boot parameters to add")
 	bootParamsAddCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
-	bootParamsAddCmd.Flags().StringP("format-input", "f", defaultInputFormat, "format of input payload data (json,yaml)")
+	bootParamsAddCmd.Flags().VarP(&formatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
 
+	bootParamsAddCmd.RegisterFlagCompletionFunc("format-input", completionFormatData)
 	bootParamsAddCmd.MarkFlagsOneRequired("xname", "mac", "nid", "data")
 	bootParamsAddCmd.MarkFlagsOneRequired("kernel", "initrd", "params", "data")
 

--- a/cmd/bss-boot-params-delete.go
+++ b/cmd/bss-boot-params-delete.go
@@ -180,7 +180,7 @@ func init() {
 	bootParamsDeleteCmd.Flags().StringSliceP("mac", "m", []string{}, "one or more MAC addresses whose boot parameters to delete")
 	bootParamsDeleteCmd.Flags().Int32SliceP("nid", "n", []int32{}, "one or more node IDs whose boot parameters to delete")
 	bootParamsDeleteCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
-	bootParamsDeleteCmd.Flags().StringP("format-input", "f", defaultInputFormat, "format of input payload data (json,yaml)")
+	bootParamsDeleteCmd.Flags().VarP(&formatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
 	bootParamsDeleteCmd.Flags().Bool("force", false, "do not ask before attempting deletion")
 
 	// We can delete either by component or by boot parameters

--- a/cmd/bss-boot-params-get.go
+++ b/cmd/bss-boot-params-get.go
@@ -105,13 +105,7 @@ See ochami-bss(1) for more details.`,
 			os.Exit(1)
 		}
 
-		outFmt, err := cmd.Flags().GetString("format-output")
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get value for --format-output")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-		if outBytes, err := client.FormatBody(httpEnv.Body, outFmt); err != nil {
+		if outBytes, err := client.FormatBody(httpEnv.Body, formatOutput); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to format output")
 			logHelpError(cmd)
 			os.Exit(1)
@@ -125,6 +119,9 @@ func init() {
 	bootParamsGetCmd.Flags().StringSliceP("xname", "x", []string{}, "one or more xnames whose boot parameters to get")
 	bootParamsGetCmd.Flags().StringSliceP("mac", "m", []string{}, "one or more MAC addresses whose boot parameters to get")
 	bootParamsGetCmd.Flags().Int32SliceP("nid", "n", []int32{}, "one or more node IDs whose boot parameters to get")
-	bootParamsGetCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,yaml)")
+	bootParamsGetCmd.Flags().VarP(&formatOutput, "format-output", "F", "format of output printed to standard output (json,json-pretty,yaml)")
+
+	bootParamsGetCmd.RegisterFlagCompletionFunc("format-output", completionFormatData)
+
 	bootParamsCmd.AddCommand(bootParamsGetCmd)
 }

--- a/cmd/bss-boot-params-set.go
+++ b/cmd/bss-boot-params-set.go
@@ -168,7 +168,9 @@ func init() {
 	bootParamsSetCmd.Flags().StringSliceP("mac", "m", []string{}, "one or more MAC addresses whose boot parameters to set")
 	bootParamsSetCmd.Flags().Int32SliceP("nid", "n", []int32{}, "one or more node IDs whose boot parameters to set")
 	bootParamsSetCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
-	bootParamsSetCmd.Flags().StringP("format-input", "f", defaultInputFormat, "format of input payload data (json,yaml)")
+	bootParamsSetCmd.Flags().VarP(&formatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
+
+	bootParamsSetCmd.RegisterFlagCompletionFunc("format-input", completionFormatData)
 
 	bootParamsSetCmd.MarkFlagsOneRequired("xname", "mac", "nid", "data")
 	bootParamsSetCmd.MarkFlagsOneRequired("kernel", "initrd", "params", "data")

--- a/cmd/bss-boot-params-update.go
+++ b/cmd/bss-boot-params-update.go
@@ -166,7 +166,9 @@ func init() {
 	bootParamsUpdateCmd.Flags().StringSliceP("mac", "m", []string{}, "one or more MAC addresses whose boot parameters to update")
 	bootParamsUpdateCmd.Flags().Int32SliceP("nid", "n", []int32{}, "one or more node IDs whose boot parameters to update")
 	bootParamsUpdateCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
-	bootParamsUpdateCmd.Flags().StringP("format-input", "f", defaultInputFormat, "format of input payload data (json,yaml)")
+	bootParamsUpdateCmd.Flags().VarP(&formatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
+
+	bootParamsUpdateCmd.RegisterFlagCompletionFunc("format-input", completionFormatData)
 
 	bootParamsUpdateCmd.MarkFlagsOneRequired("xname", "mac", "nid", "data")
 	bootParamsUpdateCmd.MarkFlagsOneRequired("kernel", "initrd", "params", "data")

--- a/cmd/bss-dumpstate.go
+++ b/cmd/bss-dumpstate.go
@@ -54,14 +54,7 @@ See ochami-bss(1) for more details.`,
 		}
 
 		// Print output
-		fmt.Println(string(httpEnv.Body))
-		outFmt, err := cmd.Flags().GetString("format-output")
-		if err != nil {
-			logHelpError(cmd)
-			log.Logger.Error().Err(err).Msg("failed to get value for --format-output")
-			os.Exit(1)
-		}
-		if outBytes, err := client.FormatBody(httpEnv.Body, outFmt); err != nil {
+		if outBytes, err := client.FormatBody(httpEnv.Body, formatOutput); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to format output")
 			logHelpError(cmd)
 			os.Exit(1)
@@ -72,6 +65,9 @@ See ochami-bss(1) for more details.`,
 }
 
 func init() {
-	bssDumpStateCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,yaml)")
+	bssDumpStateCmd.Flags().VarP(&formatOutput, "format-output", "F", "format of output printed to standard output (json,json-pretty,yaml)")
+
+	bssDumpStateCmd.RegisterFlagCompletionFunc("format-output", completionFormatData)
+
 	bssCmd.AddCommand(bssDumpStateCmd)
 }

--- a/cmd/bss-history.go
+++ b/cmd/bss-history.go
@@ -80,13 +80,7 @@ See ochami-bss(1) for more details.`,
 		}
 
 		// Print output
-		outFmt, err := cmd.Flags().GetString("format-output")
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get value for --format-output")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-		if outBytes, err := client.FormatBody(httpEnv.Body, outFmt); err != nil {
+		if outBytes, err := client.FormatBody(httpEnv.Body, formatOutput); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to format output")
 			logHelpError(cmd)
 			os.Exit(1)
@@ -99,6 +93,9 @@ See ochami-bss(1) for more details.`,
 func init() {
 	bssHistoryCmd.Flags().String("xname", "", "filter by xname")
 	bssHistoryCmd.Flags().String("endpoint", "", "filter by endpoint")
-	bssHistoryCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,yaml)")
+	bssHistoryCmd.Flags().VarP(&formatOutput, "format-output", "F", "format of output printed to standard output (json,json-pretty,yaml)")
+
+	bssHistoryCmd.RegisterFlagCompletionFunc("format-output", completionFormatData)
+
 	bssCmd.AddCommand(bssHistoryCmd)
 }

--- a/cmd/bss-hosts-get.go
+++ b/cmd/bss-hosts-get.go
@@ -89,13 +89,7 @@ See ochami-bss(1) for more details.`,
 		}
 
 		// Print output
-		outFmt, err := cmd.Flags().GetString("format-output")
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get value for --format-output")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-		if outBytes, err := client.FormatBody(httpEnv.Body, outFmt); err != nil {
+		if outBytes, err := client.FormatBody(httpEnv.Body, formatOutput); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to format output")
 			logHelpError(cmd)
 			os.Exit(1)
@@ -109,6 +103,9 @@ func init() {
 	bssHostsGetCmd.Flags().StringP("xname", "x", "", "xname whose host information to get")
 	bssHostsGetCmd.Flags().StringP("mac", "m", "", "MAC address whose boot parameters to get")
 	bssHostsGetCmd.Flags().Int32P("nid", "n", 0, "node ID whose host information to get")
-	bssHostsGetCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,yaml)")
+	bssHostsGetCmd.Flags().VarP(&formatOutput, "format-output", "F", "format of output printed to standard output (json,json-pretty,yaml)")
+
+	bssHostsGetCmd.RegisterFlagCompletionFunc("format-output", completionFormatData)
+
 	bssHostsCmd.AddCommand(bssHostsGetCmd)
 }

--- a/cmd/bss-status.go
+++ b/cmd/bss-status.go
@@ -65,13 +65,7 @@ See ochami-bss(1) for more details.`,
 		}
 
 		// Print output
-		outFmt, err := cmd.Flags().GetString("format-output")
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get value for --format-output")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-		if outBytes, err := client.FormatBody(httpEnv.Body, outFmt); err != nil {
+		if outBytes, err := client.FormatBody(httpEnv.Body, formatOutput); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to format output")
 			logHelpError(cmd)
 			os.Exit(1)
@@ -86,9 +80,10 @@ func init() {
 	bssStatusCmd.Flags().Bool("storage", false, "print status of storage backend from BSS")
 	bssStatusCmd.Flags().Bool("smd", false, "print status of BSS connection to SMD")
 	bssStatusCmd.Flags().Bool("version", false, "print version of BSS")
+	bssStatusCmd.Flags().VarP(&formatOutput, "format-output", "F", "format of output printed to standard output (json,json-pretty,yaml)")
 
+	bssStatusCmd.RegisterFlagCompletionFunc("format-output", completionFormatData)
 	bssStatusCmd.MarkFlagsMutuallyExclusive("all", "storage", "smd", "version")
 
-	bssStatusCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,yaml)")
 	bssCmd.AddCommand(bssStatusCmd)
 }

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -457,9 +457,10 @@ See ochami-discover(1) for more details.`,
 
 func init() {
 	discoverCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
-	discoverCmd.Flags().StringP("format-input", "f", defaultInputFormat, "format of input payload data (json,yaml)")
+	discoverCmd.Flags().VarP(&formatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
 	discoverCmd.Flags().Bool("overwrite", false, "overwrite any existing information instead of failing")
 
+	discoverCmd.RegisterFlagCompletionFunc("format-input", completionFormatData)
 	discoverCmd.MarkFlagRequired("data")
 
 	rootCmd.AddCommand(discoverCmd)

--- a/cmd/lib.go
+++ b/cmd/lib.go
@@ -392,14 +392,13 @@ func setTokenFromEnvVar(cmd *cobra.Command) {
 	logHelpError(cmd)
 }
 
-// handlePayload unmarshals a payload file into v for command cmd if --data
-// and, optionally, --format-input, are passed.
+// handlePayload unmarshals raw data or data from a payload file into v for
+// command cmd if --data and, optionally, --format-input, are passed.
 func handlePayload(cmd *cobra.Command, v any) {
 	if cmd.Flag("data").Changed {
 		data := cmd.Flag("data").Value.String()
 		dFormat := cmd.Flag("format-input").Value.String()
-		err := client.ReadPayload(data, dFormat, v)
-		if err != nil {
+		if err := client.ReadPayload(data, dFormat, v); err != nil {
 			log.Logger.Error().Err(err).Msg("unable to read payload data or file")
 			logHelpError(cmd)
 			os.Exit(1)

--- a/cmd/lib.go
+++ b/cmd/lib.go
@@ -16,6 +16,7 @@ import (
 	"github.com/OpenCHAMI/ochami/internal/config"
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/pkg/client"
+	"github.com/OpenCHAMI/ochami/pkg/format"
 	"github.com/lestrrat-go/jwx/jwt"
 	"github.com/spf13/cobra"
 )
@@ -397,8 +398,7 @@ func setTokenFromEnvVar(cmd *cobra.Command) {
 func handlePayload(cmd *cobra.Command, v any) {
 	if cmd.Flag("data").Changed {
 		data := cmd.Flag("data").Value.String()
-		dFormat := cmd.Flag("format-input").Value.String()
-		if err := client.ReadPayload(data, dFormat, v); err != nil {
+		if err := client.ReadPayload(data, formatInput, v); err != nil {
 			log.Logger.Error().Err(err).Msg("unable to read payload data or file")
 			logHelpError(cmd)
 			os.Exit(1)
@@ -429,4 +429,14 @@ func logHelpError(cmd *cobra.Command) {
 // command invocation without flags or arguments is printed in the message.
 func logHelpWarn(cmd *cobra.Command) {
 	log.Logger.Warn().Msgf("see '%s --help' for long command help", cmd.CommandPath())
+}
+
+// completionFormatData is the cobra completion function for any flag that uses
+// the format.DataFormat type.
+func completionFormatData(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	var helpSlice []string
+	for k, v := range format.DataFormatHelp {
+		helpSlice = append(helpSlice, fmt.Sprintf("%s\t%s", k, v))
+	}
+	return helpSlice, cobra.ShellCompDirectiveDefault
 }

--- a/cmd/pcs-status.go
+++ b/cmd/pcs-status.go
@@ -177,7 +177,7 @@ See ochami-pcs(1) for more details.`,
 		}
 
 		// Print output
-		if outBytes, err := format.FormatData(output, formatOutput); err != nil {
+		if outBytes, err := format.MarshalData(output, formatOutput); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to format output")
 			logHelpError(cmd)
 			os.Exit(1)

--- a/cmd/pcs-status.go
+++ b/cmd/pcs-status.go
@@ -177,13 +177,7 @@ See ochami-pcs(1) for more details.`,
 		}
 
 		// Print output
-		outFmt, err := cmd.Flags().GetString("format-output")
-		if err != nil {
-			log.Logger.Fatal().Err(err).Msg("failed to get value for --format-output")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-		if outBytes, err := format.FormatData(output, outFmt); err != nil {
+		if outBytes, err := format.FormatData(output, formatOutput); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to format output")
 			logHelpError(cmd)
 			os.Exit(1)
@@ -208,6 +202,8 @@ func init() {
 		pcsStatusCmd.MarkFlagsMutuallyExclusive("all", flags[i])
 	}
 
-	pcsStatusCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,json-pretty,yaml)")
+	pcsStatusCmd.Flags().VarP(&formatOutput, "format-output", "F", "format of output printed to standard output (json,json-pretty,yaml)")
+	pcsStatusCmd.RegisterFlagCompletionFunc("format-output", completionFormatData)
+
 	pcsCmd.AddCommand(pcsStatusCmd)
 }

--- a/cmd/pcs-transition-abort.go
+++ b/cmd/pcs-transition-abort.go
@@ -71,7 +71,7 @@ See ochami-pcs(1) for more details.`,
 		}
 
 		// Print output
-		if outBytes, err := format.FormatData(output, formatOutput); err != nil {
+		if outBytes, err := format.MarshalData(output, formatOutput); err != nil {
 			log.Logger.Fatal().Err(err).Msg("failed to format output")
 		} else {
 			fmt.Println(string(outBytes))

--- a/cmd/pcs-transition-abort.go
+++ b/cmd/pcs-transition-abort.go
@@ -71,12 +71,7 @@ See ochami-pcs(1) for more details.`,
 		}
 
 		// Print output
-		outFmt, err := cmd.Flags().GetString("format-output")
-		if err != nil {
-			log.Logger.Fatal().Err(err).Msg("failed to get value for --format-output")
-		}
-
-		if outBytes, err := format.FormatData(output, outFmt); err != nil {
+		if outBytes, err := format.FormatData(output, formatOutput); err != nil {
 			log.Logger.Fatal().Err(err).Msg("failed to format output")
 		} else {
 			fmt.Println(string(outBytes))
@@ -85,6 +80,9 @@ See ochami-pcs(1) for more details.`,
 }
 
 func init() {
-	pcsTransitionAbortCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,json-pretty,yaml)")
+	pcsTransitionAbortCmd.Flags().VarP(&formatOutput, "format-output", "F", "format of output printed to standard output (json,json-pretty,yaml)")
+
+	pcsTransitionAbortCmd.RegisterFlagCompletionFunc("format-output", completionFormatData)
+
 	pcsTransitionCmd.AddCommand(pcsTransitionAbortCmd)
 }

--- a/cmd/pcs-transition-list.go
+++ b/cmd/pcs-transition-list.go
@@ -65,12 +65,7 @@ See ochami-pcs(1) for more details.`,
 		}
 
 		// Print output
-		outFmt, err := cmd.Flags().GetString("format-output")
-		if err != nil {
-			log.Logger.Fatal().Err(err).Msg("failed to get value for --format-output")
-		}
-
-		if outBytes, err := format.FormatData(output, outFmt); err != nil {
+		if outBytes, err := format.FormatData(output, formatOutput); err != nil {
 			log.Logger.Fatal().Err(err).Msg("failed to format output")
 		} else {
 			fmt.Println(string(outBytes))
@@ -79,6 +74,9 @@ See ochami-pcs(1) for more details.`,
 }
 
 func init() {
-	pcsTransitionListCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,json-pretty,yaml)")
+	pcsTransitionListCmd.Flags().VarP(&formatOutput, "format-output", "F", "format of output printed to standard output (json,json-pretty,yaml)")
+
+	pcsTransitionListCmd.RegisterFlagCompletionFunc("format-output", completionFormatData)
+
 	pcsTransitionCmd.AddCommand(pcsTransitionListCmd)
 }

--- a/cmd/pcs-transition-list.go
+++ b/cmd/pcs-transition-list.go
@@ -65,7 +65,7 @@ See ochami-pcs(1) for more details.`,
 		}
 
 		// Print output
-		if outBytes, err := format.FormatData(output, formatOutput); err != nil {
+		if outBytes, err := format.MarshalData(output, formatOutput); err != nil {
 			log.Logger.Fatal().Err(err).Msg("failed to format output")
 		} else {
 			fmt.Println(string(outBytes))

--- a/cmd/pcs-transition-show.go
+++ b/cmd/pcs-transition-show.go
@@ -68,12 +68,7 @@ See ochami-pcs(1) for more details.`,
 		}
 
 		// Print output
-		outFmt, err := cmd.Flags().GetString("format-output")
-		if err != nil {
-			log.Logger.Fatal().Err(err).Msg("failed to get value for --output-format")
-		}
-
-		if outBytes, err := format.FormatData(output, outFmt); err != nil {
+		if outBytes, err := format.FormatData(output, formatOutput); err != nil {
 			log.Logger.Fatal().Err(err).Msg("failed to format output")
 		} else {
 			fmt.Println(string(outBytes))
@@ -82,6 +77,9 @@ See ochami-pcs(1) for more details.`,
 }
 
 func init() {
-	pcsTransitionShowCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,json-pretty,yaml)")
+	pcsTransitionShowCmd.Flags().VarP(&formatOutput, "format-output", "F", "format of output printed to standard output (json,json-pretty,yaml)")
+
+	pcsTransitionShowCmd.RegisterFlagCompletionFunc("format-output", completionFormatData)
+
 	pcsTransitionCmd.AddCommand(pcsTransitionShowCmd)
 }

--- a/cmd/pcs-transition-show.go
+++ b/cmd/pcs-transition-show.go
@@ -68,7 +68,7 @@ See ochami-pcs(1) for more details.`,
 		}
 
 		// Print output
-		if outBytes, err := format.FormatData(output, formatOutput); err != nil {
+		if outBytes, err := format.MarshalData(output, formatOutput); err != nil {
 			log.Logger.Fatal().Err(err).Msg("failed to format output")
 		} else {
 			fmt.Println(string(outBytes))

--- a/cmd/pcs-transition-start.go
+++ b/cmd/pcs-transition-start.go
@@ -106,11 +106,7 @@ See ochami-pcs(1) for more details.`,
 		}
 
 		// Print output
-		outFmt, err := cmd.Flags().GetString("format-output")
-		if err != nil {
-			log.Logger.Fatal().Err(err).Msg("failed to get value for --format-output")
-		}
-		if outBytes, err := format.FormatData(output, outFmt); err != nil {
+		if outBytes, err := format.FormatData(output, formatOutput); err != nil {
 			log.Logger.Fatal().Err(err).Msg("failed to format output")
 		} else {
 			fmt.Println(string(outBytes))
@@ -124,6 +120,9 @@ func init() {
 		log.Logger.Fatal().Err(err).Msg("failed to mark xname as required")
 	}
 
-	pcsTransitionStartCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,json-pretty,yaml)")
+	pcsTransitionStartCmd.Flags().VarP(&formatOutput, "format-output", "F", "format of output printed to standard output (json,json-pretty,yaml)")
+
+	pcsTransitionStartCmd.RegisterFlagCompletionFunc("format-output", completionFormatData)
+
 	pcsTransitionCmd.AddCommand(pcsTransitionStartCmd)
 }

--- a/cmd/pcs-transition-start.go
+++ b/cmd/pcs-transition-start.go
@@ -106,7 +106,7 @@ See ochami-pcs(1) for more details.`,
 		}
 
 		// Print output
-		if outBytes, err := format.FormatData(output, formatOutput); err != nil {
+		if outBytes, err := format.MarshalData(output, formatOutput); err != nil {
 			log.Logger.Fatal().Err(err).Msg("failed to format output")
 		} else {
 			fmt.Println(string(outBytes))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,18 +8,19 @@ import (
 	"github.com/OpenCHAMI/ochami/internal/config"
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/internal/version"
+	"github.com/OpenCHAMI/ochami/pkg/format"
 	"github.com/spf13/cobra"
-)
-
-const (
-	defaultInputFormat  = "json"
-	defaultOutputFormat = "json"
 )
 
 var (
 	configFile string
 	logLevel   string
 	logFormat  string
+
+	// Variables to store values of --format-output and --format-input.
+	// Default values are set here.
+	formatInput  = format.DataFormatJson
+	formatOutput = format.DataFormatJson
 
 	// These are only used by subcommands.
 	cacertPath string

--- a/cmd/smd-compep-delete.go
+++ b/cmd/smd-compep-delete.go
@@ -155,7 +155,10 @@ See ochami-smd(1) for more details.`,
 func init() {
 	compepDeleteCmd.Flags().BoolP("all", "a", false, "delete all redfish endpoints in SMD")
 	compepDeleteCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
-	compepDeleteCmd.Flags().StringP("format-input", "f", defaultInputFormat, "format of input payload data (json,yaml)")
+	compepDeleteCmd.Flags().VarP(&formatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
 	compepDeleteCmd.Flags().Bool("force", false, "do not ask before attempting deletion")
+
+	compepDeleteCmd.RegisterFlagCompletionFunc("format-input", completionFormatData)
+
 	compepCmd.AddCommand(compepDeleteCmd)
 }

--- a/cmd/smd-compep-get.go
+++ b/cmd/smd-compep-get.go
@@ -60,13 +60,7 @@ See ochami-smd(1) for more details.`,
 			}
 
 			// Print output
-			outFmt, err := cmd.Flags().GetString("format-output")
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to get value for --format-output")
-				logHelpError(cmd)
-				os.Exit(1)
-			}
-			if outBytes, err := client.FormatBody(httpEnv.Body, outFmt); err != nil {
+			if outBytes, err := client.FormatBody(httpEnv.Body, formatOutput); err != nil {
 				log.Logger.Error().Err(err).Msg("failed to format output")
 				logHelpError(cmd)
 				os.Exit(1)
@@ -127,13 +121,7 @@ See ochami-smd(1) for more details.`,
 			}
 
 			// Print output
-			outFmt, err := cmd.Flags().GetString("format-output")
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to get value for --format-output")
-				logHelpError(cmd)
-				os.Exit(1)
-			}
-			if outBytes, err := client.FormatBody(cesBytes, outFmt); err != nil {
+			if outBytes, err := client.FormatBody(cesBytes, formatOutput); err != nil {
 				log.Logger.Error().Err(err).Msg("failed to format output")
 				logHelpError(cmd)
 				os.Exit(1)
@@ -145,6 +133,9 @@ See ochami-smd(1) for more details.`,
 }
 
 func init() {
-	compepGetCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,yaml)")
+	compepGetCmd.Flags().VarP(&formatOutput, "format-output", "F", "format of output printed to standard output (json,json-pretty,yaml)")
+
+	compepGetCmd.RegisterFlagCompletionFunc("format-output", completionFormatData)
+
 	compepCmd.AddCommand(compepGetCmd)
 }

--- a/cmd/smd-component-add.go
+++ b/cmd/smd-component-add.go
@@ -128,7 +128,9 @@ func init() {
 	componentAddCmd.Flags().String("role", "Compute", "role of new component")
 	componentAddCmd.Flags().String("arch", "X86", "CPU architecture of new component")
 	componentAddCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
-	componentAddCmd.Flags().StringP("format-input", "f", defaultInputFormat, "format of input payload data (json,yaml)")
+	componentAddCmd.Flags().VarP(&formatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
+
+	componentAddCmd.RegisterFlagCompletionFunc("format-input", completionFormatData)
 
 	componentAddCmd.MarkFlagsMutuallyExclusive("state", "data")
 	componentAddCmd.MarkFlagsMutuallyExclusive("enabled", "data")

--- a/cmd/smd-component-delete.go
+++ b/cmd/smd-component-delete.go
@@ -152,8 +152,10 @@ See ochami-smd(1) for more details.`,
 func init() {
 	componentDeleteCmd.Flags().BoolP("all", "a", false, "delete all components in SMD")
 	componentDeleteCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
-	componentDeleteCmd.Flags().StringP("format-input", "f", defaultInputFormat, "format of input payload data (json,yaml)")
+	componentDeleteCmd.Flags().VarP(&formatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
 	componentDeleteCmd.Flags().Bool("force", false, "do not ask before attempting deletion")
+
+	componentDeleteCmd.RegisterFlagCompletionFunc("format-input", completionFormatData)
 
 	componentCmd.AddCommand(componentDeleteCmd)
 }

--- a/cmd/smd-component-get.go
+++ b/cmd/smd-component-get.go
@@ -74,13 +74,7 @@ See ochami-smd(1) for more details.`,
 		}
 
 		// Print output
-		outFmt, err := cmd.Flags().GetString("format-output")
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get value for --format-output")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-		if outBytes, err := client.FormatBody(httpEnv.Body, outFmt); err != nil {
+		if outBytes, err := client.FormatBody(httpEnv.Body, formatOutput); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to format output")
 			logHelpError(cmd)
 			os.Exit(1)
@@ -93,8 +87,9 @@ See ochami-smd(1) for more details.`,
 func init() {
 	componentGetCmd.Flags().StringP("xname", "x", "", "xname whose Component to fetch")
 	componentGetCmd.Flags().Int32P("nid", "n", 0, "node ID whose Component to fetch")
-	componentGetCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,yaml)")
+	componentGetCmd.Flags().VarP(&formatOutput, "format-output", "F", "format of output printed to standard output (json,json-pretty,yaml)")
 
+	componentGetCmd.RegisterFlagCompletionFunc("format-output", completionFormatData)
 	componentGetCmd.MarkFlagsMutuallyExclusive("xname", "nid")
 
 	componentCmd.AddCommand(componentGetCmd)

--- a/cmd/smd-group-add.go
+++ b/cmd/smd-group-add.go
@@ -166,8 +166,9 @@ func init() {
 	groupAddCmd.Flags().StringP("exclusive-group", "e", "", "name of group that cannot share members with this one")
 	groupAddCmd.Flags().StringSliceP("member", "m", []string{}, "one or more component IDs to add to the new group")
 	groupAddCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
-	groupAddCmd.Flags().StringP("format-input", "f", defaultInputFormat, "format of input payload data (json,yaml)")
+	groupAddCmd.Flags().VarP(&formatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
 
+	groupAddCmd.RegisterFlagCompletionFunc("format-input", completionFormatData)
 	groupAddCmd.MarkFlagsMutuallyExclusive("description", "data")
 	groupAddCmd.MarkFlagsMutuallyExclusive("tag", "data")
 	groupAddCmd.MarkFlagsMutuallyExclusive("exclusive-group", "data")

--- a/cmd/smd-group-delete.go
+++ b/cmd/smd-group-delete.go
@@ -132,8 +132,10 @@ See ochami-smd(1) for more details.`,
 
 func init() {
 	groupDeleteCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
-	groupDeleteCmd.Flags().StringP("format-input", "f", defaultInputFormat, "format of input payload data (json,yaml)")
+	groupDeleteCmd.Flags().VarP(&formatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
 	groupDeleteCmd.Flags().Bool("force", false, "do not ask before attempting deletion")
+
+	groupDeleteCmd.RegisterFlagCompletionFunc("format-input", completionFormatData)
 
 	groupCmd.AddCommand(groupDeleteCmd)
 }

--- a/cmd/smd-group-get.go
+++ b/cmd/smd-group-get.go
@@ -93,13 +93,7 @@ See ochami-smd(1) for more details.`,
 		}
 
 		// Print output
-		outFmt, err := cmd.Flags().GetString("format-output")
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get value for --format-output")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-		if outBytes, err := client.FormatBody(httpEnv.Body, outFmt); err != nil {
+		if outBytes, err := client.FormatBody(httpEnv.Body, formatOutput); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to format output")
 			logHelpError(cmd)
 			os.Exit(1)
@@ -112,6 +106,9 @@ See ochami-smd(1) for more details.`,
 func init() {
 	groupGetCmd.Flags().StringSlice("name", []string{}, "filter groups by name")
 	groupGetCmd.Flags().StringSlice("tag", []string{}, "filter groups by tag")
-	groupGetCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,yaml)")
+	groupGetCmd.Flags().VarP(&formatOutput, "format-output", "F", "format of output printed to standard output (json,json-pretty,yaml)")
+
+	groupGetCmd.RegisterFlagCompletionFunc("format-output", completionFormatData)
+
 	groupCmd.AddCommand(groupGetCmd)
 }

--- a/cmd/smd-group-member-get.go
+++ b/cmd/smd-group-member-get.go
@@ -59,13 +59,7 @@ See ochami-smd(1) for more details.`,
 		}
 
 		// Print output
-		outFmt, err := cmd.Flags().GetString("format-output")
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get value for --format-output")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-		if outBytes, err := client.FormatBody(httpEnv.Body, outFmt); err != nil {
+		if outBytes, err := client.FormatBody(httpEnv.Body, formatOutput); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to format output")
 			logHelpError(cmd)
 			os.Exit(1)
@@ -76,6 +70,9 @@ See ochami-smd(1) for more details.`,
 }
 
 func init() {
-	groupMemberGetCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,yaml)")
+	groupMemberGetCmd.Flags().VarP(&formatOutput, "format-output", "F", "format of output printed to standard output (json,json-pretty,yaml)")
+
+	groupMemberGetCmd.RegisterFlagCompletionFunc("format-output", completionFormatData)
+
 	groupMemberCmd.AddCommand(groupMemberGetCmd)
 }

--- a/cmd/smd-group-update.go
+++ b/cmd/smd-group-update.go
@@ -140,8 +140,9 @@ func init() {
 	groupUpdateCmd.Flags().StringP("description", "D", "", "short description to update group with")
 	groupUpdateCmd.Flags().StringSlice("tag", []string{}, "one or more tags to set for group")
 	groupUpdateCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
-	groupUpdateCmd.Flags().StringP("format-input", "f", defaultInputFormat, "format of input payload data (json,yaml)")
+	groupUpdateCmd.Flags().VarP(&formatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
 
+	groupUpdateCmd.RegisterFlagCompletionFunc("format-input", completionFormatData)
 	groupUpdateCmd.MarkFlagsOneRequired("description", "tag", "data")
 
 	groupCmd.AddCommand(groupUpdateCmd)

--- a/cmd/smd-iface-add.go
+++ b/cmd/smd-iface-add.go
@@ -137,8 +137,9 @@ See ochami-smd(1) for more details.`,
 func init() {
 	ifaceAddCmd.Flags().StringP("description", "D", "Undescribed Ethernet Interface", "description of interface")
 	ifaceAddCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
-	ifaceAddCmd.Flags().StringP("format-input", "f", defaultInputFormat, "format of input payload data (json,yaml)")
+	ifaceAddCmd.Flags().VarP(&formatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
 
+	ifaceAddCmd.RegisterFlagCompletionFunc("format-input", completionFormatData)
 	ifaceAddCmd.MarkFlagsMutuallyExclusive("description", "data")
 
 	ifaceCmd.AddCommand(ifaceAddCmd)

--- a/cmd/smd-iface-delete.go
+++ b/cmd/smd-iface-delete.go
@@ -154,7 +154,10 @@ See ochami-smd(1) for more details.`,
 func init() {
 	ifaceDeleteCmd.Flags().BoolP("all", "a", false, "delete all ethernet interfaces in SMD")
 	ifaceDeleteCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
-	ifaceDeleteCmd.Flags().StringP("format-input", "f", defaultInputFormat, "format of input payload data (json,yaml)")
+	ifaceDeleteCmd.Flags().VarP(&formatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
 	ifaceDeleteCmd.Flags().Bool("force", false, "do not ask before attempting deletion")
+
+	ifaceDeleteCmd.RegisterFlagCompletionFunc("format-input", completionFormatData)
+
 	ifaceCmd.AddCommand(ifaceDeleteCmd)
 }

--- a/cmd/smd-iface-get.go
+++ b/cmd/smd-iface-get.go
@@ -169,13 +169,7 @@ See ochami-smd(1) for more details.`,
 		}
 
 		// Print output
-		outFmt, err := cmd.Flags().GetString("format-output")
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get value for --format-output")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-		if outBytes, err := client.FormatBody(httpEnv.Body, outFmt); err != nil {
+		if outBytes, err := client.FormatBody(httpEnv.Body, formatOutput); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to format output")
 			logHelpError(cmd)
 			os.Exit(1)
@@ -195,8 +189,9 @@ func init() {
 	ifaceGetCmd.Flags().StringSlice("type", []string{}, "filter ethernet interfaces by type")
 	ifaceGetCmd.Flags().String("older-than", "", "filter ethernet interfaces by update time older than specified time (RFC3339-formatted)")
 	ifaceGetCmd.Flags().String("newer-than", "", "filter ethernet interfaces by update time older than specified time (RFC3339-formatted)")
-	ifaceGetCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,yaml)")
+	ifaceGetCmd.Flags().VarP(&formatOutput, "format-output", "F", "format of output printed to standard output (json,json-pretty,yaml)")
 
+	ifaceGetCmd.RegisterFlagCompletionFunc("format-output", completionFormatData)
 	ifaceGetCmd.MarkFlagsMutuallyExclusive("id", "mac")
 	ifaceGetCmd.MarkFlagsMutuallyExclusive("id", "ip")
 	ifaceGetCmd.MarkFlagsMutuallyExclusive("id", "net")

--- a/cmd/smd-rfe-add.go
+++ b/cmd/smd-rfe-add.go
@@ -167,8 +167,9 @@ func init() {
 	rfeAddCmd.Flags().String("username", "", "username to use when interrogating endpoint")
 	rfeAddCmd.Flags().String("password", "", "password to use when interrogating endpoint")
 	rfeAddCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
-	rfeAddCmd.Flags().StringP("format-input", "f", defaultInputFormat, "format of input payload data (json,yaml)")
+	rfeAddCmd.Flags().VarP(&formatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
 
+	rfeAddCmd.RegisterFlagCompletionFunc("format-input", completionFormatData)
 	rfeAddCmd.MarkFlagsMutuallyExclusive("domain", "data")
 	rfeAddCmd.MarkFlagsMutuallyExclusive("hostname", "data")
 	rfeAddCmd.MarkFlagsMutuallyExclusive("username", "data")

--- a/cmd/smd-rfe-delete.go
+++ b/cmd/smd-rfe-delete.go
@@ -154,8 +154,10 @@ See ochami-smd(1) for more details.`,
 func init() {
 	rfeDeleteCmd.Flags().BoolP("all", "a", false, "delete all redfish endpoints in SMD")
 	rfeDeleteCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
-	rfeDeleteCmd.Flags().StringP("format-input", "f", defaultInputFormat, "format of input payload data (json,yaml)")
+	rfeDeleteCmd.Flags().VarP(&formatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
 	rfeDeleteCmd.Flags().Bool("force", false, "do not ask before attempting deletion")
+
+	rfeDeleteCmd.RegisterFlagCompletionFunc("format-input", completionFormatData)
 
 	rfeCmd.AddCommand(rfeDeleteCmd)
 }

--- a/cmd/smd-rfe-get.go
+++ b/cmd/smd-rfe-get.go
@@ -133,13 +133,7 @@ See ochami-smd(1) for more details.`,
 		}
 
 		// Print output
-		outFmt, err := cmd.Flags().GetString("format-output")
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get value for --format-output")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-		if outBytes, err := client.FormatBody(httpEnv.Body, outFmt); err != nil {
+		if outBytes, err := client.FormatBody(httpEnv.Body, formatOutput); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to format output")
 			logHelpError(cmd)
 			os.Exit(1)
@@ -156,6 +150,9 @@ func init() {
 	rfeGetCmd.Flags().StringSlice("uuid", []string{}, "filter redfish endpoints by UUID")
 	rfeGetCmd.Flags().StringSliceP("mac", "m", []string{}, "filter redfish endpoints by MAC address")
 	rfeGetCmd.Flags().StringSliceP("ip", "i", []string{}, "filter redfish endpoints by IP address")
-	rfeGetCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,yaml)")
+	rfeGetCmd.Flags().VarP(&formatOutput, "format-output", "F", "format of output printed to standard output (json,json-pretty,yaml)")
+
+	rfeGetCmd.RegisterFlagCompletionFunc("format-output", completionFormatData)
+
 	rfeCmd.AddCommand(rfeGetCmd)
 }

--- a/cmd/smd-status.go
+++ b/cmd/smd-status.go
@@ -59,13 +59,7 @@ See ochami-smd(1) for more details.`,
 		}
 
 		// Print output
-		outFmt, err := cmd.Flags().GetString("format-output")
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get value for --format-output")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-		if outBytes, err := client.FormatBody(httpEnv.Body, outFmt); err != nil {
+		if outBytes, err := client.FormatBody(httpEnv.Body, formatOutput); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to format output")
 			logHelpError(cmd)
 			os.Exit(1)
@@ -77,7 +71,9 @@ See ochami-smd(1) for more details.`,
 
 func init() {
 	smdStatusCmd.Flags().Bool("all", false, "print all status data from SMD")
+	smdStatusCmd.Flags().VarP(&formatOutput, "format-output", "F", "format of output printed to standard output (json,json-pretty,yaml)")
 
-	smdStatusCmd.Flags().StringP("format-output", "F", defaultOutputFormat, "format of output printed to standard output (json,yaml)")
+	smdStatusCmd.RegisterFlagCompletionFunc("format-output", completionFormatData)
+
 	smdCmd.AddCommand(smdStatusCmd)
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -446,12 +446,12 @@ func ReadPayloadFile(path, format string, v any) error {
 		var data []byte
 		data, err = oio.ReadStdin()
 		if err != nil {
-			return fmt.Errorf("unable to read payload data: %w", err)
+			return fmt.Errorf("unable to read from stdin: %w", err)
 		}
 		log.Logger.Debug().Msgf("bytes read: %q", data)
 		body, err = BytesToHTTPBody(data, format)
 		if err != nil {
-			return fmt.Errorf("unable to create HTTP body from payload bytes: %w", err)
+			return fmt.Errorf("unable to create HTTP body from bytes: %w", err)
 		}
 	} else {
 		body, err = FileToHTTPBody(path, format)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -353,7 +353,13 @@ func BytesToHTTPBody(data []byte, inFormat format.DataFormat) (HTTPBody, error) 
 		return nil, fmt.Errorf("byte slice is empty")
 	}
 
-	b, err := format.FormatData(data, inFormat)
+	var v interface{}
+	if err := format.UnmarshalData(data, &v, inFormat); err != nil {
+		return nil, fmt.Errorf("failed for convert bytes to HTTP body: %w", err)
+	}
+
+	b, err := format.MarshalData(v, format.DataFormatJson)
+
 	return HTTPBody(b), err
 }
 
@@ -372,7 +378,7 @@ func FileToHTTPBody(path string, inFormat format.DataFormat) (HTTPBody, error) {
 		return nil, fmt.Errorf("failed to read file %q: %w", path, err)
 	}
 
-	b, err := format.FormatData(contents, inFormat)
+	b, err := format.MarshalData(contents, inFormat)
 	return HTTPBody(b), err
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -18,6 +17,7 @@ import (
 	oio "github.com/OpenCHAMI/ochami/internal/io"
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/internal/version"
+	"github.com/OpenCHAMI/ochami/pkg/format"
 )
 
 var (
@@ -348,41 +348,13 @@ func (oc *OchamiClient) UseCACert(caCertPath string) error {
 // returning it. If an unmarshalling error occurs or either of the arguments are
 // empty, nil and an error are returned. Current file formats supported are JSON
 // and YAML.
-func BytesToHTTPBody(data []byte, format string) (HTTPBody, error) {
+func BytesToHTTPBody(data []byte, inFormat format.DataFormat) (HTTPBody, error) {
 	if len(data) == 0 {
 		return nil, fmt.Errorf("byte slice is empty")
 	}
-	if format == "" {
-		return nil, fmt.Errorf("format is empty")
-	}
 
-	var b HTTPBody
-	var err error
-	switch strings.ToLower(format) {
-	case "json":
-		var j interface{}
-		err = json.Unmarshal(data, &j)
-		if err != nil {
-			return nil, fmt.Errorf("failed to unmarshal JSON: %w", err)
-		}
-		b, err = json.Marshal(j)
-		if err != nil {
-			err = fmt.Errorf("failed to marshal JSON: %w", err)
-		}
-	case "yaml":
-		var y interface{}
-		err = yaml.Unmarshal(data, &y)
-		if err != nil {
-			return nil, fmt.Errorf("failed to unmarshal YAML: %w", err)
-		}
-		y = CanonicalizeInterface(y)
-		b, err = json.Marshal(y)
-		if err != nil {
-			err = fmt.Errorf("failed to marshal JSON (converted from YAML): %w", err)
-		}
-	}
-
-	return b, err
+	b, err := format.FormatData(data, inFormat)
+	return HTTPBody(b), err
 }
 
 // FileToHTTPBody takes a file path and string representing the format of the
@@ -390,12 +362,9 @@ func BytesToHTTPBody(data []byte, format string) (HTTPBody, error) {
 // in JSON form, returning it. If an unmarshalling error occurs or either of the
 // arguments are empty, nil and an error are returned. Current file formats
 // supported are JSON and YAML.
-func FileToHTTPBody(path, format string) (HTTPBody, error) {
+func FileToHTTPBody(path string, inFormat format.DataFormat) (HTTPBody, error) {
 	if path == "" {
 		return nil, fmt.Errorf("file path is empty")
-	}
-	if format == "" {
-		return nil, fmt.Errorf("format is empty")
 	}
 
 	contents, err := os.ReadFile(path)
@@ -403,41 +372,17 @@ func FileToHTTPBody(path, format string) (HTTPBody, error) {
 		return nil, fmt.Errorf("failed to read file %q: %w", path, err)
 	}
 
-	var b HTTPBody
-	switch strings.ToLower(format) {
-	case "json":
-		var j interface{}
-		err = json.Unmarshal(contents, &j)
-		if err != nil {
-			return nil, fmt.Errorf("failed to unmarshal JSON contents from %q: %w", path, err)
-		}
-		b, err = json.Marshal(j)
-		if err != nil {
-			err = fmt.Errorf("failed to marshal JSON from file %q: %w", path, err)
-		}
-	case "yaml":
-		var y interface{}
-		err = yaml.Unmarshal(contents, &y)
-		if err != nil {
-			return nil, fmt.Errorf("failed to unmarshal YAML contents from %q: %w", path, err)
-		}
-		y = CanonicalizeInterface(y)
-		b, err = json.Marshal(y)
-		if err != nil {
-			err = fmt.Errorf("failed to marshal JSON (converted from YAML) from file %q: %w", path, err)
-		}
-	}
-
-	return b, err
+	b, err := format.FormatData(contents, inFormat)
+	return HTTPBody(b), err
 }
 
 // ReadPayloadFile reads in the file pointed to by path and unmarshals the data
 // into value v. The data can be in formats other than JSON (whichever formats
 // FileToHTTPBody supports), such as YAML. If a marshalling/unmarshalling error
 // occurs or either path or format are empty, an error is returned.
-func ReadPayloadFile(path, format string, v any) error {
+func ReadPayloadFile(path string, inFormat format.DataFormat, v any) error {
 	log.Logger.Debug().Msgf("payload file: %s", path)
-	log.Logger.Debug().Msgf("payload file format: %s", format)
+	log.Logger.Debug().Msgf("payload file format: %s", inFormat)
 
 	var body HTTPBody
 	var err error
@@ -449,12 +394,12 @@ func ReadPayloadFile(path, format string, v any) error {
 			return fmt.Errorf("unable to read from stdin: %w", err)
 		}
 		log.Logger.Debug().Msgf("bytes read: %q", data)
-		body, err = BytesToHTTPBody(data, format)
+		body, err = BytesToHTTPBody(data, inFormat)
 		if err != nil {
 			return fmt.Errorf("unable to create HTTP body from bytes: %w", err)
 		}
 	} else {
-		body, err = FileToHTTPBody(path, format)
+		body, err = FileToHTTPBody(path, inFormat)
 		if err != nil {
 			return fmt.Errorf("unable to create HTTP body from file: %w", err)
 		}
@@ -472,7 +417,7 @@ func ReadPayloadFile(path, format string, v any) error {
 // ReadPayload unmarshals data formatted as format into v. If data begins with
 // "@", it is treated as a file path and calls ReadPayloadFile to read the
 // contents. If the file path is "-", the data is read from standard input.
-func ReadPayload(data, format string, v any) error {
+func ReadPayload(data string, format format.DataFormat, v any) error {
 	if strings.HasPrefix(data, "@") {
 		// Passed data is actually a file path, return data within file.
 		return ReadPayloadFile(strings.TrimPrefix(data, "@"), format, v)

--- a/pkg/client/http.go
+++ b/pkg/client/http.go
@@ -114,7 +114,7 @@ func FormatBody(body HTTPBody, outFormat format.DataFormat) ([]byte, error) {
 		return nil, fmt.Errorf("failed to unmarshal HTTP body: %w", err)
 	}
 
-	return format.FormatData(jmap, outFormat)
+	return format.MarshalData(jmap, outFormat)
 }
 
 func (he HTTPEnvelope) CheckResponse() error {

--- a/pkg/client/http.go
+++ b/pkg/client/http.go
@@ -108,7 +108,7 @@ func NewHTTPEnvelopeFromResponse(res *http.Response) (HTTPEnvelope, error) {
 // FormatBody takes an HTTPBody and marshals it into the format specified,
 // returning the resulting bytes. If an error occurs during
 // marshalling/unmarshalling or the format is unsupported, an error occurs.
-func FormatBody(body HTTPBody, outFormat string) ([]byte, error) {
+func FormatBody(body HTTPBody, outFormat format.DataFormat) ([]byte, error) {
 	var jmap interface{}
 	if err := json.Unmarshal(body, &jmap); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal HTTP body: %w", err)

--- a/pkg/format/format.go
+++ b/pkg/format/format.go
@@ -4,28 +4,68 @@ import (
 	"encoding/json"
 	"fmt"
 	"gopkg.in/yaml.v3"
-	"strings"
 )
+
+// DataType represents the supported data formats
+type DataFormat string
+
+const (
+	DataFormatJson       DataFormat = "json"
+	DataFormatJsonPretty DataFormat = "json-pretty"
+	DataFormatYaml       DataFormat = "yaml"
+)
+
+var (
+	DataFormatHelp = map[string]string{
+		string(DataFormatJson):       "One-line JSON format",
+		string(DataFormatJsonPretty): "Unindented JSON format",
+		string(DataFormatYaml):       "YAML format",
+	}
+)
+
+func (df DataFormat) String() string {
+	return string(df)
+}
+
+func (df *DataFormat) Set(v string) error {
+	switch DataFormat(v) {
+	case DataFormatJson,
+		DataFormatJsonPretty,
+		DataFormatYaml:
+		*df = DataFormat(v)
+		return nil
+	default:
+		return fmt.Errorf("must be one of %v", []DataFormat{
+			DataFormatJson,
+			DataFormatJsonPretty,
+			DataFormatYaml,
+		})
+	}
+}
+
+func (df DataFormat) Type() string {
+	return "DataFormat"
+}
 
 // FormatData marshals arbitrary data into a byte slice formatted as outFormat.
 // If a marshalling error occurrs or outFormat is unknown, an error is returned.
 //
 // Supported values are: json, json-pretty, yaml
-func FormatData(data interface{}, outFormat string) ([]byte, error) {
-	switch strings.ToLower(outFormat) {
-	case "json":
+func FormatData(data interface{}, outFormat DataFormat) ([]byte, error) {
+	switch outFormat {
+	case DataFormatJson:
 		if bytes, err := json.Marshal(data); err != nil {
 			return nil, fmt.Errorf("failed to marshal data into JSON: %w", err)
 		} else {
 			return bytes, nil
 		}
-	case "json-pretty":
+	case DataFormatJsonPretty:
 		if bytes, err := json.MarshalIndent(data, "", "  "); err != nil {
 			return nil, fmt.Errorf("failed to marshal data into pretty JSON: %w", err)
 		} else {
 			return bytes, nil
 		}
-	case "yaml":
+	case DataFormatYaml:
 		if bytes, err := yaml.Marshal(data); err != nil {
 			return nil, fmt.Errorf("failed to marshal data into YAML: %w", err)
 		} else {

--- a/pkg/format/format.go
+++ b/pkg/format/format.go
@@ -47,11 +47,11 @@ func (df DataFormat) Type() string {
 	return "DataFormat"
 }
 
-// FormatData marshals arbitrary data into a byte slice formatted as outFormat.
-// If a marshalling error occurrs or outFormat is unknown, an error is returned.
+// MarshalData marshals arbitrary data into a byte slice formatted as outFormat.
+// If a marshalling error occurs or outFormat is unknown, an error is returned.
 //
 // Supported values are: json, json-pretty, yaml
-func FormatData(data interface{}, outFormat DataFormat) ([]byte, error) {
+func MarshalData(data interface{}, outFormat DataFormat) ([]byte, error) {
 	switch outFormat {
 	case DataFormatJson:
 		if bytes, err := json.Marshal(data); err != nil {
@@ -74,4 +74,26 @@ func FormatData(data interface{}, outFormat DataFormat) ([]byte, error) {
 	default:
 		return nil, fmt.Errorf("unknown data format: %s", outFormat)
 	}
+}
+
+// UnmarshalData unmarshals a byte slice formatted as inFormat into an interface
+// v. If an unmarshalling error occurs or inFormat is unknown, an error is
+// returned.
+//
+// Supported values are: json, json-pretty, yaml
+func UnmarshalData(data []byte, v interface{}, inFormat DataFormat) error {
+	switch inFormat {
+	case DataFormatJson, DataFormatJsonPretty:
+		if err := json.Unmarshal(data, v); err != nil {
+			return fmt.Errorf("failed to unmarshal data into JSON: %w", err)
+		}
+	case DataFormatYaml:
+		if err := yaml.Unmarshal(data, v); err != nil {
+			return fmt.Errorf("failed to unmarshal data into YAML: %w", err)
+		}
+	default:
+		return fmt.Errorf("unknown data format: %s", inFormat)
+	}
+
+	return nil
 }


### PR DESCRIPTION
These are some fixes and refactorings that were made while implementing the cloud-init changes mentioned in #10.

These include:

- Updating Makefile to properly find all source files to know when to rebuild
- Improving some of the client error messages when reading payload data
- Fixing an error when trying to marshal an HTTP body using the new `format` package
  - Includes changing `format.FormatData()` into `format.UnmarshalData()` and `format.MarshalData()`
- Changing the `--format-input` and `--format-output` flags to use an enum to better handle unknown/unsupported formats