### PR TITLE
hotfix: add missing YAML reflect tags

### DIFF
--- a/cmd/cloud_init-group-get.go
+++ b/cmd/cloud_init-group-get.go
@@ -132,9 +132,9 @@ See ochami-cloud-init(1) for more details.`,
 
 		// Extract cloud-config for each group
 		type configGroup struct {
-			Name     string                 `json:"name"`
-			Data     map[string]interface{} `json:"meta-data"`
-			Content  []byte                 `json:"content"`
+			Name     string                 `json:"name" yaml:"name"`
+			Data     map[string]interface{} `json:"meta-data" yaml:"meta-data"`
+			Content  []byte                 `json:"content" yaml:"content"`
 			Encoding string                 `json:"encoding" enums:"base64,plain"`
 		}
 		var configSlice []configGroup
@@ -203,8 +203,8 @@ See ochami-cloud-init(1) for more details.`,
 
 		// Extract meta-data for each group
 		type mdGroup struct {
-			Name string                 `json:"name"`
-			Data map[string]interface{} `json:"meta-data"`
+			Name string                 `json:"name" yaml:"name"`
+			Data map[string]interface{} `json:"meta-data" yaml:"meta-data"`
 		}
 		var mdSlice []mdGroup
 		for _, group := range groupSlice {

--- a/cmd/pcs-status.go
+++ b/cmd/pcs-status.go
@@ -28,10 +28,10 @@ const (
 // status for DistLocking (as the only implementation uses ETCD, so the status
 // is just duplicated) or the TaskRunner (as we only use the local implementation)
 type commandOutput struct {
-	Status       string `json:"pcs,omitempty"`
-	KvStore      string `json:"storage,omitempty"`
-	StateManager string `json:"smd,omitempty"`
-	Vault        string `json:"vault,omitempty"`
+	Status       string `json:"pcs,omitempty" yaml:"pcs,omitempty"`
+	KvStore      string `json:"storage,omitempty" yaml:"storage,omitempty"`
+	StateManager string `json:"smd,omitempty" yaml:"smd,omitempty"`
+	Vault        string `json:"vault,omitempty" yaml:"vault,omitempty"`
 }
 
 // Get the status of PCS either "live" or "ready"

--- a/cmd/pcs-transition-monitor.go
+++ b/cmd/pcs-transition-monitor.go
@@ -35,18 +35,18 @@ const (
 
 // transitionTaskCounts represents the counts of tasks in a PCS transition
 type transitionTaskCounts struct {
-	Total       int `json:"total"`
-	New         int `json:"new"`
-	InProgress  int `json:"in-progress"`
-	Failed      int `json:"failed"`
-	Succeeded   int `json:"succeeded"`
-	Unsupported int `json:"un-supported"`
+	Total       int `json:"total" yaml:"total"`
+	New         int `json:"new" yaml:"new"`
+	InProgress  int `json:"in-progress" yaml:"in-progress"`
+	Failed      int `json:"failed" yaml:"failed"`
+	Succeeded   int `json:"succeeded" yaml:"succeeded"`
+	Unsupported int `json:"un-supported" yaml:"un-supported"`
 }
 
 // transitionProgress represents the progress of a PCS transition
 type transitionProgress struct {
-	Status     string               `json:"transitionStatus"`
-	TaskCounts transitionTaskCounts `json:"taskCounts"`
+	Status     string               `json:"transitionStatus" yaml:"transitionStatus"`
+	TaskCounts transitionTaskCounts `json:"taskCounts" yaml:"taskCounts"`
 }
 
 // Create and style a progress bar

--- a/cmd/smd-compep-get.go
+++ b/cmd/smd-compep-get.go
@@ -70,7 +70,7 @@ See ochami-smd(1) for more details.`,
 
 			// Put selected ComponentEndpoints into array and marshal
 			type compEp struct {
-				ComponentEndpoints []interface{} `json:"ComponentEndpoints"`
+				ComponentEndpoints []interface{} `json:"ComponentEndpoints" yaml:"ComponentEndpoints"`
 			}
 			var ceArr []interface{}
 			for i, h := range httpEnvs {

--- a/pkg/client/pcs/pcs.go
+++ b/pkg/client/pcs/pcs.go
@@ -89,13 +89,13 @@ func (pc *PCSClient) GetHealth() (client.HTTPEnvelope, error) {
 }
 
 type transitionBody struct {
-	Operation    string          `json:"operation"`
-	TaskDeadline *int            `json:"taskDeadlineMinutes"`
-	Location     []locationEntry `json:"location"`
+	Operation    string          `json:"operation" yaml:"operation"`
+	TaskDeadline *int            `json:"taskDeadlineMinutes" yaml:"taskDeadlineMinutes"`
+	Location     []locationEntry `json:"location" yaml:"location"`
 }
 
 type locationEntry struct {
-	Xname string `json:"xname"`
+	Xname string `json:"xname" yaml:"xname"`
 }
 
 // CreateTransition is a wrapper function around OchamiClient.PostData to

--- a/pkg/client/smd/smd.go
+++ b/pkg/client/smd/smd.go
@@ -34,48 +34,48 @@ const (
 // Component is a minimal subset of SMD's Component struct that contains only
 // what is necessary for sending a valid Component request to SMD.
 type Component struct {
-	ID      string `json:"ID"`
-	Type    string `json:"Type"`
-	State   string `json:"State,omitempty"`
-	Enabled bool   `json:"Enabled,omitempty"`
-	Role    string `json:"Role,omitempty"`
-	Arch    string `json:"Arch,omitempty"`
-	NID     int64  `json:"NID,omitempty"`
+	ID      string `json:"ID" yaml:"ID"`
+	Type    string `json:"Type" yaml:"Type"`
+	State   string `json:"State,omitempty" yaml:"State,omitempty"`
+	Enabled bool   `json:"Enabled,omitempty" yaml:"Enabled,omitempty"`
+	Role    string `json:"Role,omitempty" yaml:"Role,omitempty"`
+	Arch    string `json:"Arch,omitempty" yaml:"Arch,omitempty"`
+	NID     int64  `json:"NID,omitempty" yaml:"NID,omitempty"`
 }
 
 // ComponentSlice is a convenience data structure to make marshalling Component
 // requests easier.
 type ComponentSlice struct {
-	Components []Component `json:"Components"`
+	Components []Component `json:"Components" yaml:"Components"`
 }
 
 // EthernetInterface is a minimal subset of SMD's EthernetInterface struct that
 // contains only what is necessary for sending a valid EthernetInterface request
 // to SMD.
 type EthernetInterface struct {
-	ID          string       `json:"ID"`
-	ComponentID string       `json:"ComponentID"`
-	Type        string       `json:"Type"`
-	Description string       `json:"Description"`
-	MACAddress  string       `json:"MACAddress"`
-	IPAddresses []EthernetIP `json:"IPAddresses"`
+	ID          string       `json:"ID" yaml:"ID"`
+	ComponentID string       `json:"ComponentID" yaml:"ComponentID"`
+	Type        string       `json:"Type" yaml:"Type"`
+	Description string       `json:"Description" yaml:"Description"`
+	MACAddress  string       `json:"MACAddress" yaml:"MACAddress"`
+	IPAddresses []EthernetIP `json:"IPAddresses" yaml:"IPAddresses"`
 }
 
 type EthernetIP struct {
-	IPAddress string `json:"IPAddress"`
-	Network   string `json:"Network"`
+	IPAddress string `json:"IPAddress" yaml:"IPAddress"`
+	Network   string `json:"Network" yaml:"Network"`
 }
 
 // RedfishEndpointSlice is a convenience data structure to make marshalling
 // RedfishEndpoint requests easier.
 type RedfishEndpointSlice struct {
-	RedfishEndpoints []csm.RedfishEndpoint `json:"RedfishEndpoints"`
+	RedfishEndpoints []csm.RedfishEndpoint `json:"RedfishEndpoints" yaml:"RedfishEndpoints"`
 }
 
 // RedfishEndpointSliceV2 is a convenience data structure to make marshalling
 // RedfishEndpointV2 requests easier.
 type RedfishEndpointSliceV2 struct {
-	RedfishEndpoints []RedfishEndpointV2 `json:"RedfishEndpoints"`
+	RedfishEndpoints []RedfishEndpointV2 `json:"RedfishEndpoints" yaml:"RedfishEndpoints"`
 }
 
 // RedfishEndpointV2 holds the redfish endpoint data read from/into SMD using
@@ -84,44 +84,44 @@ type RedfishEndpointSliceV2 struct {
 // contained in this struct.
 type RedfishEndpointV2 struct {
 	csm.RedfishEndpoint
-	SchemaVersion int       `json:"SchemaVersion"`
-	Systems       []System  `json:"Systems"`
-	Managers      []Manager `json:"Managers"`
+	SchemaVersion int       `json:"SchemaVersion" yaml:"SchemaVersion"`
+	Systems       []System  `json:"Systems" yaml:"Systems"`
+	Managers      []Manager `json:"Managers" yaml:"Managers"`
 }
 
 // System represents data that would be retrieved from BMC System data, except
 // reduced to a minimum needed for discovery.
 type System struct {
-	URI                string                      `json:"uri"`
-	UUID               string                      `json:"uuid"`
-	Name               string                      `json:"name"`
-	EthernetInterfaces []schemas.EthernetInterface `json:"ethernet_interfaces"`
+	URI                string                      `json:"uri" yaml:"uri"`
+	UUID               string                      `json:"uuid" yaml:"uuid"`
+	Name               string                      `json:"name" yaml:"name"`
+	EthernetInterfaces []schemas.EthernetInterface `json:"ethernet_interfaces" yaml:"ethernet_interfaces"`
 }
 
 // Manager represents data that would be retrieved from BMC Manager data, except
 // reduced to a minimum needed for discovery.
 type Manager struct {
 	System
-	Description string `json:"description"`
-	Type        string `json:"type"`
+	Description string `json:"description" yaml:"description"`
+	Type        string `json:"type" yaml:"type"`
 }
 
 // Group represents the payload structure for SMD groups.
 type Group struct {
-	Label          string   `json:"label"`
-	Description    string   `json:"description"`
-	Tags           []string `json:"tags,omitempty"`
-	ExclusiveGroup string   `json:"exclusiveGroup,omitempty"`
+	Label          string   `json:"label" yaml:"label"`
+	Description    string   `json:"description" yaml:"description"`
+	Tags           []string `json:"tags,omitempty" yaml:"tags,omitempty"`
+	ExclusiveGroup string   `json:"exclusiveGroup,omitempty" yaml:"exclusiveGroup,omitempty"`
 	Members        struct {
-		IDs []string `json:"ids,omitempty"`
-	} `json:"members,omitempty"`
+		IDs []string `json:"ids,omitempty" yaml:"ids,omitempty"`
+	} `json:"members,omitempty" yaml:"members,omitempty"`
 }
 
 // GroupMembers represents the payload structure for SMD group membership for
 // PUT requests. It consists of only the group label and list of group IDs.
 type GroupMembers struct {
-	Label string   `json:"label"`
-	IDs   []string `json:"ids"`
+	Label string   `json:"label" yaml:"label"`
+	IDs   []string `json:"ids" yaml:"ids"`
 }
 
 // NewClient takes a baseURI and returns a pointer to a new SMDClient. If an

--- a/pkg/discover/discover.go
+++ b/pkg/discover/discover.go
@@ -14,7 +14,7 @@ import (
 // NodeList is simply a list of Nodes. Data from a payload file is unmarshalled
 // into this.
 type NodeList struct {
-	Nodes []Node `json:"nodes"`
+	Nodes []Node `json:"nodes" yaml:"nodes"`
 }
 
 func (nl NodeList) String() string {
@@ -34,13 +34,13 @@ func (nl NodeList) String() string {
 // Node represents a node entry in a payload file. Multiple of these are send to
 // SMD to "discover" them.
 type Node struct {
-	Name   string  `json:"name"`
-	NID    int64   `json:"nid"`
-	Xname  string  `json:"xname"`
-	Group  string  `json:"group"`
-	BMCMac string  `json:"bmc_mac"`
-	BMCIP  string  `json:"bmc_ip"`
-	Ifaces []Iface `json:"interfaces"`
+	Name   string  `json:"name" yaml:"name"`
+	NID    int64   `json:"nid" yaml:"nid"`
+	Xname  string  `json:"xname" yaml:"xname"`
+	Group  string  `json:"group" yaml:"group"`
+	BMCMac string  `json:"bmc_mac" yaml:"bmc_mac"`
+	BMCIP  string  `json:"bmc_ip" yaml:"bmc_ip"`
+	Ifaces []Iface `json:"interfaces" yaml:"interfaces"`
 }
 
 func (n Node) String() string {
@@ -61,8 +61,8 @@ func (n Node) String() string {
 // Iface represents a single interface with multiple IP addresses. Nodes can
 // have multiple of these.
 type Iface struct {
-	MACAddr string    `json:"mac_addr"`
-	IPAddrs []IfaceIP `json:"ip_addrs"`
+	MACAddr string    `json:"mac_addr" yaml:"mac_addr"`
+	IPAddrs []IfaceIP `json:"ip_addrs" yaml:"ip_addrs"`
 }
 
 func (i Iface) String() string {
@@ -84,8 +84,8 @@ func (i Iface) String() string {
 // the IP address is on. Note that Network is NOT the subnet mask or CIDR of the
 // IPAddr.
 type IfaceIP struct {
-	Network string `json:"network"`
-	IPAddr  string `json:"ip_addr"`
+	Network string `json:"network" yaml:"network"`
+	IPAddr  string `json:"ip_addr" yaml:"ip_addr"`
 }
 
 func (i IfaceIP) String() string {


### PR DESCRIPTION
Missing YAML reflect tags caused certain fields to be blank when unmarshalling using YAML.