### PR TITLE
feat: change `--force` to `--no-confirm` for clarity

### DIFF
--- a/cmd/bss-boot-params-delete.go
+++ b/cmd/bss-boot-params-delete.go
@@ -23,7 +23,7 @@ var bootParamsDeleteCmd = &cobra.Command{
 This command can delete boot parameters by config (kernel URI,
 initrd URI, or kernel command line) or by component (--xname,
 --mac, or --nid). The user will be asked for confirmation before
-deletion unless --force is passed. Alternatively, pass -d to pass
+deletion unless --no-confirm is passed. Alternatively, pass -d to pass
 raw payload data or (if flag argument starts with @) a file containing
 the payload data. -f can be specified to change the format of the
 input payload data ('json' by default), but the rules above still
@@ -146,9 +146,9 @@ See ochami-bss(1) for more details.`,
 			}
 		}
 
-		// Ask before attempting deletion unless --force was passed
-		if !cmd.Flag("force").Changed {
-			log.Logger.Debug().Msg("--force not passed, prompting user to confirm deletion")
+		// Ask before attempting deletion unless --no-confirm was passed
+		if !cmd.Flag("no-confirm").Changed {
+			log.Logger.Debug().Msg("--no-confirm not passed, prompting user to confirm deletion")
 			respDelete := loopYesNo("Really delete?")
 			if !respDelete {
 				log.Logger.Info().Msg("User aborted boot parameter deletion")
@@ -181,7 +181,7 @@ func init() {
 	bootParamsDeleteCmd.Flags().Int32SliceP("nid", "n", []int32{}, "one or more node IDs whose boot parameters to delete")
 	bootParamsDeleteCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
 	bootParamsDeleteCmd.Flags().VarP(&formatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
-	bootParamsDeleteCmd.Flags().Bool("force", false, "do not ask before attempting deletion")
+	bootParamsDeleteCmd.Flags().Bool("no-confirm", false, "do not ask before attempting deletion")
 
 	// We can delete either by component or by boot parameters
 	bootParamsDeleteCmd.MarkFlagsOneRequired("xname", "mac", "nid", "kernel", "initrd", "params", "data")

--- a/cmd/cloud_init-group-delete.go
+++ b/cmd/cloud_init-group-delete.go
@@ -68,9 +68,9 @@ See ochami-cloud-init(1) for more details.`,
 			groupsToDel = args
 		}
 
-		// Ask before attempting deletion unless --force was passed
-		if !cmd.Flag("force").Changed {
-			log.Logger.Debug().Msg("--force not passed, prompting user to confirm deletion")
+		// Ask before attempting deletion unless --no-confirm was passed
+		if !cmd.Flag("no-confirm").Changed {
+			log.Logger.Debug().Msg("--no-confirm not passed, prompting user to confirm deletion")
 			respDelete := loopYesNo("Really delete?")
 			if !respDelete {
 				log.Logger.Info().Msg("User aborted cloud-init group deletion")
@@ -109,7 +109,7 @@ See ochami-cloud-init(1) for more details.`,
 }
 
 func init() {
-	cloudInitGroupDeleteCmd.Flags().Bool("force", false, "do not ask before attempting deletion")
+	cloudInitGroupDeleteCmd.Flags().Bool("no-confirm", false, "do not ask before attempting deletion")
 	cloudInitGroupDeleteCmd.Flags().VarP(&formatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
 	cloudInitGroupDeleteCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
 

--- a/cmd/smd-compep-delete.go
+++ b/cmd/smd-compep-delete.go
@@ -80,9 +80,9 @@ See ochami-smd(1) for more details.`,
 		// Check if a CA certificate was passed and load it into client if valid
 		useCACert(smdClient.OchamiClient)
 
-		// Ask before attempting deletion unless --force was passed
-		if !cmd.Flag("force").Changed {
-			log.Logger.Debug().Msg("--force not passed, prompting user to confirm deletion")
+		// Ask before attempting deletion unless --no-confirm was passed
+		if !cmd.Flag("no-confirm").Changed {
+			log.Logger.Debug().Msg("--no-confirm not passed, prompting user to confirm deletion")
 			var respDelete bool
 			if cmd.Flag("all").Changed {
 				respDelete = loopYesNo("Really delete ALL COMPONENT ENDPOINTS?")
@@ -156,7 +156,7 @@ func init() {
 	compepDeleteCmd.Flags().BoolP("all", "a", false, "delete all redfish endpoints in SMD")
 	compepDeleteCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
 	compepDeleteCmd.Flags().VarP(&formatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
-	compepDeleteCmd.Flags().Bool("force", false, "do not ask before attempting deletion")
+	compepDeleteCmd.Flags().Bool("no-confirm", false, "do not ask before attempting deletion")
 
 	compepDeleteCmd.RegisterFlagCompletionFunc("format-input", completionFormatData)
 

--- a/cmd/smd-component-delete.go
+++ b/cmd/smd-component-delete.go
@@ -80,9 +80,9 @@ See ochami-smd(1) for more details.`,
 		// Check if a CA certificate was passed and load it into client if valid
 		useCACert(smdClient.OchamiClient)
 
-		// Ask before attempting deletion unless --force was passed
-		if !cmd.Flag("force").Changed {
-			log.Logger.Debug().Msg("--force not passed, prompting user to confirm deletion")
+		// Ask before attempting deletion unless --no-confirm was passed
+		if !cmd.Flag("no-confirm").Changed {
+			log.Logger.Debug().Msg("--no-confirm not passed, prompting user to confirm deletion")
 			var respDelete bool
 			if cmd.Flag("all").Changed {
 				respDelete = loopYesNo("Really delete ALL COMPONENTS?")
@@ -153,7 +153,7 @@ func init() {
 	componentDeleteCmd.Flags().BoolP("all", "a", false, "delete all components in SMD")
 	componentDeleteCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
 	componentDeleteCmd.Flags().VarP(&formatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
-	componentDeleteCmd.Flags().Bool("force", false, "do not ask before attempting deletion")
+	componentDeleteCmd.Flags().Bool("no-confirm", false, "do not ask before attempting deletion")
 
 	componentDeleteCmd.RegisterFlagCompletionFunc("format-input", completionFormatData)
 

--- a/cmd/smd-group-delete.go
+++ b/cmd/smd-group-delete.go
@@ -78,9 +78,9 @@ See ochami-smd(1) for more details.`,
 		// Check if a CA certificate was passed and load it into client if valid
 		useCACert(smdClient.OchamiClient)
 
-		// Ask before attempting deletion unless --force was passed
-		if !cmd.Flag("force").Changed {
-			log.Logger.Debug().Msg("--force not passed, prompting user to confirm deletion")
+		// Ask before attempting deletion unless --no-confirm was passed
+		if !cmd.Flag("no-confirm").Changed {
+			log.Logger.Debug().Msg("--no-confirm not passed, prompting user to confirm deletion")
 			respDelete := loopYesNo("Really delete?")
 			if !respDelete {
 				log.Logger.Info().Msg("User aborted group deletion")
@@ -133,7 +133,7 @@ See ochami-smd(1) for more details.`,
 func init() {
 	groupDeleteCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
 	groupDeleteCmd.Flags().VarP(&formatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
-	groupDeleteCmd.Flags().Bool("force", false, "do not ask before attempting deletion")
+	groupDeleteCmd.Flags().Bool("no-confirm", false, "do not ask before attempting deletion")
 
 	groupDeleteCmd.RegisterFlagCompletionFunc("format-input", completionFormatData)
 

--- a/cmd/smd-group-member-delete.go
+++ b/cmd/smd-group-member-delete.go
@@ -45,9 +45,9 @@ See ochami-smd(1) for more details.`,
 		// Check if a CA certificate was passed and load it into client if valid
 		useCACert(smdClient.OchamiClient)
 
-		// Ask before attempting deletion unless --force was passed
-		if !cmd.Flag("force").Changed {
-			log.Logger.Debug().Msg("--force not passed, prompting user to confirm deletion")
+		// Ask before attempting deletion unless --no-confirm was passed
+		if !cmd.Flag("no-confirm").Changed {
+			log.Logger.Debug().Msg("--no-confirm not passed, prompting user to confirm deletion")
 			respDelete := loopYesNo("Really delete?")
 			if !respDelete {
 				log.Logger.Info().Msg("User aborted group deletion")
@@ -87,6 +87,6 @@ See ochami-smd(1) for more details.`,
 }
 
 func init() {
-	groupMemberDeleteCmd.Flags().Bool("force", false, "do not ask before attempting deletion")
+	groupMemberDeleteCmd.Flags().Bool("no-confirm", false, "do not ask before attempting deletion")
 	groupMemberCmd.AddCommand(groupMemberDeleteCmd)
 }

--- a/cmd/smd-iface-delete.go
+++ b/cmd/smd-iface-delete.go
@@ -79,9 +79,9 @@ See ochami-smd(1) for more details.`,
 		// Check if a CA certificate was passed and load it into client if valid
 		useCACert(smdClient.OchamiClient)
 
-		// Ask before attempting deletion unless --force was passed
-		if !cmd.Flag("force").Changed {
-			log.Logger.Debug().Msg("--force not passed, prompting user to confirm deletion")
+		// Ask before attempting deletion unless --no-confirm was passed
+		if !cmd.Flag("no-confirm").Changed {
+			log.Logger.Debug().Msg("--no-confirm not passed, prompting user to confirm deletion")
 			var respDelete bool
 			if cmd.Flag("all").Changed {
 				respDelete = loopYesNo("Really delete ALL ETHERNET INTERFACES?")
@@ -155,7 +155,7 @@ func init() {
 	ifaceDeleteCmd.Flags().BoolP("all", "a", false, "delete all ethernet interfaces in SMD")
 	ifaceDeleteCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
 	ifaceDeleteCmd.Flags().VarP(&formatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
-	ifaceDeleteCmd.Flags().Bool("force", false, "do not ask before attempting deletion")
+	ifaceDeleteCmd.Flags().Bool("no-confirm", false, "do not ask before attempting deletion")
 
 	ifaceDeleteCmd.RegisterFlagCompletionFunc("format-input", completionFormatData)
 

--- a/cmd/smd-rfe-delete.go
+++ b/cmd/smd-rfe-delete.go
@@ -79,9 +79,9 @@ See ochami-smd(1) for more details.`,
 		// Check if a CA certificate was passed and load it into client if valid
 		useCACert(smdClient.OchamiClient)
 
-		// Ask before attempting deletion unless --force was passed
-		if !cmd.Flag("force").Changed {
-			log.Logger.Debug().Msg("--force not passed, prompting user to confirm deletion")
+		// Ask before attempting deletion unless --no-confirm was passed
+		if !cmd.Flag("no-confirm").Changed {
+			log.Logger.Debug().Msg("--no-confirm not passed, prompting user to confirm deletion")
 			var respDelete bool
 			if cmd.Flag("all").Changed {
 				respDelete = loopYesNo("Really delete ALL REDFISH ENDPOINTS?")
@@ -155,7 +155,7 @@ func init() {
 	rfeDeleteCmd.Flags().BoolP("all", "a", false, "delete all redfish endpoints in SMD")
 	rfeDeleteCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
 	rfeDeleteCmd.Flags().VarP(&formatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
-	rfeDeleteCmd.Flags().Bool("force", false, "do not ask before attempting deletion")
+	rfeDeleteCmd.Flags().Bool("no-confirm", false, "do not ask before attempting deletion")
 
 	rfeDeleteCmd.RegisterFlagCompletionFunc("format-input", completionFormatData)
 

--- a/man/ochami-bss.1.sc
+++ b/man/ochami-bss.1.sc
@@ -113,14 +113,14 @@ Subcommands for this command are as follows:
 	*--params* _kernel_params_
 		Command line arguments to pass to kernel for components.
 
-*delete* [--force] ([--mac, _mac_,...] [--nid, _nid_,...] [--xname _xname_,...] [--kernel _kernel_] [--initrd _initrd_])++
-*delete* [--force] -d _data_ [-f _format_]++
-*delete* [--force] -d @_file_ [-f _format_]++
-*delete* [--force] -d @- [-f _format_]
+*delete* [--no-confirm] ([--mac, _mac_,...] [--nid, _nid_,...] [--xname _xname_,...] [--kernel _kernel_] [--initrd _initrd_])++
+*delete* [--no-confirm] -d _data_ [-f _format_]++
+*delete* [--no-confirm] -d @_file_ [-f _format_]++
+*delete* [--no-confirm] -d @- [-f _format_]
 	Delete boot parameters for one or more components. Which boot parameters are
 	deleted are determined by passed filters, which can be passed via CLI flag
-	or within a payload file. Unless *--force* is passed, the user is asked to
-	confirm deletion.
+	or within a payload file. Unless *--no-confirm* is passed, the user is asked
+	to confirm deletion.
 
 	In the first form of the command, one or more of *--mac*, *--nid*,
 	*--xname*, *--kernel*, or *--initrd* is required to identify which
@@ -148,7 +148,7 @@ Subcommands for this command are as follows:
 		read in any of these forms is JSON by default unless *-f* is specified
 		to change it.
 
-	*--force*
+	*--no-confirm*
 		Do not ask the user to confirm deletion. Use with caution.
 
 	*-f, --format-input* _format_

--- a/man/ochami-cloud-init.1.sc
+++ b/man/ochami-cloud-init.1.sc
@@ -134,7 +134,10 @@ An example in JSON format is:
 
 ## NODE USER-DATA
 
-Node-specific user-data is used with the */cloud-init/impersonation/{id}/user-data* and */cloud-init/user-data* endpoints. In the OpenCHAMI cloud-init server, user-data is always empty and is not used.
+Node-specific user-data is used with the
+*/cloud-init/impersonation/{id}/user-data* and */cloud-init/user-data*
+endpoints. In the OpenCHAMI cloud-init server, user-data is always empty and is
+not used.
 
 For example, any node that requests its user-data will get the following back:
 

--- a/man/ochami-cloud-init.1.sc
+++ b/man/ochami-cloud-init.1.sc
@@ -278,10 +278,10 @@ Subcommands for this command are as follows:
 		- _json-pretty_
 		- _yaml_
 
-*delete* [--force] _group_name_...++
-*delete* [--force] [-f _format_] -d @_file_++
-*delete* [--force] [-f _format_] -d @- < _file_++
-*delete* [--force] [-f _format_] -d _data_
+*delete* [--no-confirm] _group_name_...++
+*delete* [--no-confirm] [-f _format_] -d @_file_++
+*delete* [--no-confirm] [-f _format_] -d @- < _file_++
+*delete* [--no-confirm] [-f _format_] -d _data_
 	Delete one or more cloud-init groups, identified by one or more _group_name_
 	arguments or *name* fields in payload data.
 
@@ -308,7 +308,7 @@ Subcommands for this command are as follows:
 		read in any of these forms is JSON by default unless *-f* is specified
 		to change it.
 
-	*--force*
+	*--no-confirm*
 		Do not ask the user to confirm deletion. Use with caution.
 
 	*-f, --format-input* _format_

--- a/man/ochami-smd.1.sc
+++ b/man/ochami-smd.1.sc
@@ -236,13 +236,13 @@ Manage component endpoints.
 
 Subcommands for this command are as follows:
 
-*delete* [--force] --all++
-*delete* [--force] _xname_...++
-*delete* [--force] -d _data_ [-f _format_]++
-*delete* [--force] -d @_file_ [-f _format_]++
-*delete* [--force] -d @- [-f _format_]
-	Delete one or more component endpoints. Unless *--force* is passed, the user
-	is asked to confirm deletion.
+*delete* [--no-confirm] --all++
+*delete* [--no-confirm] _xname_...++
+*delete* [--no-confirm] -d _data_ [-f _format_]++
+*delete* [--no-confirm] -d @_file_ [-f _format_]++
+*delete* [--no-confirm] -d @- [-f _format_]
+	Delete one or more component endpoints. Unless *--no-confirm* is passed, the
+	user is asked to confirm deletion.
 
 	In the first form of the command, all component endpoints are deleted. *BE
 	CAREFUL!*
@@ -274,7 +274,7 @@ Subcommands for this command are as follows:
 		read in any of these forms is JSON by default unless *-f* is specified
 		to change it.
 
-	*--force*
+	*--no-confirm*
 		Do not ask the user to confirm deletion. Use with caution.
 
 	*-f, --format-input* _format_
@@ -369,8 +369,8 @@ Subcommands for this command are as follows:
 *delete* -d _data_ [-f _format_]++
 *delete* -d @_file_ [-f _format_]++
 *delete* -d @- [-f _format_]
-	Delete one or more components in SMD. Unless *--force* is passed, the user
-	is asked to confirm deletion.
+	Delete one or more components in SMD. Unless *--no-confirm* is passed, the
+	user is asked to confirm deletion.
 
 	In the first form of the command, all components are deleted. *BE CAREFUL!*
 
@@ -400,7 +400,7 @@ Subcommands for this command are as follows:
 		read in any of these forms is JSON by default unless *-f* is specified
 		to change it.
 
-	*--force*
+	*--no-confirm*
 		Do not ask the user to confirm deletion. Use with caution.
 
 	*-f, --format-input* _format_
@@ -502,12 +502,12 @@ Subcommands for this command are as follows:
 		flag can be specified multiple times or this flag can be specified once
 		and multiple tags can be specified, separated by commas.
 
-*delete* [--force] _group_name_...++
-*delete* [--force] -d _data_ [-f _format_]++
-*delete* [--force] -d @_file_ [-f _format_]++
-*delete* [--force] -d @- [-f _format_]
-	Delete one or more groups in SMD. Unless *--force* is passed, the user is
-	asked to confirm deletion.
+*delete* [--no-confirm] _group_name_...++
+*delete* [--no-confirm] -d _data_ [-f _format_]++
+*delete* [--no-confirm] -d @_file_ [-f _format_]++
+*delete* [--no-confirm] -d @- [-f _format_]
+	Delete one or more groups in SMD. Unless *--no-confirm* is passed, the user
+	is asked to confirm deletion.
 
 	In the first form of the command, one or more group labels can be specified
 	to delete one or more groups.
@@ -531,7 +531,7 @@ Subcommands for this command are as follows:
 		read in any of these forms is JSON by default unless *-f* is specified
 		to change it.
 
-	*--force*
+	*--no-confirm*
 		Do not ask the user to confirm deletion. Use with caution.
 
 	*-f, --format-input* _format_


### PR DESCRIPTION
From [this comment](https://github.com/OpenCHAMI/ochami/pull/19#discussion_r2031951786), `--no-confirm` was identified as a more succinct way of telling `ochami` not to prompt the user to ask if they really want to delete something than `--force`.