### PR TITLE
feat: add "bss boot image set"

### DIFF
--- a/cmd/bss-boot-image-set.go
+++ b/cmd/bss-boot-image-set.go
@@ -1,0 +1,184 @@
+// This source code is licensed under the license found in the LICENSE file at
+// the root directory of this source tree.
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+
+	"github.com/OpenCHAMI/bss/pkg/bssTypes"
+	"github.com/OpenCHAMI/ochami/internal/log"
+	"github.com/OpenCHAMI/ochami/pkg/client"
+	"github.com/OpenCHAMI/ochami/pkg/format"
+	"github.com/spf13/cobra"
+	kargs "github.com/synackd/go-kargs"
+)
+
+// bootImageSetCmd represents the "bss boot image set" command
+var bootImageSetCmd = &cobra.Command{
+	Use:   "set (-x <xname>[,...] | -m <mac>[,...] | -n <nid>[,...]) <image>",
+	Args:  cobra.ExactArgs(1),
+	Short: "Set root= kernel command line for one or more nodes, overwriting any previously set",
+	Long: `Set root= kernel command line for one or more nodes, overwriting any previously set.
+At least one of --xname, --mac, or --nid is required to tell ochami which
+components need modification.
+
+An access token is required.
+
+See ochami-bss(1) for more details.`,
+	Example: `  # Set nodes to boot live image
+  ochami bss boot image set --mac 00:de:ad:be:ef:00,de:ca:fc:0f:fe:ee live:https://172.16.0.254/image.squashfs`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Create client to use for requests
+		bssClient := bssGetClient(cmd, true)
+
+		// Get current kernel command line args
+		values := url.Values{}
+		if cmd.Flag("xname").Changed {
+			s, err := cmd.Flags().GetStringSlice("xname")
+			if err != nil {
+				log.Logger.Error().Err(err).Msg("unable to fetch xname list")
+				logHelpError(cmd)
+				os.Exit(1)
+			}
+			for _, x := range s {
+				values.Add("name", x)
+			}
+		}
+		if cmd.Flag("mac").Changed {
+			s, err := cmd.Flags().GetStringSlice("mac")
+			if err != nil {
+				log.Logger.Error().Err(err).Msg("unable to fetch mac list")
+				logHelpError(cmd)
+				os.Exit(1)
+			}
+			for _, m := range s {
+				values.Add("mac", m)
+			}
+		}
+		if cmd.Flag("nid").Changed {
+			s, err := cmd.Flags().GetInt32Slice("nid")
+			if err != nil {
+				log.Logger.Error().Err(err).Msg("unable to fetch nid list")
+				logHelpError(cmd)
+				os.Exit(1)
+			}
+			for _, n := range s {
+				values.Add("nid", fmt.Sprintf("%d", n))
+			}
+		}
+		qstr := values.Encode()
+		httpEnv, err := bssClient.GetBootParams(qstr, token)
+		if err != nil {
+			if errors.Is(err, client.UnsuccessfulHTTPError) {
+				log.Logger.Error().Err(err).Msg("BSS boot parameter request yielded unsuccessful HTTP response")
+			} else {
+				log.Logger.Error().Err(err).Msg("failed to request boot parameters from BSS")
+			}
+			logHelpError(cmd)
+			os.Exit(1)
+		}
+		var bps []bssTypes.BootParams
+		if err := format.UnmarshalData(httpEnv.Body, &bps, format.DataFormatJson); err != nil {
+			log.Logger.Error().Err(err).Msg("failed to unmarshal boot params")
+			logHelpError(cmd)
+			os.Exit(1)
+		}
+		if len(bps) == 0 {
+			log.Logger.Error().Msg("no boot params to edit")
+			logHelpError(cmd)
+			os.Exit(1)
+		}
+
+		// Warn user of any xnames/nids/macs not found
+		hostsFound := make(map[string]bool)
+		nidsFound := make(map[int32]bool)
+		macsFound := make(map[string]bool)
+		for _, bp := range bps {
+			for _, host := range bp.Hosts {
+				hostsFound[host] = true
+			}
+			for _, nid := range bp.Nids {
+				nidsFound[nid] = true
+			}
+			for _, mac := range bp.Macs {
+				macsFound[mac] = true
+			}
+		}
+		if cmd.Flag("xname").Changed {
+			s, err := cmd.Flags().GetStringSlice("xname")
+			if err != nil {
+				log.Logger.Error().Err(err).Msg("unable to fetch xname list")
+				logHelpError(cmd)
+				os.Exit(1)
+			}
+			for _, h := range s {
+				if _, hFound := hostsFound[h]; !hFound {
+					log.Logger.Warn().Msgf("host %s not found, not updating", h)
+				}
+			}
+		}
+		if cmd.Flag("nid").Changed {
+			s, err := cmd.Flags().GetInt32Slice("nid")
+			if err != nil {
+				log.Logger.Error().Err(err).Msg("unable to fetch nid list")
+				logHelpError(cmd)
+				os.Exit(1)
+			}
+			for _, n := range s {
+				if _, nFound := nidsFound[n]; !nFound {
+					log.Logger.Warn().Msgf("node ID %d not found, not updating", n)
+				}
+			}
+		}
+		if cmd.Flag("mac").Changed {
+			s, err := cmd.Flags().GetStringSlice("mac")
+			if err != nil {
+				log.Logger.Error().Err(err).Msg("unable to fetch mac list")
+				logHelpError(cmd)
+				os.Exit(1)
+			}
+			for _, m := range s {
+				if _, mFound := macsFound[m]; !mFound {
+					log.Logger.Warn().Msgf("mac %s not found, not updating", m)
+				}
+			}
+		}
+
+		errorsOccurred := false
+		for bpIdx, bp := range bps {
+			// Edit parameters for nodes
+			k := kargs.NewKargs([]byte(bp.Params))
+			k.SetKarg("root", args[0])
+			bps[bpIdx].Params = k.String()
+
+			// Send modified params back to BSS
+			_, err = bssClient.PutBootParams(bps[bpIdx], token)
+			if err != nil {
+				if errors.Is(err, client.UnsuccessfulHTTPError) {
+					log.Logger.Error().Err(err).Msg("BSS boot parameter PUT request yielded unsuccessful HTTP response")
+				} else {
+					log.Logger.Error().Err(err).Msg("failed to set boot parameters in BSS")
+				}
+				errorsOccurred = true
+			}
+		}
+		if errorsOccurred {
+			log.Logger.Warn().Msg("updating boot images completed with errors")
+			logHelpWarn(cmd)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	bootImageSetCmd.Flags().StringSliceP("xname", "x", []string{}, "one or more xnames whose boot parameters to set")
+	bootImageSetCmd.Flags().StringSliceP("mac", "m", []string{}, "one or more MAC addresses whose boot parameters to set")
+	bootImageSetCmd.Flags().Int32SliceP("nid", "n", []int32{}, "one or more node IDs whose boot parameters to set")
+
+	bootImageSetCmd.MarkFlagsOneRequired("xname", "mac", "nid")
+
+	bootImageCmd.AddCommand(bootImageSetCmd)
+}

--- a/cmd/bss-boot-image.go
+++ b/cmd/bss-boot-image.go
@@ -1,0 +1,29 @@
+// This source code is licensed under the license found in the LICENSE file at
+// the root directory of this source tree.
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// bootImageCmd represents the "bss boot image" command
+var bootImageCmd = &cobra.Command{
+	Use:   "image",
+	Args:  cobra.NoArgs,
+	Short: "Get and set boot image for nodes",
+	Long: `Get and set boot image for nodes. This is a metacommand.
+
+See ochami-bss(1) for more details.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			printUsageHandleError(cmd)
+			os.Exit(0)
+		}
+	},
+}
+
+func init() {
+	bootCmd.AddCommand(bootImageCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/openchami/schemas v0.0.0-20240826142248-37b8af32208a
 	github.com/rs/zerolog v1.33.0
 	github.com/spf13/cobra v1.8.1
+	github.com/synackd/go-kargs v0.0.1-beta.1
 	github.com/vbauerster/mpb/v8 v8.9.3
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -198,6 +198,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -207,6 +208,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/synackd/go-kargs v0.0.1-beta.1 h1:Ef/Fvla5R8ZXgINLWiSylwHbgl5bZLeLJhJZbSGP4UU=
+github.com/synackd/go-kargs v0.0.1-beta.1/go.mod h1:3WRYU3XCDcxsdxX/Mru0HFLWakmcmhWluipYRsj0Avw=
 github.com/vbauerster/mpb/v8 v8.9.3 h1:PnMeF+sMvYv9u23l6DO6Q3+Mdj408mjLRXIzmUmU2Z8=
 github.com/vbauerster/mpb/v8 v8.9.3/go.mod h1:hxS8Hz4C6ijnppDSIX6LjG8FYJSoPo9iIOcE53Zik0c=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=

--- a/man/ochami-bss.1.sc
+++ b/man/ochami-bss.1.sc
@@ -6,7 +6,8 @@ ochami-bss - Communicate with the Boot Script Service (BSS)
 
 # SYNOPSIS
 
-ochami bss boot params (add | delete | get | set | update) [OPTIONS]
+ochami bss boot image set [OPTIONS]++
+ochami bss boot params (add | delete | get | set | update) [OPTIONS]++
 ochami bss boot script get [OPTIONS]
 
 # DATA STRUCTURE
@@ -40,6 +41,40 @@ The data structure for sending and receiving data with subcommands under the
 	cluster configuration options.
 
 # COMMANDS
+
+## boot image
+
+Manage how nodes boot images.
+
+Subcommands for this command are as follows:
+
+*set* (-x _xname_[,...] | -m _mac_[,...] | -n _nid_[,...]) _image_
+	Set nodes to boot _image_. Nodes are specified by either *-x*, *-m*, and/or
+	*-n*. At least one of these flags is required. This command works by
+	fetching the boot parameters of the selected nodes, setting the *root=*
+	kernel command	line argument of the selected nodes to _image_ (no checks
+	are performed on the value of _image_ before setting), and the modified
+	kernel command line arguments are updated in BSS. Boot parameters must exist
+	in BSS for the selected nodes for them to be updated. Otherwise, they are
+	skipped.
+
+	This command accepts the following options:
+
+	*-m, --mac* _mac_addr_,...
+		Change the boot image for one or more MAC addresses. For multiple MAC
+		addresses, either this flag can be specified multiple times or this flag
+		can be specified once and multiple MAC addresses can be specified,
+		separated by commas.
+
+	*-n, --nid* _nid_,...
+		Change the boot image for one or more node IDs. For multiple NIDs,
+		either this flag can be specified multiple times or this flag can be
+		specified once and multiple NIDs can be specified, separated by commas.
+
+	*-x, --xname* _xname_,...
+		Change the boot image for one or more xnames. For multiple xnames,
+		either this flag can be specified multiple times or this flag can be
+		specified once and multiple xnames, separated by commas.
 
 ## boot params
 


### PR DESCRIPTION
Closes #17 

Add the `ochami bss boot image set` command to set the boot image for one or more nodes. This provides a convenience so that one need not rewrite the _whole_ kernel command line with `ochami boot params set` when wanting to change just the boot image.

Rather than adding flags and functionality to each command under `ochami bss boot params`, it makes more sense to have a separate command for this since the flag for the boot params subcommands are already a bit complex.

The `set` subcommand works by:

1. Fetching the current boot params for the selected nodes (warning the user if any specified don't exist)
2. Modifying the `root=` kernel command line argument locally using the [`go-kargs`](https://github.com/synackd/go-kargs) library
3. Sending the modified params back to BSS using PUT.

Usage:

```
ochami bss boot image set (-x <xname>[,...] | -m <mac>[,...] | -n <nid>[,...]) <image>
```

Example:

```
ochami bss boot image set --mac 00:de:ad:be:ef:00,de:ca:fc:0f:fe:ee live:https://172.16.0.254/image.squashfs
```