### PR TITLE
refactor: put client creation routine into lib functions

### DIFF
--- a/cmd/bss-boot-params-add.go
+++ b/cmd/bss-boot-params-add.go
@@ -9,7 +9,6 @@ import (
 	"github.com/OpenCHAMI/bss/pkg/bssTypes"
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/pkg/client"
-	"github.com/OpenCHAMI/ochami/pkg/client/bss"
 	"github.com/spf13/cobra"
 )
 
@@ -60,28 +59,8 @@ See ochami-bss(1) for more details.`,
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		bssBaseURI, err := getBaseURIBSS(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for BSS")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// This endpoint requires authentication, so a token is needed
-		setTokenFromEnvVar(cmd)
-		checkToken(cmd)
-
-		// Create client to make request to BSS
-		bssClient, err := bss.NewClient(bssBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new BSS client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(bssClient.OchamiClient)
+		// Create client to use for requests
+		bssClient := bssGetClient(cmd, true)
 
 		// The BSS BootParams struct we will send
 		bp := bssTypes.BootParams{}
@@ -90,6 +69,7 @@ See ochami-bss(1) for more details.`,
 		handlePayload(cmd, &bp)
 
 		// Set the hosts the boot parameters are for
+		var err error
 		if cmd.Flag("xname").Changed {
 			bp.Hosts, err = cmd.Flags().GetStringSlice("xname")
 			if err != nil {

--- a/cmd/bss-boot-params-delete.go
+++ b/cmd/bss-boot-params-delete.go
@@ -9,7 +9,6 @@ import (
 	"github.com/OpenCHAMI/bss/pkg/bssTypes"
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/pkg/client"
-	"github.com/OpenCHAMI/ochami/pkg/client/bss"
 	"github.com/spf13/cobra"
 )
 
@@ -60,28 +59,8 @@ See ochami-bss(1) for more details.`,
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		bssBaseURI, err := getBaseURIBSS(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for BSS")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// This endpoint requires authentication, so a token is needed
-		setTokenFromEnvVar(cmd)
-		checkToken(cmd)
-
-		// Create client to make request to BSS
-		bssClient, err := bss.NewClient(bssBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new BSS client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(bssClient.OchamiClient)
+		// Create client to use for requests
+		bssClient := bssGetClient(cmd, true)
 
 		// The BSS BootParams struct we will send
 		bp := bssTypes.BootParams{}
@@ -90,6 +69,7 @@ See ochami-bss(1) for more details.`,
 		handlePayload(cmd, &bp)
 
 		// Set the hosts the boot parameters are for
+		var err error
 		if cmd.Flag("xname").Changed {
 			bp.Hosts, err = cmd.Flags().GetStringSlice("xname")
 			if err != nil {

--- a/cmd/bss-boot-params-get.go
+++ b/cmd/bss-boot-params-get.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/pkg/client"
-	"github.com/OpenCHAMI/ochami/pkg/client/bss"
 	"github.com/spf13/cobra"
 )
 
@@ -31,27 +30,8 @@ See ochami-bss(1) for more details.`,
   ochami bss boot params get --mac 00:de:ad:be:ef:00,00:c0:ff:ee:00:00
   ochami bss boot params get --mac 00:de:ad:be:ef:00 --mac 00:c0:ff:ee:00:00`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		bssBaseURI, err := getBaseURIBSS(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for BSS")
-			os.Exit(1)
-		}
-
-		// This endpoint requires authentication, so a token is needed
-		setTokenFromEnvVar(cmd)
-		checkToken(cmd)
-
-		// Create client to make request to BSS
-		bssClient, err := bss.NewClient(bssBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new BSS client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(bssClient.OchamiClient)
+		// Create client to use for requests
+		bssClient := bssGetClient(cmd, true)
 
 		// If no ID flags are specified, get all boot parameters
 		qstr := ""

--- a/cmd/bss-boot-params-set.go
+++ b/cmd/bss-boot-params-set.go
@@ -9,7 +9,6 @@ import (
 	"github.com/OpenCHAMI/bss/pkg/bssTypes"
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/pkg/client"
-	"github.com/OpenCHAMI/ochami/pkg/client/bss"
 	"github.com/spf13/cobra"
 )
 
@@ -60,28 +59,8 @@ See ochami-bss(1) for more details.`,
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		bssBaseURI, err := getBaseURIBSS(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for BSS")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// This endpoint requires authentication, so a token is needed
-		setTokenFromEnvVar(cmd)
-		checkToken(cmd)
-
-		// Create client to make request to BSS
-		bssClient, err := bss.NewClient(bssBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new BSS client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(bssClient.OchamiClient)
+		// Create client to use for requests
+		bssClient := bssGetClient(cmd, true)
 
 		// The BSS BootParams struct we will send
 		bp := bssTypes.BootParams{}
@@ -90,6 +69,7 @@ See ochami-bss(1) for more details.`,
 		handlePayload(cmd, &bp)
 
 		// Set the hosts the boot parameters are for
+		var err error
 		if cmd.Flag("xname").Changed {
 			bp.Hosts, err = cmd.Flags().GetStringSlice("xname")
 			if err != nil {

--- a/cmd/bss-boot-params-update.go
+++ b/cmd/bss-boot-params-update.go
@@ -9,7 +9,6 @@ import (
 	"github.com/OpenCHAMI/bss/pkg/bssTypes"
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/pkg/client"
-	"github.com/OpenCHAMI/ochami/pkg/client/bss"
 	"github.com/spf13/cobra"
 )
 
@@ -58,28 +57,8 @@ See ochami-bss(1) for details.`,
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		bssBaseURI, err := getBaseURIBSS(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for BSS")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// This endpoint requires authentication, so a token is needed
-		setTokenFromEnvVar(cmd)
-		checkToken(cmd)
-
-		// Create client to make request to BSS
-		bssClient, err := bss.NewClient(bssBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new BSS client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(bssClient.OchamiClient)
+		// Create client to use for requests
+		bssClient := bssGetClient(cmd, true)
 
 		// The BSS BootParams struct we will send
 		bp := bssTypes.BootParams{}
@@ -88,6 +67,7 @@ See ochami-bss(1) for details.`,
 		handlePayload(cmd, &bp)
 
 		// Set the hosts the boot parameters are for
+		var err error
 		if cmd.Flag("xname").Changed {
 			bp.Hosts, err = cmd.Flags().GetStringSlice("xname")
 			if err != nil {

--- a/cmd/bss-boot-script-get.go
+++ b/cmd/bss-boot-script-get.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/pkg/client"
-	"github.com/OpenCHAMI/ochami/pkg/client/bss"
 	"github.com/spf13/cobra"
 )
 
@@ -27,24 +26,8 @@ This command sends a GET to BSS. An access token is not required.
 See ochami-bss(1) for more details.`,
 	Example: `  ochami boot script get --mac 00:c0:ff:ee:00:00`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		bssBaseURI, err := getBaseURIBSS(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for BSS")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Create client to make request to BSS
-		bssClient, err := bss.NewClient(bssBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new BSS client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(bssClient.OchamiClient)
+		// Create client to use for requests
+		bssClient := bssGetClient(cmd, false)
 
 		// Structure representing the boot script query string
 		values := url.Values{}

--- a/cmd/bss-dumpstate.go
+++ b/cmd/bss-dumpstate.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/pkg/client"
-	"github.com/OpenCHAMI/ochami/pkg/client/bss"
 	"github.com/spf13/cobra"
 )
 
@@ -22,24 +21,8 @@ var bssDumpStateCmd = &cobra.Command{
 
 See ochami-bss(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		bssBaseURI, err := getBaseURIBSS(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for BSS")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Create client to make request to BSS
-		bssClient, err := bss.NewClient(bssBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new BSS client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(bssClient.OchamiClient)
+		// Create client to use for requests
+		bssClient := bssGetClient(cmd, false)
 
 		// Send request
 		httpEnv, err := bssClient.GetDumpState()

--- a/cmd/bss-history.go
+++ b/cmd/bss-history.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/pkg/client"
-	"github.com/OpenCHAMI/ochami/pkg/client/bss"
 	"github.com/spf13/cobra"
 )
 
@@ -23,24 +22,8 @@ var bssHistoryCmd = &cobra.Command{
 
 See ochami-bss(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		bssBaseURI, err := getBaseURIBSS(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for BSS")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Create client to make request to BSS
-		bssClient, err := bss.NewClient(bssBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new BSS client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(bssClient.OchamiClient)
+		// Create client to use for requests
+		bssClient := bssGetClient(cmd, false)
 
 		// If no ID flags are specified, get all boot parameters
 		qstr := ""

--- a/cmd/bss-hosts-get.go
+++ b/cmd/bss-hosts-get.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/pkg/client"
-	"github.com/OpenCHAMI/ochami/pkg/client/bss"
 	"github.com/spf13/cobra"
 )
 
@@ -23,24 +22,8 @@ var bssHostsGetCmd = &cobra.Command{
 
 See ochami-bss(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		bssBaseURI, err := getBaseURIBSS(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for BSS")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Create client to make request to BSS
-		bssClient, err := bss.NewClient(bssBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new BSS client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(bssClient.OchamiClient)
+		// Create client to use for requests
+		bssClient := bssGetClient(cmd, false)
 
 		// If no ID flags are specified, get all boot parameters
 		qstr := ""

--- a/cmd/bss-status.go
+++ b/cmd/bss-status.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/pkg/client"
-	"github.com/OpenCHAMI/ochami/pkg/client/bss"
 	"github.com/spf13/cobra"
 )
 
@@ -22,27 +21,12 @@ var bssStatusCmd = &cobra.Command{
 
 See ochami-bss(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		bssBaseURI, err := getBaseURIBSS(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for BSS")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Create client to make request to BSS
-		bssClient, err := bss.NewClient(bssBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new BSS client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(bssClient.OchamiClient)
+		// Create client to use for requests
+		bssClient := bssGetClient(cmd, false)
 
 		// Determine which component to get status for and send request
 		var httpEnv client.HTTPEnvelope
+		var err error
 		if cmd.Flag("all").Changed {
 			httpEnv, err = bssClient.GetStatus("all")
 		} else if cmd.Flag("storage").Changed {

--- a/cmd/cloud_init-defaults-get.go
+++ b/cmd/cloud_init-defaults-get.go
@@ -22,7 +22,7 @@ See ochami-cloud-init(1) for more details.`,
 	Example: `  ochami cloud-init defaults get`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		cloudInitClient := cloudInitGetClient(cmd)
+		cloudInitClient := cloudInitGetClient(cmd, true)
 
 		// Get data
 		henv, err := cloudInitClient.GetDefaults(token)

--- a/cmd/cloud_init-defaults-set.go
+++ b/cmd/cloud_init-defaults-set.go
@@ -51,7 +51,7 @@ See ochami-cloud-init(1) for more details.`,
   echo '<yaml_data>' | ochami cloud-init defaults set -d @- -f yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		cloudInitClient := cloudInitGetClient(cmd)
+		cloudInitClient := cloudInitGetClient(cmd, true)
 
 		// The ClusterDefaults data we will send
 		ciDflts := cistore.ClusterDefaults{}

--- a/cmd/cloud_init-group-add.go
+++ b/cmd/cloud_init-group-add.go
@@ -51,7 +51,7 @@ See ochami-cloud-init(1) for more details.`,
   echo '<yaml_data>' | ochami cloud-init group add -d @- -f yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		cloudInitClient := cloudInitGetClient(cmd)
+		cloudInitClient := cloudInitGetClient(cmd, true)
 
 		// The group data we will send
 		ciGroups := []cistore.GroupData{}

--- a/cmd/cloud_init-group-delete.go
+++ b/cmd/cloud_init-group-delete.go
@@ -52,7 +52,7 @@ See ochami-cloud-init(1) for more details.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		cloudInitClient := cloudInitGetClient(cmd)
+		cloudInitClient := cloudInitGetClient(cmd, true)
 
 		// The group data we will send
 		ciGroups := []cistore.GroupData{}

--- a/cmd/cloud_init-group-get.go
+++ b/cmd/cloud_init-group-get.go
@@ -19,7 +19,7 @@ import (
 // requested groups. If an error occurs, the program exits.
 func cloudInitGetGroupData(cmd *cobra.Command, args []string) (groupSlice []cistore.GroupData) {
 	// Create client to use for requests
-	cloudInitClient := cloudInitGetClient(cmd)
+	cloudInitClient := cloudInitGetClient(cmd, true)
 
 	// Get data
 	if len(args) == 0 {

--- a/cmd/cloud_init-group-render.go
+++ b/cmd/cloud_init-group-render.go
@@ -35,7 +35,7 @@ See ochami-cloud-init(1) for more details.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		cloudInitClient := cloudInitGetClient(cmd)
+		cloudInitClient := cloudInitGetClient(cmd, true)
 
 		// Get group config
 		henvs, errs, err := cloudInitClient.GetNodeGroupData(token, args[1], args[0])

--- a/cmd/cloud_init-group-set.go
+++ b/cmd/cloud_init-group-set.go
@@ -51,7 +51,7 @@ See ochami-cloud-init(1) for more details.`,
   echo '<yaml_data>' | ochami cloud-init group set -d @- -f yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		cloudInitClient := cloudInitGetClient(cmd)
+		cloudInitClient := cloudInitGetClient(cmd, true)
 
 		// The list of group data we will send
 		ciGroups := []cistore.GroupData{}

--- a/cmd/cloud_init-node-get.go
+++ b/cmd/cloud_init-node-get.go
@@ -51,7 +51,7 @@ See ochami-cloud-init(1) for more details.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		cloudInitClient := cloudInitGetClient(cmd)
+		cloudInitClient := cloudInitGetClient(cmd, true)
 
 		// Get node group data
 		henvs, errs, err := cloudInitClient.GetNodeGroupData(token, args[0], args[1:]...)
@@ -127,7 +127,7 @@ See ochami-cloud-init(1) for more details.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		cloudInitClient := cloudInitGetClient(cmd)
+		cloudInitClient := cloudInitGetClient(cmd, true)
 
 		// Get meta-data
 		henvs, errs, err := cloudInitClient.GetNodeData(ci.CloudInitMetaData, token, args...)
@@ -211,7 +211,7 @@ See ochami-cloud-init(1) for more details.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		cloudInitClient := cloudInitGetClient(cmd)
+		cloudInitClient := cloudInitGetClient(cmd, true)
 
 		// Get user-data
 		henvs, errs, err := cloudInitClient.GetNodeData(ci.CloudInitUserData, token, args...)
@@ -282,7 +282,7 @@ See ochami-cloud-init(1) for more details.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		cloudInitClient := cloudInitGetClient(cmd)
+		cloudInitClient := cloudInitGetClient(cmd, true)
 
 		// Get vendor-data
 		henvs, errs, err := cloudInitClient.GetNodeData(ci.CloudInitVendorData, token, args...)

--- a/cmd/cloud_init-node-set.go
+++ b/cmd/cloud_init-node-set.go
@@ -55,7 +55,7 @@ See ochami-cloud-init(1) for more details.`,
   echo '<yaml_data>' | ochami cloud-init group set -d @- -f yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		cloudInitClient := cloudInitGetClient(cmd)
+		cloudInitClient := cloudInitGetClient(cmd, true)
 
 		// The instance information list we will send
 		ciInstInfo := []cistore.OpenCHAMIInstanceInfo{}

--- a/cmd/cloud_init.go
+++ b/cmd/cloud_init.go
@@ -61,15 +61,22 @@ func cloudInitCompletionHeaderWhen(cmd *cobra.Command, args []string, toComplete
 }
 
 // cloudInitGetClient sets up the cloud-init client with the cloud-init base URI
-// and certificates (if necessary) and returns it. This function is used by each
-// subcommand.
-func cloudInitGetClient(cmd *cobra.Command) *ci.CloudInitClient {
+// and certificates (if necessary) and returns it. If tokenRequired is true,
+// it will ensure that the token is set and valid and load it. This function is
+// used by each subcommand.
+func cloudInitGetClient(cmd *cobra.Command, tokenRequired bool) *ci.CloudInitClient {
 	// Without a base URI, we cannot do anything
 	cloudInitbaseURI, err := getBaseURICloudInit(cmd)
 	if err != nil {
 		log.Logger.Error().Err(err).Msg("failed to get base URI for cloud-init")
 		logHelpError(cmd)
 		os.Exit(1)
+	}
+
+	// Make sure token is set/valid, if required
+	if tokenRequired {
+		setTokenFromEnvVar(cmd)
+		checkToken(cmd)
 	}
 
 	// Create client to make request to cloud-init

--- a/cmd/pcs-status.go
+++ b/cmd/pcs-status.go
@@ -93,24 +93,8 @@ See ochami-pcs(1) for more details.`,
 	Example: `  # Get status of PCS
   ochami pcs status`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		pcsBaseURI, err := getBaseURIPCS(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for PCS")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Create client to make request to PCS
-		pcsClient, err := pcs.NewClient(pcsBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new PCS client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(pcsClient.OchamiClient)
+		// Create client to use for requests
+		pcsClient := pcsGetClient(cmd, false)
 
 		// Figure out if we need to hit the /health endpoint (only if a flag has been provided)
 		flagsProvided := false

--- a/cmd/pcs-transition-abort.go
+++ b/cmd/pcs-transition-abort.go
@@ -8,12 +8,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
-
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/pkg/client"
-	"github.com/OpenCHAMI/ochami/pkg/client/pcs"
 	"github.com/OpenCHAMI/ochami/pkg/format"
+	"github.com/spf13/cobra"
 )
 
 // pcsTransitionAbortCmd represents the "pcs transition abort" command
@@ -29,26 +27,8 @@ See ochami-pcs(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		transitionID := args[0]
 
-		// Without a base URI, we cannot do anything
-		pcsBaseURI, err := getBaseURIPCS(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for PCS")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// This endpoint requires authentication, so a token is needed
-		setTokenFromEnvVar(cmd)
-		checkToken(cmd)
-
-		// Create client to make request to PCS
-		pcsClient, err := pcs.NewClient(pcsBaseURI, insecure)
-		if err != nil {
-			log.Logger.Fatal().Err(err).Msg("error creating new PCS client")
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(pcsClient.OchamiClient)
+		// Create client to use for requests
+		pcsClient := pcsGetClient(cmd, true)
 
 		// Abort the transition
 		transitionHttpEnv, err := pcsClient.DeleteTransition(transitionID, token)

--- a/cmd/pcs-transition-abort.go
+++ b/cmd/pcs-transition-abort.go
@@ -34,25 +34,33 @@ See ochami-pcs(1) for more details.`,
 		transitionHttpEnv, err := pcsClient.DeleteTransition(transitionID, token)
 		if err != nil {
 			if errors.Is(err, client.UnsuccessfulHTTPError) {
-				log.Logger.Fatal().Err(err).Msg("PCS transition abort request yielded unsuccessful HTTP response")
+				log.Logger.Error().Err(err).Msg("PCS transition abort request yielded unsuccessful HTTP response")
 			} else {
-				log.Logger.Fatal().Err(err).Msg("failed to abort PCS transition")
+				log.Logger.Error().Err(err).Msg("failed to abort PCS transition")
 			}
+			logHelpError(cmd)
+			os.Exit(1)
 		}
 
 		if err != nil {
-			log.Logger.Fatal().Err(err).Msg("failed to abort transition")
+			log.Logger.Error().Err(err).Msg("failed to abort transition")
+			logHelpError(cmd)
+			os.Exit(1)
 		}
 
 		var output interface{}
 		err = json.Unmarshal(transitionHttpEnv.Body, &output)
 		if err != nil {
-			log.Logger.Fatal().Msg("failed to unmarshal abort transitions response")
+			log.Logger.Error().Err(err).Msg("failed to unmarshal abort transitions response")
+			logHelpError(cmd)
+			os.Exit(1)
 		}
 
 		// Print output
 		if outBytes, err := format.MarshalData(output, formatOutput); err != nil {
-			log.Logger.Fatal().Err(err).Msg("failed to format output")
+			log.Logger.Error().Err(err).Msg("failed to format output")
+			logHelpError(cmd)
+			os.Exit(1)
 		} else {
 			fmt.Println(string(outBytes))
 		}

--- a/cmd/pcs-transition-list.go
+++ b/cmd/pcs-transition-list.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/pkg/client"
-	"github.com/OpenCHAMI/ochami/pkg/client/pcs"
 	"github.com/OpenCHAMI/ochami/pkg/format"
 )
 
@@ -27,26 +26,8 @@ See ochami-pcs(1) for more details.`,
 	Example: `  # List transitions
   ochami pcs transition list`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		pcsBaseURI, err := getBaseURIPCS(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for PCS")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// This endpoint requires authentication, so a token is needed
-		setTokenFromEnvVar(cmd)
-		checkToken(cmd)
-
-		// Create client to make request to PCS
-		pcsClient, err := pcs.NewClient(pcsBaseURI, insecure)
-		if err != nil {
-			log.Logger.Fatal().Err(err).Msg("error creating new PCS client")
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(pcsClient.OchamiClient)
+		// Create client to use for requests
+		pcsClient := pcsGetClient(cmd, true)
 
 		// Get transitions
 		transitionsHttpEnv, err := pcsClient.GetTransitions(token)

--- a/cmd/pcs-transition-list.go
+++ b/cmd/pcs-transition-list.go
@@ -33,21 +33,27 @@ See ochami-pcs(1) for more details.`,
 		transitionsHttpEnv, err := pcsClient.GetTransitions(token)
 		if err != nil {
 			if errors.Is(err, client.UnsuccessfulHTTPError) {
-				log.Logger.Fatal().Err(err).Msg("PCS transitions request yielded unsuccessful HTTP response")
+				log.Logger.Error().Err(err).Msg("PCS transitions request yielded unsuccessful HTTP response")
 			} else {
-				log.Logger.Fatal().Err(err).Msg("failed to list PCS transitions")
+				log.Logger.Error().Err(err).Msg("failed to list PCS transitions")
 			}
+			logHelpError(cmd)
+			os.Exit(1)
 		}
 
 		var output interface{}
 		err = json.Unmarshal(transitionsHttpEnv.Body, &output)
 		if err != nil {
-			log.Logger.Fatal().Msg("failed to unmarshal transitions")
+			log.Logger.Error().Err(err).Msg("failed to unmarshal transitions")
+			logHelpError(cmd)
+			os.Exit(1)
 		}
 
 		// Print output
 		if outBytes, err := format.MarshalData(output, formatOutput); err != nil {
-			log.Logger.Fatal().Err(err).Msg("failed to format output")
+			log.Logger.Error().Err(err).Msg("failed to format output")
+			logHelpError(cmd)
+			os.Exit(1)
 		} else {
 			fmt.Println(string(outBytes))
 		}

--- a/cmd/pcs-transition-monitor.go
+++ b/cmd/pcs-transition-monitor.go
@@ -87,13 +87,17 @@ See ochami-pcs(1) for more details.`,
 		for {
 			transitionHttpEnv, err := pcsClient.GetTransition(transitionID, token)
 			if err != nil {
-				log.Logger.Fatal().Err(err).Msg("failed to get transition")
+				log.Logger.Error().Err(err).Msg("failed to get transition")
+				logHelpError(cmd)
+				os.Exit(1)
 			}
 
 			// Unmarshal the progress information
 			var progress transitionProgress
 			if err := json.Unmarshal(transitionHttpEnv.Body, &progress); err != nil {
-				log.Logger.Fatal().Err(err).Msg("failed to unmarshal transition")
+				log.Logger.Error().Err(err).Msg("failed to unmarshal transition")
+				logHelpError(cmd)
+				os.Exit(1)
 			}
 
 			// Set the totals for each bar

--- a/cmd/pcs-transition-monitor.go
+++ b/cmd/pcs-transition-monitor.go
@@ -12,7 +12,6 @@ import (
 	"github.com/vbauerster/mpb/v8/decor"
 
 	"github.com/OpenCHAMI/ochami/internal/log"
-	"github.com/OpenCHAMI/ochami/pkg/client/pcs"
 )
 
 var pollInterval int = 1
@@ -74,26 +73,8 @@ See ochami-pcs(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		transitionID := args[0]
 
-		// Without a base URI, we cannot do anything
-		pcsBaseURI, err := getBaseURIPCS(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for PCS")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// This endpoint requires authentication, so a token is needed
-		setTokenFromEnvVar(cmd)
-		checkToken(cmd)
-
-		// Create client to make request to PCS
-		pcsClient, err := pcs.NewClient(pcsBaseURI, insecure)
-		if err != nil {
-			log.Logger.Fatal().Err(err).Msg("error creating new PCS client")
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(pcsClient.OchamiClient)
+		// Create client to use for requests
+		pcsClient := pcsGetClient(cmd, true)
 
 		p := mpb.New(mpb.WithWidth(64))
 

--- a/cmd/pcs-transition-show.go
+++ b/cmd/pcs-transition-show.go
@@ -35,22 +35,28 @@ See ochami-pcs(1) for more details.`,
 		transitionHttpEnv, err := pcsClient.GetTransition(transitionID, token)
 		if err != nil {
 			if errors.Is(err, client.UnsuccessfulHTTPError) {
-				log.Logger.Fatal().Err(err).Msg("PCS transitions request yielded unsuccessful HTTP response")
+				log.Logger.Error().Err(err).Msg("PCS transitions request yielded unsuccessful HTTP response")
 			} else {
-				log.Logger.Fatal().Err(err).Msg("failed to get PCS transition")
+				log.Logger.Error().Err(err).Msg("failed to get PCS transition")
 			}
+			logHelpError(cmd)
+			os.Exit(1)
 		}
 
 		// Unmarshal output
 		var output interface{}
 		err = json.Unmarshal(transitionHttpEnv.Body, &output)
 		if err != nil {
-			log.Logger.Fatal().Msg("failed to unmarshal transitions")
+			log.Logger.Error().Err(err).Msg("failed to unmarshal transitions")
+			logHelpError(cmd)
+			os.Exit(1)
 		}
 
 		// Print output
 		if outBytes, err := format.MarshalData(output, formatOutput); err != nil {
-			log.Logger.Fatal().Err(err).Msg("failed to format output")
+			log.Logger.Error().Err(err).Msg("failed to format output")
+			logHelpError(cmd)
+			os.Exit(1)
 		} else {
 			fmt.Println(string(outBytes))
 		}

--- a/cmd/pcs-transition-show.go
+++ b/cmd/pcs-transition-show.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/pkg/client"
-	"github.com/OpenCHAMI/ochami/pkg/client/pcs"
 	"github.com/OpenCHAMI/ochami/pkg/format"
 )
 
@@ -29,26 +28,8 @@ See ochami-pcs(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		transitionID := args[0]
 
-		// Without a base URI, we cannot do anything
-		pcsBaseURI, err := getBaseURIPCS(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for PCS")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// This endpoint requires authentication, so a token is needed
-		setTokenFromEnvVar(cmd)
-		checkToken(cmd)
-
-		// Create client to make request to PCS
-		pcsClient, err := pcs.NewClient(pcsBaseURI, insecure)
-		if err != nil {
-			log.Logger.Fatal().Err(err).Msg("error creating new PCS client")
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(pcsClient.OchamiClient)
+		// Create client to use for requests
+		pcsClient := pcsGetClient(cmd, true)
 
 		// Get transition
 		transitionHttpEnv, err := pcsClient.GetTransition(transitionID, token)

--- a/cmd/pcs-transition-start.go
+++ b/cmd/pcs-transition-start.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/pkg/client"
-	"github.com/OpenCHAMI/ochami/pkg/client/pcs"
 	"github.com/OpenCHAMI/ochami/pkg/format"
 )
 
@@ -61,28 +60,11 @@ See ochami-pcs(1) for more details.`,
 			os.Exit(1)
 		}
 
-		// Without a base URI, we cannot do anything
-		pcsBaseURI, err := getBaseURIPCS(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for PCS")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// This endpoint requires authentication, so a token is needed
-		setTokenFromEnvVar(cmd)
-		checkToken(cmd)
-
-		// Create client to make request to PCS
-		pcsClient, err := pcs.NewClient(pcsBaseURI, insecure)
-		if err != nil {
-			log.Logger.Fatal().Err(err).Msg("error creating new PCS client")
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(pcsClient.OchamiClient)
+		// Create client to use for requests
+		pcsClient := pcsGetClient(cmd, true)
 
 		// Get the list of target components
+		var err error
 		xnames, err = cmd.Flags().GetStringSlice("xname")
 		if err != nil {
 			log.Logger.Fatal().Err(err).Msg("failed to get value for --xname")

--- a/cmd/pcs-transition-start.go
+++ b/cmd/pcs-transition-start.go
@@ -67,29 +67,37 @@ See ochami-pcs(1) for more details.`,
 		var err error
 		xnames, err = cmd.Flags().GetStringSlice("xname")
 		if err != nil {
-			log.Logger.Fatal().Err(err).Msg("failed to get value for --xname")
+			log.Logger.Error().Err(err).Msg("failed to get value for --xname")
+			logHelpError(cmd)
+			os.Exit(1)
 		}
 
 		// Create transition
 		transitionHttpEnv, err := pcsClient.CreateTransition(operation, nil, xnames, token)
 		if err != nil {
 			if errors.Is(err, client.UnsuccessfulHTTPError) {
-				log.Logger.Fatal().Err(err).Msg("PCS transition create request yielded unsuccessful HTTP response")
+				log.Logger.Error().Err(err).Msg("PCS transition create request yielded unsuccessful HTTP response")
 			} else {
-				log.Logger.Fatal().Err(err).Msg("failed to create transition")
+				log.Logger.Error().Err(err).Msg("failed to create transition")
 			}
+			logHelpError(cmd)
+			os.Exit(1)
 		}
 
 		// Unmarshall the transition
 		var output createOutput
 		err = json.Unmarshal(transitionHttpEnv.Body, &output)
 		if err != nil {
-			log.Logger.Fatal().Msg("failed to unmarshal output")
+			log.Logger.Error().Err(err).Msg("failed to unmarshal output")
+			logHelpError(cmd)
+			os.Exit(1)
 		}
 
 		// Print output
 		if outBytes, err := format.MarshalData(output, formatOutput); err != nil {
-			log.Logger.Fatal().Err(err).Msg("failed to format output")
+			log.Logger.Error().Err(err).Msg("failed to format output")
+			logHelpError(cmd)
+			os.Exit(1)
 		} else {
 			fmt.Println(string(outBytes))
 		}

--- a/cmd/smd-compep-delete.go
+++ b/cmd/smd-compep-delete.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/pkg/client"
-	"github.com/OpenCHAMI/ochami/pkg/client/smd"
 	"github.com/OpenCHAMI/smd/v2/pkg/sm"
 	"github.com/spf13/cobra"
 )
@@ -57,28 +56,8 @@ See ochami-smd(1) for more details.`,
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		smdBaseURI, err := getBaseURISMD(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// This endpoint requires authentication, so a token is needed
-		setTokenFromEnvVar(cmd)
-		checkToken(cmd)
-
-		// Create client to make request to SMD
-		smdClient, err := smd.NewClient(smdBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new SMD client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(smdClient.OchamiClient)
+		// Create client to use for requests
+		smdClient := smdGetClient(cmd, true)
 
 		// Ask before attempting deletion unless --no-confirm was passed
 		if !cmd.Flag("no-confirm").Changed {

--- a/cmd/smd-compep-get.go
+++ b/cmd/smd-compep-get.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/pkg/client"
-	"github.com/OpenCHAMI/ochami/pkg/client/smd"
 	"github.com/spf13/cobra"
 )
 
@@ -22,30 +21,11 @@ var compepGetCmd = &cobra.Command{
 
 See ochami-smd(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		smdBaseURI, err := getBaseURISMD(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// This endpoint requires authentication, so a token is needed
-		setTokenFromEnvVar(cmd)
-		checkToken(cmd)
-
-		// Create client to make request to SMD
-		smdClient, err := smd.NewClient(smdBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new SMD client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(smdClient.OchamiClient)
+		// Create client to use for requests
+		smdClient := smdGetClient(cmd, true)
 
 		var httpEnv client.HTTPEnvelope
+		var err error
 		if len(args) == 0 {
 			// Get all ComponentEndpoints if no args passed
 			httpEnv, err = smdClient.GetComponentEndpointsAll(token)

--- a/cmd/smd-component-add.go
+++ b/cmd/smd-component-add.go
@@ -65,30 +65,11 @@ See ochami-smd(1) for more details.`,
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		smdBaseURI, err := getBaseURISMD(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// This endpoint requires authentication, so a token is needed
-		setTokenFromEnvVar(cmd)
-		checkToken(cmd)
-
-		// Create client to make request to SMD
-		smdClient, err := smd.NewClient(smdBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new SMD client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(smdClient.OchamiClient)
+		// Create client to use for requests
+		smdClient := smdGetClient(cmd, true)
 
 		var compSlice smd.ComponentSlice
+		var err error
 		if cmd.Flag("data").Changed {
 			handlePayload(cmd, &compSlice)
 		} else {

--- a/cmd/smd-component-delete.go
+++ b/cmd/smd-component-delete.go
@@ -59,26 +59,8 @@ See ochami-smd(1) for more details.`,
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		smdBaseURI, err := getBaseURISMD(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
-			os.Exit(1)
-		}
-
-		// This endpoint requires authentication, so a token is needed
-		setTokenFromEnvVar(cmd)
-		checkToken(cmd)
-
-		// Create client to make request to SMD
-		smdClient, err := smd.NewClient(smdBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new SMD client")
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(smdClient.OchamiClient)
+		// Create client to use for requests
+		smdClient := smdGetClient(cmd, true)
 
 		// Ask before attempting deletion unless --no-confirm was passed
 		if !cmd.Flag("no-confirm").Changed {

--- a/cmd/smd-component-get.go
+++ b/cmd/smd-component-get.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/pkg/client"
-	"github.com/OpenCHAMI/ochami/pkg/client/smd"
 	"github.com/spf13/cobra"
 )
 
@@ -22,26 +21,11 @@ var componentGetCmd = &cobra.Command{
 
 See ochami-smd(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		smdBaseURI, err := getBaseURISMD(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Create client to make request to SMD
-		smdClient, err := smd.NewClient(smdBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new SMD client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(smdClient.OchamiClient)
+		// Create client to use for requests
+		smdClient := smdGetClient(cmd, false)
 
 		var httpEnv client.HTTPEnvelope
+		var err error
 		if cmd.Flag("xname").Changed {
 			// This endpoint requires authentication, so a token is needed
 			setTokenFromEnvVar(cmd)

--- a/cmd/smd-group-add.go
+++ b/cmd/smd-group-add.go
@@ -71,30 +71,14 @@ See ochami-smd(1) for more details.`,
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		smdBaseURI, err := getBaseURISMD(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// This endpoint requires authentication, so a token is needed
-		setTokenFromEnvVar(cmd)
-		checkToken(cmd)
-
-		// Create client to make request to SMD
-		smdClient, err := smd.NewClient(smdBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new SMD client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
+		// Create client to use for requests
+		smdClient := smdGetClient(cmd, true)
 
 		// Check if a CA certificate was passed and load it into client if valid
 		useCACert(smdClient.OchamiClient)
 
 		var groups []smd.Group
+		var err error
 		if cmd.Flag("data").Changed {
 			// Use payload file if passed
 			handlePayload(cmd, &groups)

--- a/cmd/smd-group-delete.go
+++ b/cmd/smd-group-delete.go
@@ -55,28 +55,8 @@ See ochami-smd(1) for more details.`,
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		smdBaseURI, err := getBaseURISMD(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// This endpoint requires authentication, so a token is needed
-		setTokenFromEnvVar(cmd)
-		checkToken(cmd)
-
-		// Create client to make request to SMD
-		smdClient, err := smd.NewClient(smdBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new SMD client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(smdClient.OchamiClient)
+		// Create client to use for requests
+		smdClient := smdGetClient(cmd, true)
 
 		// Ask before attempting deletion unless --no-confirm was passed
 		if !cmd.Flag("no-confirm").Changed {

--- a/cmd/smd-group-get.go
+++ b/cmd/smd-group-get.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/pkg/client"
-	"github.com/OpenCHAMI/ochami/pkg/client/smd"
 	"github.com/spf13/cobra"
 )
 
@@ -30,28 +29,8 @@ See ochami-smd(1) for more details.`,
   ochami smd group get --name group1,group2 --tag tag1,tag2
   ochami smd group get --name group1 --name group2 --tag tag1 --tag tag2`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		smdBaseURI, err := getBaseURISMD(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// This endpoint requires authentication, so a token is needed
-		setTokenFromEnvVar(cmd)
-		checkToken(cmd)
-
-		// Create client to make request to SMD
-		smdClient, err := smd.NewClient(smdBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new SMD client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(smdClient.OchamiClient)
+		// Create client to use for requests
+		smdClient := smdGetClient(cmd, true)
 
 		// If no ID flags are specified, get all groups
 		qstr := ""

--- a/cmd/smd-group-member-add.go
+++ b/cmd/smd-group-member-add.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/pkg/client"
-	"github.com/OpenCHAMI/ochami/pkg/client/smd"
 	"github.com/spf13/cobra"
 )
 
@@ -22,28 +21,8 @@ var groupMemberAddCmd = &cobra.Command{
 See ochami-smd(1) for more details.`,
 	Example: `  ochami smd group member add compute x3000c1s7b56n0`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		smdBaseURI, err := getBaseURISMD(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// This endpoint requires authentication, so a token is needed
-		setTokenFromEnvVar(cmd)
-		checkToken(cmd)
-
-		// Create client to make request to SMD
-		smdClient, err := smd.NewClient(smdBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new SMD client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(smdClient.OchamiClient)
+		// Create client to use for requests
+		smdClient := smdGetClient(cmd, true)
 
 		// Send off request
 		_, errs, err := smdClient.PostGroupMembers(token, args[0], args[1:]...)

--- a/cmd/smd-group-member-delete.go
+++ b/cmd/smd-group-member-delete.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/pkg/client"
-	"github.com/OpenCHAMI/ochami/pkg/client/smd"
 	"github.com/spf13/cobra"
 )
 
@@ -22,28 +21,8 @@ var groupMemberDeleteCmd = &cobra.Command{
 See ochami-smd(1) for more details.`,
 	Example: `  ochami smd group member delete compute x3000c1s7b56n0`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		smdBaseURI, err := getBaseURISMD(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// This endpoint requires authentication, so a token is needed
-		setTokenFromEnvVar(cmd)
-		checkToken(cmd)
-
-		// Create client to make request to SMD
-		smdClient, err := smd.NewClient(smdBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new SMD client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(smdClient.OchamiClient)
+		// Create client to use for requests
+		smdClient := smdGetClient(cmd, true)
 
 		// Ask before attempting deletion unless --no-confirm was passed
 		if !cmd.Flag("no-confirm").Changed {

--- a/cmd/smd-group-member-get.go
+++ b/cmd/smd-group-member-get.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/pkg/client"
-	"github.com/OpenCHAMI/ochami/pkg/client/smd"
 	"github.com/spf13/cobra"
 )
 
@@ -23,28 +22,8 @@ var groupMemberGetCmd = &cobra.Command{
 See ochami-smd(1) for more details.`,
 	Example: `  ochami smd group member get compute`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		smdBaseURI, err := getBaseURISMD(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// This endpoint requires authentication, so a token is needed
-		setTokenFromEnvVar(cmd)
-		checkToken(cmd)
-
-		// Create client to make request to SMD
-		smdClient, err := smd.NewClient(smdBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new SMD client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(smdClient.OchamiClient)
+		// Create client to use for requests
+		smdClient := smdGetClient(cmd, true)
 
 		// Send request
 		httpEnv, err := smdClient.GetGroupMembers(args[0], token)

--- a/cmd/smd-group-update.go
+++ b/cmd/smd-group-update.go
@@ -59,33 +59,14 @@ See ochami-smd(1) for more details.`,
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		smdBaseURI, err := getBaseURISMD(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// This endpoint requires authentication, so a token is needed
-		setTokenFromEnvVar(cmd)
-		checkToken(cmd)
-
-		// Create client to make request to SMD
-		smdClient, err := smd.NewClient(smdBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new SMD client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(smdClient.OchamiClient)
+		// Create client to use for requests
+		smdClient := smdGetClient(cmd, true)
 
 		// The group list we will send
 		var groups []smd.Group
 
 		// Read payload from file first, allowing overwrites from flags
+		var err error
 		if cmd.Flag("data").Changed {
 			handlePayload(cmd, &groups)
 		} else {

--- a/cmd/smd-iface-add.go
+++ b/cmd/smd-iface-add.go
@@ -55,28 +55,8 @@ See ochami-smd(1) for more details.`,
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		smdBaseURI, err := getBaseURISMD(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// This endpoint requires authentication, so a token is needed
-		setTokenFromEnvVar(cmd)
-		checkToken(cmd)
-
-		// Create client to make request to SMD
-		smdClient, err := smd.NewClient(smdBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new SMD client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(smdClient.OchamiClient)
+		// Create client to use for requests
+		smdClient := smdGetClient(cmd, true)
 
 		var eis []smd.EthernetInterface
 		if cmd.Flag("data").Changed {

--- a/cmd/smd-iface-delete.go
+++ b/cmd/smd-iface-delete.go
@@ -56,28 +56,8 @@ See ochami-smd(1) for more details.`,
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		smdBaseURI, err := getBaseURISMD(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// This endpoint requires authentication, so a token is needed
-		setTokenFromEnvVar(cmd)
-		checkToken(cmd)
-
-		// Create client to make request to SMD
-		smdClient, err := smd.NewClient(smdBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new SMD client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(smdClient.OchamiClient)
+		// Create client to use for requests
+		smdClient := smdGetClient(cmd, true)
 
 		// Ask before attempting deletion unless --no-confirm was passed
 		if !cmd.Flag("no-confirm").Changed {

--- a/cmd/smd-iface-get.go
+++ b/cmd/smd-iface-get.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/pkg/client"
-	"github.com/OpenCHAMI/ochami/pkg/client/smd"
 	"github.com/spf13/cobra"
 )
 
@@ -25,24 +24,8 @@ ethernet interfaces returned.
 
 See ochami-smd(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		smdBaseURI, err := getBaseURISMD(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Create client to make request to SMD
-		smdClient, err := smd.NewClient(smdBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new SMD client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(smdClient.OchamiClient)
+		// Create client to use for requests
+		smdClient := smdGetClient(cmd, false)
 
 		// Deal with --id
 		if cmd.Flag("id").Changed {

--- a/cmd/smd-rfe-add.go
+++ b/cmd/smd-rfe-add.go
@@ -67,30 +67,14 @@ See ochami-smd(1) for more details.`,
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		smdBaseURI, err := getBaseURISMD(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// This endpoint requires authentication, so a token is needed
-		setTokenFromEnvVar(cmd)
-		checkToken(cmd)
-
-		// Create client to make request to SMD
-		smdClient, err := smd.NewClient(smdBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new SMD client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
+		// Create client to use for requests
+		smdClient := smdGetClient(cmd, true)
 
 		// Check if a CA certificate was passed and load it into client if valid
 		useCACert(smdClient.OchamiClient)
 
 		var rfes smd.RedfishEndpointSlice
+		var err error
 		if cmd.Flag("data").Changed {
 			// Use payload file if passed
 			handlePayload(cmd, &rfes.RedfishEndpoints)

--- a/cmd/smd-rfe-delete.go
+++ b/cmd/smd-rfe-delete.go
@@ -56,28 +56,8 @@ See ochami-smd(1) for more details.`,
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		smdBaseURI, err := getBaseURISMD(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// This endpoint requires authentication, so a token is needed
-		setTokenFromEnvVar(cmd)
-		checkToken(cmd)
-
-		// Create client to make request to SMD
-		smdClient, err := smd.NewClient(smdBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new SMD client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(smdClient.OchamiClient)
+		// Create client to use for requests
+		smdClient := smdGetClient(cmd, true)
 
 		// Ask before attempting deletion unless --no-confirm was passed
 		if !cmd.Flag("no-confirm").Changed {

--- a/cmd/smd-rfe-get.go
+++ b/cmd/smd-rfe-get.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/pkg/client"
-	"github.com/OpenCHAMI/ochami/pkg/client/smd"
 	"github.com/spf13/cobra"
 )
 
@@ -25,28 +24,8 @@ endpoints returned.
 
 See ochami-smd(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		smdBaseURI, err := getBaseURISMD(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// This endpoint requires authentication, so a token is needed
-		setTokenFromEnvVar(cmd)
-		checkToken(cmd)
-
-		// Create client to make request to SMD
-		smdClient, err := smd.NewClient(smdBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new SMD client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(smdClient.OchamiClient)
+		// Create client to use for requests
+		smdClient := smdGetClient(cmd, true)
 
 		// If no ID flags are specified, get all redfish endpoints
 		qstr := ""

--- a/cmd/smd-status.go
+++ b/cmd/smd-status.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/pkg/client"
-	"github.com/OpenCHAMI/ochami/pkg/client/smd"
 	"github.com/spf13/cobra"
 )
 
@@ -22,27 +21,12 @@ var smdStatusCmd = &cobra.Command{
 
 See ochami-smd(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// Without a base URI, we cannot do anything
-		smdBaseURI, err := getBaseURISMD(cmd)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Create client to make request to SMD
-		smdClient, err := smd.NewClient(smdBaseURI, insecure)
-		if err != nil {
-			log.Logger.Error().Err(err).Msg("error creating new SMD client")
-			logHelpError(cmd)
-			os.Exit(1)
-		}
-
-		// Check if a CA certificate was passed and load it into client if valid
-		useCACert(smdClient.OchamiClient)
+		// Create client to use for requests
+		smdClient := smdGetClient(cmd, false)
 
 		// Determine which component to get status for and send request
 		var httpEnv client.HTTPEnvelope
+		var err error
 		if cmd.Flag("all").Changed {
 			httpEnv, err = smdClient.GetStatus("all")
 		} else {

--- a/cmd/smd.go
+++ b/cmd/smd.go
@@ -5,8 +5,41 @@ package cmd
 import (
 	"os"
 
+	"github.com/OpenCHAMI/ochami/internal/log"
+	"github.com/OpenCHAMI/ochami/pkg/client/smd"
 	"github.com/spf13/cobra"
 )
+
+// smdGetClient sets up the SMD client with the SMD base URI and certificates
+// (if necessary) and returns it. If tokenRequired is true, it will ensure that
+// the token is set and valid and load it. This function is used by each
+// subcommand.
+func smdGetClient(cmd *cobra.Command, tokenRequired bool) *smd.SMDClient {
+	// Without a base URI, we cannot do anything
+	smdBaseURI, err := getBaseURISMD(cmd)
+	if err != nil {
+		log.Logger.Error().Err(err).Msg("failed to get base URI for SMD")
+		logHelpError(cmd)
+		os.Exit(1)
+	}
+
+	// This endpoint requires authentication, so a token is needed
+	setTokenFromEnvVar(cmd)
+	checkToken(cmd)
+
+	// Create client to make request to SMD
+	smdClient, err := smd.NewClient(smdBaseURI, insecure)
+	if err != nil {
+		log.Logger.Error().Err(err).Msg("error creating new SMD client")
+		logHelpError(cmd)
+		os.Exit(1)
+	}
+
+	// Check if a CA certificate was passed and load it into client if valid
+	useCACert(smdClient.OchamiClient)
+
+	return smdClient
+}
 
 // smdCmd represents the bss command
 var smdCmd = &cobra.Command{


### PR DESCRIPTION
The code for getting the base URI for a service, creating a client from it, checking the token, and handling the certificate is a bit repetitive at the beginning of each command. This can cause difficulties when changes are needed to it as changes must be made to each command.

This PR, in response to [this comment](https://github.com/OpenCHAMI/ochami/pull/21#discussion_r2035884542), puts this functionality in a library function, one for each service.

It also changes the logging functions used in the PCS transition commands to allow printing of the help error message when a fatal error occurs.