### PR TITLE
Add flag to make second request to SMD optional to prevent 409 conflicts creating `EthernetInterface`s

### DIFF
--- a/cmd/discover-static.go
+++ b/cmd/discover-static.go
@@ -92,7 +92,7 @@ See ochami-discover(1) for more details.`,
 
 		// Put together payload for different endpoints
 		log.Logger.Debug().Msg("generating redfish structures to send to SMD")
-		comps, rfes, _, err := discover.DiscoveryInfoV2(smdBaseURI, nodes)
+		comps, rfes, ifaces, err := discover.DiscoveryInfoV2(smdBaseURI, nodes)
 		if err != nil {
 			log.Logger.Error().Err(err).Msg("failed to construct structures to send to SMD")
 			logHelpError(cmd)
@@ -239,87 +239,93 @@ See ochami-discover(1) for more details.`,
 		}
 
 		// Send EthernetInterface requests
-		// var (
-		// 	ifaceErrorsOccurred bool = false
-		// 	ifaceHenvs          []client.HTTPEnvelope
-		// 	ifaceErrs           []error
-		// 	ifaceErr            error
-		// )
-		// if cmd.Flag("overwrite").Changed {
-		// 	// SMD's EthernetInterface API does not allow the PUT
-		// 	// method. Instead, we loop over each ethernet interface
-		// 	// to add and attempt a POST. Iff a 409 is returned for
-		// 	// that interface, a PATCH is attempted. Otherwise, an
-		// 	// error has occurred.
-		// 	for _, iface := range ifaces {
-		// 		// Attempt to POST the ethernet interface
-		// 		ifaceListWrapper := []smd.EthernetInterface{iface}
-		// 		ifaceHenvs, ifaceErrs, ifaceErr = smdClient.PostEthernetInterfaces(ifaceListWrapper, token)
+		var (
+			ifaceErrorsOccurred bool = false // could also just be...ifaceErr != nil || len(ifaceErrs) > 0
+			ifaceHenvs          []client.HTTPEnvelope
+			ifaceErrs           []error
+			ifaceErr            error
+		)
+		discoveryVersion, err := cmd.Flags().GetInt("discovery-version")
+		if err != nil {
+			log.Logger.Warn().Err(err).Msgf("could not get discovery version...using default value of %d", discoveryVersion)
+		}
+		if discoveryVersion == 1 {
+			if cmd.Flag("overwrite").Changed {
+				// SMD's EthernetInterface API does not allow the PUT
+				// method. Instead, we loop over each ethernet interface
+				// to add and attempt a POST. If a 409 is returned for
+				// that interface, a PATCH is attempted. Otherwise, an
+				// error has occurred.
+				for _, iface := range ifaces {
+					// Attempt to POST the ethernet interface
+					ifaceListWrapper := []smd.EthernetInterface{iface}
+					ifaceHenvs, ifaceErrs, ifaceErr = smdClient.PostEthernetInterfaces(ifaceListWrapper, token)
 
-		// 		if ifaceErr != nil {
-		// 			// An error in the function occurred, err for
-		// 			// this interface and move on.
-		// 			log.Logger.Error().Err(ifaceErr).Msg("failed to add ethernet interface to SMD")
-		// 			ifaceErrorsOccurred = true
-		// 			continue
-		// 		}
+					if ifaceErr != nil {
+						// An error in the function occurred, err for
+						// this interface and move on.
+						log.Logger.Error().Err(ifaceErr).Msg("failed to add ethernet interface to SMD")
+						ifaceErrorsOccurred = true
+						continue
+					}
 
-		// 		if ifaceErrs[0] != nil {
-		// 			// An HTTP error occurred
-		// 			if errors.Is(ifaceErrs[0], client.UnsuccessfulHTTPError) {
-		// 				if ifaceHenvs[0].StatusCode == 409 {
-		// 					// Ethernet interface exists, patch it
-		// 					log.Logger.Info().Msgf("ethernet interface with MAC address %s exists, attempting to update it", iface.MACAddress)
-		// 					_, patchErrs, patchErr := smdClient.PatchEthernetInterfaces(ifaceListWrapper, token)
-		// 					if patchErr != nil {
-		// 						log.Logger.Error().Err(patchErr).Msg("failed to update existing ethernet interface in SMD")
-		// 						ifaceErrorsOccurred = true
-		// 						continue
-		// 					}
-		// 					if patchErrs[0] != nil {
-		// 						var errMsg string
-		// 						if errors.Is(patchErrs[0], client.UnsuccessfulHTTPError) {
-		// 							errMsg = "SMD ethernet interface PATCH yielded unsuccessful HTTP response"
-		// 						} else {
-		// 							errMsg = "failed to update existing ethernet interface in SMD"
-		// 						}
-		// 						log.Logger.Error().Err(patchErrs[0]).Msg(errMsg)
-		// 						ifaceErrorsOccurred = true
-		// 						continue
-		// 					}
-		// 				} else {
-		// 					// Some other HTTP error occurred, err
-		// 					log.Logger.Error().Err(ifaceErrs[0]).Msg("SMD ethernet interface POST yield non-409 (duplicate) failure")
-		// 					ifaceErrorsOccurred = true
-		// 					continue
-		// 				}
-		// 			} else {
-		// 				log.Logger.Error().Err(ifaceErrs[0]).Msg("failed to add ethernet interface to SMD")
-		// 				ifaceErrorsOccurred = true
-		// 				continue
-		// 			}
-		// 		}
-		// 	}
-		// } else {
-		// 	// --overwrite was not passed, perform regular POST.
-		// 	_, ifaceErrs, ifaceErr = smdClient.PostEthernetInterfaces(ifaces, token)
-		// 	if ifaceErr != nil {
-		// 		log.Logger.Error().Err(ifaceErr).Msg("failed to add ethernet interfaces to SMD")
-		// 		ifaceErrorsOccurred = true
-		// 	}
-		// 	for _, err := range ifaceErrs {
-		// 		if err != nil {
-		// 			var errMsg string
-		// 			if errors.Is(err, client.UnsuccessfulHTTPError) {
-		// 				errMsg = "SMD ethernet interface request yielded unsuccessful HTTP response"
-		// 			} else {
-		// 				errMsg = "failed to add ethernet interface to SMD"
-		// 			}
-		// 			log.Logger.Error().Err(err).Msg(errMsg)
-		// 			ifaceErrorsOccurred = true
-		// 		}
-		// 	}
-		// }
+					if ifaceErrs[0] != nil {
+						// An HTTP error occurred
+						if errors.Is(ifaceErrs[0], client.UnsuccessfulHTTPError) {
+							if ifaceHenvs[0].StatusCode == 409 {
+								// Ethernet interface exists, patch it
+								log.Logger.Info().Msgf("ethernet interface with MAC address %s exists, attempting to update it", iface.MACAddress)
+								_, patchErrs, patchErr := smdClient.PatchEthernetInterfaces(ifaceListWrapper, token)
+								if patchErr != nil {
+									log.Logger.Error().Err(patchErr).Msg("failed to update existing ethernet interface in SMD")
+									ifaceErrorsOccurred = true
+									continue
+								}
+								if patchErrs[0] != nil {
+									var errMsg string
+									if errors.Is(patchErrs[0], client.UnsuccessfulHTTPError) {
+										errMsg = "SMD ethernet interface PATCH yielded unsuccessful HTTP response"
+									} else {
+										errMsg = "failed to update existing ethernet interface in SMD"
+									}
+									log.Logger.Error().Err(patchErrs[0]).Msg(errMsg)
+									ifaceErrorsOccurred = true
+									continue
+								}
+							} else {
+								// Some other HTTP error occurred, err
+								log.Logger.Error().Err(ifaceErrs[0]).Msg("SMD ethernet interface POST yield non-409 (duplicate) failure")
+								ifaceErrorsOccurred = true
+								continue
+							}
+						} else {
+							log.Logger.Error().Err(ifaceErrs[0]).Msg("failed to add ethernet interface to SMD")
+							ifaceErrorsOccurred = true
+							continue
+						}
+					}
+				}
+			} else {
+				// --overwrite was not passed, perform regular POST.
+				_, ifaceErrs, ifaceErr = smdClient.PostEthernetInterfaces(ifaces, token)
+				if ifaceErr != nil {
+					log.Logger.Error().Err(ifaceErr).Msg("failed to add ethernet interfaces to SMD")
+					ifaceErrorsOccurred = true
+				}
+				for _, err := range ifaceErrs {
+					if err != nil {
+						var errMsg string
+						if errors.Is(err, client.UnsuccessfulHTTPError) {
+							errMsg = "SMD ethernet interface request yielded unsuccessful HTTP response"
+						} else {
+							errMsg = "failed to add ethernet interface to SMD"
+						}
+						log.Logger.Error().Err(err).Msg(errMsg)
+						ifaceErrorsOccurred = true
+					}
+				}
+			}
+		}
 
 		// Put together list of groups to add and which components to add to those groups
 		groupsToAdd := make(map[string]smd.Group)
@@ -439,10 +445,10 @@ See ochami-discover(1) for more details.`,
 			log.Logger.Warn().Msg("redfish endpoint requests completed with errors")
 			exitStatus = 1
 		}
-		// if ifaceErrorsOccurred {
-		// 	log.Logger.Warn().Msg("ethernet interface requests completed with errors")
-		// 	exitStatus = 1
-		// }
+		if ifaceErrorsOccurred {
+			log.Logger.Warn().Msg("ethernet interface requests completed with errors")
+			exitStatus = 1
+		}
 		if groupErrorsOccurred {
 			log.Logger.Warn().Msg("group requests completed with errors")
 			exitStatus = 1
@@ -452,6 +458,7 @@ See ochami-discover(1) for more details.`,
 }
 
 func init() {
+	discoverStaticCmd.Flags().Int("discovery-version", 1, "set version for discovery method to use")
 	discoverStaticCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
 	discoverStaticCmd.Flags().VarP(&formatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
 	discoverStaticCmd.Flags().Bool("overwrite", false, "overwrite any existing information instead of failing")

--- a/cmd/discover-static.go
+++ b/cmd/discover-static.go
@@ -15,11 +15,6 @@ import (
 	"github.com/OpenCHAMI/ochami/pkg/discover"
 )
 
-const (
-	DISCOVER_V1 int = iota + 1 // 1
-	DISCOVER_V2                // 2
-)
-
 // discoverStaticCmd represents the discover-static command
 var discoverStaticCmd = &cobra.Command{
 	Use:   "static [--overwrite] [-d (<data> | @<path>)] [-f <format>]",
@@ -459,7 +454,7 @@ See ochami-discover(1) for more details.`,
 }
 
 func init() {
-	discoverStaticCmd.Flags().Int("discovery-version", DISCOVER_V2, "set version for discovery method to use")
+	discoverStaticCmd.Flags().Var(&discoveryVersion, "discovery-version", "set version for discovery method to use")
 	discoverStaticCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
 	discoverStaticCmd.Flags().VarP(&formatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
 	discoverStaticCmd.Flags().Bool("overwrite", false, "overwrite any existing information instead of failing")

--- a/cmd/discover-static.go
+++ b/cmd/discover-static.go
@@ -15,6 +15,11 @@ import (
 	"github.com/OpenCHAMI/ochami/pkg/discover"
 )
 
+const (
+	DISCOVER_V1 int = iota + 1 // 1
+	DISCOVER_V2                // 2
+)
+
 // discoverStaticCmd represents the discover-static command
 var discoverStaticCmd = &cobra.Command{
 	Use:   "static [--overwrite] [-d (<data> | @<path>)] [-f <format>]",
@@ -240,16 +245,16 @@ See ochami-discover(1) for more details.`,
 
 		// Send EthernetInterface requests
 		var (
-			ifaceErrorsOccurred bool = false // could also just be...ifaceErr != nil || len(ifaceErrs) > 0
+			ifaceErrorsOccurred bool = false
 			ifaceHenvs          []client.HTTPEnvelope
 			ifaceErrs           []error
 			ifaceErr            error
 		)
 		discoveryVersion, err := cmd.Flags().GetInt("discovery-version")
 		if err != nil {
-			log.Logger.Warn().Err(err).Msgf("could not get discovery version...using default value of %d", discoveryVersion)
+			log.Logger.Warn().Err(err).Msgf("could not get discovery version, using default value of %d", discoveryVersion)
 		}
-		if discoveryVersion == 1 {
+		if discoveryVersion == 2 {
 			if cmd.Flag("overwrite").Changed {
 				// SMD's EthernetInterface API does not allow the PUT
 				// method. Instead, we loop over each ethernet interface
@@ -434,7 +439,7 @@ See ochami-discover(1) for more details.`,
 
 		// Notify user if any request errors occurred
 		exitStatus := 0
-		if compErrorsOccurred || rfeErrorsOccurred || groupErrorsOccurred {
+		if compErrorsOccurred || rfeErrorsOccurred || ifaceErrorsOccurred || groupErrorsOccurred {
 			logHelpError(cmd)
 		}
 		if compErrorsOccurred {
@@ -458,7 +463,7 @@ See ochami-discover(1) for more details.`,
 }
 
 func init() {
-	discoverStaticCmd.Flags().Int("discovery-version", 1, "set version for discovery method to use")
+	discoverStaticCmd.Flags().Int("discovery-version", DISCOVER_V2, "set version for discovery method to use")
 	discoverStaticCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
 	discoverStaticCmd.Flags().VarP(&formatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
 	discoverStaticCmd.Flags().Bool("overwrite", false, "overwrite any existing information instead of failing")

--- a/cmd/discover-static.go
+++ b/cmd/discover-static.go
@@ -17,21 +17,7 @@ import (
 
 // discoverStaticCmd represents the discover-static command
 var discoverStaticCmd = &cobra.Command{
-	Use: "static [--overwrite] [-d (<data> | @<path>)] [-f <format>]",
-	Args: func(cmd *cobra.Command, args []string) error {
-		// get the discovery version value
-		discoveryVersion, err := cmd.Flags().GetInt("discovery-version")
-		if err != nil {
-			return err
-		}
-		// check that value of discovery-version is valid or else...
-		switch discoveryVersion {
-		case int(discover.DiscoveryMethodV1), int(discover.DiscoveryMethodV2):
-			return cobra.NoArgs(cmd, args)
-		default:
-			return fmt.Errorf("--discovery-version value must be 1 or 2")
-		}
-	},
+	Use:   "static [--overwrite] [-d (<data> | @<path>)] [-f <format>]",
 	Short: "Populate SMD with data statically",
 	Long: `Populate SMD using static data. This data can be from a file (if an
 argument is passed) or from standard input. This "fake" discovery
@@ -259,8 +245,7 @@ See ochami-discover(1) for more details.`,
 			ifaceErr            error
 		)
 		// get discovery version value (err handled in cmd.Args)
-		discoveryVersion, _ := cmd.Flags().GetInt("discovery-version")
-		if discoveryVersion == 2 {
+		if discoveryVersion == discover.DiscoveryMethodV2 {
 			if cmd.Flag("overwrite").Changed {
 				// SMD's EthernetInterface API does not allow the PUT
 				// method. Instead, we loop over each ethernet interface

--- a/cmd/discover-static.go
+++ b/cmd/discover-static.go
@@ -15,6 +15,11 @@ import (
 	"github.com/OpenCHAMI/ochami/pkg/discover"
 )
 
+const (
+	DISCOVER_V1 int = iota + 1 // 1
+	DISCOVER_V2                // 2
+)
+
 // discoverStaticCmd represents the discover-static command
 var discoverStaticCmd = &cobra.Command{
 	Use:   "static [--overwrite] [-d (<data> | @<path>)] [-f <format>]",
@@ -454,7 +459,7 @@ See ochami-discover(1) for more details.`,
 }
 
 func init() {
-	discoverStaticCmd.Flags().Var(&discoveryVersion, "discovery-version", "set version for discovery method to use")
+	discoverStaticCmd.Flags().Int("discovery-version", DISCOVER_V2, "set version for discovery method to use")
 	discoverStaticCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
 	discoverStaticCmd.Flags().VarP(&formatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
 	discoverStaticCmd.Flags().Bool("overwrite", false, "overwrite any existing information instead of failing")

--- a/cmd/discover-static.go
+++ b/cmd/discover-static.go
@@ -22,8 +22,23 @@ const (
 
 // discoverStaticCmd represents the discover-static command
 var discoverStaticCmd = &cobra.Command{
-	Use:   "static [--overwrite] [-d (<data> | @<path>)] [-f <format>]",
-	Args:  cobra.NoArgs,
+	Use: "static [--overwrite] [-d (<data> | @<path>)] [-f <format>]",
+	Args: func(cmd *cobra.Command, args []string) error {
+		// get the discovery version value
+		discoveryVersion, err := cmd.Flags().GetInt("discovery-version")
+		if err != nil {
+			return err
+		}
+		// check that value of discovery-version is valid or else...
+		switch discoveryVersion {
+		case DISCOVER_V1:
+			fallthrough
+		case DISCOVER_V2:
+			return cobra.NoArgs(cmd, args)
+		default:
+			return fmt.Errorf("--discovery-version value must be 1 or 2")
+		}
+	},
 	Short: "Populate SMD with data statically",
 	Long: `Populate SMD using static data. This data can be from a file (if an
 argument is passed) or from standard input. This "fake" discovery
@@ -250,10 +265,8 @@ See ochami-discover(1) for more details.`,
 			ifaceErrs           []error
 			ifaceErr            error
 		)
-		discoveryVersion, err := cmd.Flags().GetInt("discovery-version")
-		if err != nil {
-			log.Logger.Warn().Err(err).Msgf("could not get discovery version, using default value of %d", discoveryVersion)
-		}
+		// get discovery version value (err handled in cmd.Args)
+		discoveryVersion, _ := cmd.Flags().GetInt("discovery-version")
 		if discoveryVersion == 2 {
 			if cmd.Flag("overwrite").Changed {
 				// SMD's EthernetInterface API does not allow the PUT

--- a/cmd/discover-static.go
+++ b/cmd/discover-static.go
@@ -460,6 +460,7 @@ func init() {
 	discoverStaticCmd.Flags().Bool("overwrite", false, "overwrite any existing information instead of failing")
 
 	discoverStaticCmd.RegisterFlagCompletionFunc("format-input", completionFormatData)
+	discoverStaticCmd.RegisterFlagCompletionFunc("discovery-version", completionDiscoveryVersion)
 
 	discoverCmd.AddCommand(discoverStaticCmd)
 }

--- a/cmd/discover-static.go
+++ b/cmd/discover-static.go
@@ -15,11 +15,6 @@ import (
 	"github.com/OpenCHAMI/ochami/pkg/discover"
 )
 
-const (
-	DISCOVER_V1 int = iota + 1 // 1
-	DISCOVER_V2                // 2
-)
-
 // discoverStaticCmd represents the discover-static command
 var discoverStaticCmd = &cobra.Command{
 	Use: "static [--overwrite] [-d (<data> | @<path>)] [-f <format>]",
@@ -31,9 +26,7 @@ var discoverStaticCmd = &cobra.Command{
 		}
 		// check that value of discovery-version is valid or else...
 		switch discoveryVersion {
-		case DISCOVER_V1:
-			fallthrough
-		case DISCOVER_V2:
+		case int(discover.DiscoveryMethodV1), int(discover.DiscoveryMethodV2):
 			return cobra.NoArgs(cmd, args)
 		default:
 			return fmt.Errorf("--discovery-version value must be 1 or 2")
@@ -476,7 +469,7 @@ See ochami-discover(1) for more details.`,
 }
 
 func init() {
-	discoverStaticCmd.Flags().Int("discovery-version", DISCOVER_V2, "set version for discovery method to use")
+	discoverStaticCmd.Flags().Var(&discoveryVersion, "discovery-version", "set version for discovery method to use")
 	discoverStaticCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
 	discoverStaticCmd.Flags().VarP(&formatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
 	discoverStaticCmd.Flags().Bool("overwrite", false, "overwrite any existing information instead of failing")

--- a/cmd/lib.go
+++ b/cmd/lib.go
@@ -15,6 +15,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/OpenCHAMI/ochami/internal/config"
+	"github.com/OpenCHAMI/ochami/internal/log"
+	"github.com/OpenCHAMI/ochami/pkg/client"
+	"github.com/OpenCHAMI/ochami/pkg/discover"
+	"github.com/OpenCHAMI/ochami/pkg/format"
 	"github.com/lestrrat-go/jwx/jwt"
 	"github.com/spf13/cobra"
 

--- a/cmd/lib.go
+++ b/cmd/lib.go
@@ -476,7 +476,7 @@ func completionFormatData(cmd *cobra.Command, args []string, toComplete string) 
 func completionDiscoveryVersion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	var helpSlice []string
 	for k, v := range discover.DiscoveryVersionHelp {
-		helpSlice = append(helpSlice, fmt.Sprintf("%s\t%s", k, v))
+		helpSlice = append(helpSlice, fmt.Sprintf("%d\t%s", k, v))
 	}
 	return helpSlice, cobra.ShellCompDirectiveDefault
 }

--- a/cmd/lib.go
+++ b/cmd/lib.go
@@ -15,13 +15,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lestrrat-go/jwx/jwt"
+	"github.com/spf13/cobra"
+
 	"github.com/OpenCHAMI/ochami/internal/config"
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/pkg/client"
 	"github.com/OpenCHAMI/ochami/pkg/discover"
 	"github.com/OpenCHAMI/ochami/pkg/format"
-	"github.com/lestrrat-go/jwx/jwt"
-	"github.com/spf13/cobra"
 
 	"github.com/OpenCHAMI/ochami/internal/version"
 )

--- a/cmd/lib.go
+++ b/cmd/lib.go
@@ -22,6 +22,7 @@ import (
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/internal/version"
 	"github.com/OpenCHAMI/ochami/pkg/client"
+	"github.com/OpenCHAMI/ochami/pkg/discover"
 	"github.com/OpenCHAMI/ochami/pkg/format"
 )
 
@@ -465,6 +466,16 @@ func logHelpWarn(cmd *cobra.Command) {
 func completionFormatData(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	var helpSlice []string
 	for k, v := range format.DataFormatHelp {
+		helpSlice = append(helpSlice, fmt.Sprintf("%s\t%s", k, v))
+	}
+	return helpSlice, cobra.ShellCompDirectiveDefault
+}
+
+// completionDiscoveryVersion is the cobra completion function for the
+// --discovery-version flag.
+func completionDiscoveryVersion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	var helpSlice []string
+	for k, v := range discover.DiscoveryVersionHelp {
 		helpSlice = append(helpSlice, fmt.Sprintf("%s\t%s", k, v))
 	}
 	return helpSlice, cobra.ShellCompDirectiveDefault

--- a/cmd/lib.go
+++ b/cmd/lib.go
@@ -23,12 +23,7 @@ import (
 	"github.com/lestrrat-go/jwx/jwt"
 	"github.com/spf13/cobra"
 
-	"github.com/OpenCHAMI/ochami/internal/config"
-	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/internal/version"
-	"github.com/OpenCHAMI/ochami/pkg/client"
-	"github.com/OpenCHAMI/ochami/pkg/discover"
-	"github.com/OpenCHAMI/ochami/pkg/format"
 )
 
 var (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/internal/version"
+	"github.com/OpenCHAMI/ochami/pkg/discover"
 	"github.com/OpenCHAMI/ochami/pkg/format"
 )
 
@@ -21,6 +22,9 @@ var (
 	// Default values are set here.
 	formatInput  = format.DataFormatJson
 	formatOutput = format.DataFormatJson
+
+	// Variable to store the value of --discovery-method.
+	discoveryVersion = discover.DiscoveryMethodV2
 
 	// These are only used by subcommands.
 	cacertPath string

--- a/man/ochami-discover.1.sc
+++ b/man/ochami-discover.1.sc
@@ -22,24 +22,24 @@ format is as follows:
 ```
 nodes:
 - name: node01
-		nid: 1
-		xname: x1000c1s7b0n0
-		bmc_mac: de:ca:fc:0f:ee:ee
-		bmc_ip: 172.16.0.101
-		group: compute
-		interfaces:
-		- mac_addr: de:ad:be:ee:ee:f1
-			ip_addrs:
-			- name: internal
-				ip_addr: 172.16.0.1
-		- mac_addr: de:ad:be:ee:ee:f2
-			ip_addrs:
-			- name: external
-				ip_addr: 10.15.3.100
-		- mac_addr: 02:00:00:91:31:b3
-			ip_addrs:
-			- name: HSN
-				ip_addr: 192.168.0.1
+  nid: 1
+  xname: x1000c1s7b0n0
+  bmc_mac: de:ca:fc:0f:ee:ee
+  bmc_ip: 172.16.0.101
+  group: compute
+  interfaces:
+  - mac_addr: de:ad:be:ee:ee:f1
+    ip_addrs:
+    - name: internal
+      ip_addr: 172.16.0.1
+  - mac_addr: de:ad:be:ee:ee:f2
+    ip_addrs:
+    - name: external
+      ip_addr: 10.15.3.100
+  - mac_addr: 02:00:00:91:31:b3
+    ip_addrs:
+    - name: HSN
+      ip_addr: 192.168.0.1
 ```
 
 A description of each key in the above is as follows:

--- a/man/ochami-discover.1.sc
+++ b/man/ochami-discover.1.sc
@@ -22,24 +22,24 @@ format is as follows:
 ```
 nodes:
 - name: node01
-  nid: 1
-  xname: x1000c1s7b0n0
-  bmc_mac: de:ca:fc:0f:ee:ee
-  bmc_ip: 172.16.0.101
-  group: compute
-  interfaces:
-  - mac_addr: de:ad:be:ee:ee:f1
-    ip_addrs:
-    - name: internal
-      ip_addr: 172.16.0.1
-  - mac_addr: de:ad:be:ee:ee:f2
-    ip_addrs:
-    - name: external
-      ip_addr: 10.15.3.100
-  - mac_addr: 02:00:00:91:31:b3
-    ip_addrs:
-    - name: HSN
-      ip_addr: 192.168.0.1
+	nid: 1
+	xname: x1000c1s7b0n0
+	bmc_mac: de:ca:fc:0f:ee:ee
+	bmc_ip: 172.16.0.101
+	group: compute
+	interfaces:
+	- mac_addr: de:ad:be:ee:ee:f1
+		ip_addrs:
+		- name: internal
+			ip_addr: 172.16.0.1
+	- mac_addr: de:ad:be:ee:ee:f2
+		ip_addrs:
+		- name: external
+			ip_addr: 10.15.3.100
+	- mac_addr: 02:00:00:91:31:b3
+		ip_addrs:
+		- name: HSN
+			ip_addr: 192.168.0.1
 ```
 
 A description of each key in the above is as follows:
@@ -97,7 +97,6 @@ to create the EthernetInterfaces separately in SMD. If set to 2 (the default),
 the EthernetInterfaces are created with the first discovery request.
 This flag is only for backward compatibility with earlier versions of SMD and
 may be deprecated in a later version of ochami.
-
 This command accepts the following options:
 
 *-d, --data* (_data_ | @_path_ | @-)
@@ -124,6 +123,13 @@ This command accepts the following options:
 	Instead of failing if data already exists, overwrite it with new data
 	contained in the payload.
 
+*--discovery-version*
+	Set the version of the discovery method to use for static discovery.
+	Set the version of the discovery method to use for static discovery.
+	 
+				Possible values are:
+				- _1_
+				- _2_ (default)
 
 # XNAMES
 

--- a/man/ochami-discover.1.sc
+++ b/man/ochami-discover.1.sc
@@ -22,24 +22,24 @@ format is as follows:
 ```
 nodes:
 - name: node01
-  nid: 1
-  xname: x1000c1s7b0n0
-  bmc_mac: de:ca:fc:0f:ee:ee
-  bmc_ip: 172.16.0.101
-  group: compute
-  interfaces:
-  - mac_addr: de:ad:be:ee:ee:f1
-    ip_addrs:
-    - name: internal
-      ip_addr: 172.16.0.1
-  - mac_addr: de:ad:be:ee:ee:f2
-    ip_addrs:
-    - name: external
-      ip_addr: 10.15.3.100
-  - mac_addr: 02:00:00:91:31:b3
-    ip_addrs:
-    - name: HSN
-      ip_addr: 192.168.0.1
+	nid: 1
+	xname: x1000c1s7b0n0
+	bmc_mac: de:ca:fc:0f:ee:ee
+	bmc_ip: 172.16.0.101
+	group: compute
+	interfaces:
+	- mac_addr: de:ad:be:ee:ee:f1
+		ip_addrs:
+		- name: internal
+			ip_addr: 172.16.0.1
+	- mac_addr: de:ad:be:ee:ee:f2
+		ip_addrs:
+		- name: external
+			ip_addr: 10.15.3.100
+	- mac_addr: 02:00:00:91:31:b3
+		ip_addrs:
+		- name: HSN
+			ip_addr: 192.168.0.1
 ```
 
 A description of each key in the above is as follows:
@@ -92,10 +92,11 @@ corresponding to each node. It also creates Components corresponding to each
 node's BMC which corresponds to each RedfishEndpoint created.
 
 The *--discovery-version* sets which discovery method to use when running the
-*static* subcommand. If the version is set the 1, an additional request is made
-to create the EthernetInterfaces separately in SMD. Otherwise, the EthernetInterfaces
-are created with the first discovery request.
-
+*static* subcommand. If the version is set to 1, an additional request is made
+to create the EthernetInterfaces separately in SMD. If set to 2 (the default),
+the EthernetInterfaces are created with the first discovery request.
+This flag is only for backward compatibility with earlier versions of SMD and
+may be deprecated in a later version of ochami.
 This command accepts the following options:
 
 *-d, --data* (_data_ | @_path_ | @-)
@@ -116,7 +117,12 @@ This command accepts the following options:
 	contained in the payload.
 
 *--discovery-version*
-  Set the version of the discovery method to use for static discovery.
+	Set the version of the discovery method to use for static discovery.
+	Set the version of the discovery method to use for static discovery.
+	 
+				Possible values are:
+				- _1_
+				- _2_ (default)
 
 # XNAMES
 

--- a/man/ochami-discover.1.sc
+++ b/man/ochami-discover.1.sc
@@ -22,24 +22,24 @@ format is as follows:
 ```
 nodes:
 - name: node01
-	nid: 1
-	xname: x1000c1s7b0n0
-	bmc_mac: de:ca:fc:0f:ee:ee
-	bmc_ip: 172.16.0.101
-	group: compute
-	interfaces:
-	- mac_addr: de:ad:be:ee:ee:f1
-		ip_addrs:
-		- name: internal
-			ip_addr: 172.16.0.1
-	- mac_addr: de:ad:be:ee:ee:f2
-		ip_addrs:
-		- name: external
-			ip_addr: 10.15.3.100
-	- mac_addr: 02:00:00:91:31:b3
-		ip_addrs:
-		- name: HSN
-			ip_addr: 192.168.0.1
+		nid: 1
+		xname: x1000c1s7b0n0
+		bmc_mac: de:ca:fc:0f:ee:ee
+		bmc_ip: 172.16.0.101
+		group: compute
+		interfaces:
+		- mac_addr: de:ad:be:ee:ee:f1
+			ip_addrs:
+			- name: internal
+				ip_addr: 172.16.0.1
+		- mac_addr: de:ad:be:ee:ee:f2
+			ip_addrs:
+			- name: external
+				ip_addr: 10.15.3.100
+		- mac_addr: 02:00:00:91:31:b3
+			ip_addrs:
+			- name: HSN
+				ip_addr: 192.168.0.1
 ```
 
 A description of each key in the above is as follows:
@@ -97,6 +97,7 @@ to create the EthernetInterfaces separately in SMD. If set to 2 (the default),
 the EthernetInterfaces are created with the first discovery request.
 This flag is only for backward compatibility with earlier versions of SMD and
 may be deprecated in a later version of ochami.
+
 This command accepts the following options:
 
 *-d, --data* (_data_ | @_path_ | @-)
@@ -117,8 +118,8 @@ This command accepts the following options:
 	contained in the payload.
 
 *--discovery-version*
-	Set the version of the discovery method to use for static discovery.
-	Set the version of the discovery method to use for static discovery.
+			Set the version of the discovery method to use for static discovery.
+			Set the version of the discovery method to use for static discovery.
 	 
 				Possible values are:
 				- _1_

--- a/man/ochami-discover.1.sc
+++ b/man/ochami-discover.1.sc
@@ -105,6 +105,13 @@ This command accepts the following options:
 	or to read the data from standard input (@-). The format of data read in any
 	of these forms is JSON by default unless *-f* is specified to change it.
 
+*--discovery-version*
+	Set the version of the discovery method to use for static discovery.
+
+	Possible values are:
+	- _1_
+	- _2_ (default)
+
 *-f, --format-input* _format_
 	Format of the input data. If unspecified, the payload format is _json_ by
 	default. Supported formats are:
@@ -117,13 +124,6 @@ This command accepts the following options:
 	Instead of failing if data already exists, overwrite it with new data
 	contained in the payload.
 
-*--discovery-version*
-			Set the version of the discovery method to use for static discovery.
-			Set the version of the discovery method to use for static discovery.
-	 
-				Possible values are:
-				- _1_
-				- _2_ (default)
 
 # XNAMES
 

--- a/man/ochami-discover.1.sc
+++ b/man/ochami-discover.1.sc
@@ -91,6 +91,11 @@ RedfishEndpoints, EthernetInterfaces, Components, and groups data in SMD
 corresponding to each node. It also creates Components corresponding to each
 node's BMC which corresponds to each RedfishEndpoint created.
 
+The *--discovery-version* sets which discovery method to use when running the
+*static* subcommand. If the version is set the 1, an additional request is made
+to create the EthernetInterfaces separately in SMD. Otherwise, the EthernetInterfaces
+are created with the first discovery request.
+
 This command accepts the following options:
 
 *-d, --data* (_data_ | @_path_ | @-)
@@ -109,6 +114,9 @@ This command accepts the following options:
 *--overwrite*
 	Instead of failing if data already exists, overwrite it with new data
 	contained in the payload.
+
+*--discovery-version*
+  Set the version of the discovery method to use for static discovery.
 
 # XNAMES
 

--- a/man/ochami-discover.1.sc
+++ b/man/ochami-discover.1.sc
@@ -22,24 +22,24 @@ format is as follows:
 ```
 nodes:
 - name: node01
-	nid: 1
-	xname: x1000c1s7b0n0
-	bmc_mac: de:ca:fc:0f:ee:ee
-	bmc_ip: 172.16.0.101
-	group: compute
-	interfaces:
-	- mac_addr: de:ad:be:ee:ee:f1
-		ip_addrs:
-		- name: internal
-			ip_addr: 172.16.0.1
-	- mac_addr: de:ad:be:ee:ee:f2
-		ip_addrs:
-		- name: external
-			ip_addr: 10.15.3.100
-	- mac_addr: 02:00:00:91:31:b3
-		ip_addrs:
-		- name: HSN
-			ip_addr: 192.168.0.1
+  nid: 1
+  xname: x1000c1s7b0n0
+  bmc_mac: de:ca:fc:0f:ee:ee
+  bmc_ip: 172.16.0.101
+  group: compute
+  interfaces:
+  - mac_addr: de:ad:be:ee:ee:f1
+    ip_addrs:
+    - name: internal
+      ip_addr: 172.16.0.1
+  - mac_addr: de:ad:be:ee:ee:f2
+    ip_addrs:
+    - name: external
+      ip_addr: 10.15.3.100
+  - mac_addr: 02:00:00:91:31:b3
+    ip_addrs:
+    - name: HSN
+      ip_addr: 192.168.0.1
 ```
 
 A description of each key in the above is as follows:
@@ -59,10 +59,10 @@ created for node.
 - *group* - Optional group to add node to. This will get created during
 discovery if it does not exist.
 - *interfaces* - A list of network interfaces for the node.
-	- *mac_addr* - MAC address of network interface.
-	- *ip_addrs* - List of IP addresses assigned to interface.
-		- *name* - Short name identifying the network for the IP address.
-		- *ip_addr* - IP address for interface.
+    - *mac_addr* - MAC address of network interface.
+    - *ip_addrs* - List of IP addresses assigned to interface.
+        - *name* - Short name identifying the network for the IP address.
+        - *ip_addr* - IP address for interface.
 
 # COMMANDS
 
@@ -100,36 +100,36 @@ may be deprecated in a later version of ochami.
 This command accepts the following options:
 
 *-d, --data* (_data_ | @_path_ | @-)
-	Specify raw _data_ to send, the _path_ to a file to read payload data from,
-	or to read the data from standard input (@-). The format of data read in any
-	of these forms is JSON by default unless *-f* is specified to change it.
+    Specify raw _data_ to send, the _path_ to a file to read payload data from,
+    or to read the data from standard input (@-). The format of data read in any
+    of these forms is JSON by default unless *-f* is specified to change it.
 
 *--discovery-version*
-	Set the version of the discovery method to use for static discovery.
+    Set the version of the discovery method to use for static discovery.
 
-	Possible values are:
-	- _1_
-	- _2_ (default)
+    Possible values are:
+    - _1_
+    - _2_ (default)
 
 *-f, --format-input* _format_
-	Format of the input data. If unspecified, the payload format is _json_ by
-	default. Supported formats are:
+    Format of the input data. If unspecified, the payload format is _json_ by
+    default. Supported formats are:
 
-	- _json_ (default)
-	- _json-pretty_
-	- _yaml_
+    - _json_ (default)
+    - _json-pretty_
+    - _yaml_
 
 *--overwrite*
-	Instead of failing if data already exists, overwrite it with new data
-	contained in the payload.
+    Instead of failing if data already exists, overwrite it with new data
+    contained in the payload.
 
 *--discovery-version*
-	Set the version of the discovery method to use for static discovery.
-	Set the version of the discovery method to use for static discovery.
-	 
-				Possible values are:
-				- _1_
-				- _2_ (default)
+    Set the version of the discovery method to use for static discovery.
+    Set the version of the discovery method to use for static discovery.
+     
+                Possible values are:
+                - _1_
+                - _2_ (default)
 
 # XNAMES
 

--- a/pkg/discover/version.go
+++ b/pkg/discover/version.go
@@ -13,9 +13,9 @@ const (
 )
 
 var (
-	DisocveryVersionHelp = map[int]string{
-		int(DiscoveryMethodV1): "One-line JSON format",
-		int(DiscoveryMethodV2): "Unindented JSON format",
+	DiscoveryVersionHelp = map[int]string{
+		int(DiscoveryMethodV1): "Discovery with additional request to add EthernetInterfaces",
+		int(DiscoveryMethodV2): "Discovery without request to add EthernetInterfaces",
 	}
 )
 
@@ -41,5 +41,5 @@ func (dv *DiscoveryVersion) Set(v string) error {
 }
 
 func (dv DiscoveryVersion) Type() string {
-	return "DiscoveryVersion "
+	return "DiscoveryVersion"
 }

--- a/pkg/discover/version.go
+++ b/pkg/discover/version.go
@@ -1,0 +1,45 @@
+package discover
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type DiscoveryVersion int
+
+const (
+	DiscoveryMethodV1 DiscoveryVersion = iota + 1 // 1
+	DiscoveryMethodV2                             // 2
+)
+
+var (
+	DisocveryVersionHelp = map[int]string{
+		int(DiscoveryMethodV1): "One-line JSON format",
+		int(DiscoveryMethodV2): "Unindented JSON format",
+	}
+)
+
+func (dv DiscoveryVersion) String() string {
+	return fmt.Sprintf("v%d", (dv))
+}
+
+func (dv *DiscoveryVersion) Set(v string) error {
+	i, err := strconv.Atoi(v)
+	if err != nil {
+		return err
+	}
+	switch DiscoveryVersion(i) {
+	case DiscoveryMethodV1, DiscoveryMethodV2:
+		*dv = DiscoveryVersion(i)
+		return nil
+	default:
+		return fmt.Errorf("must be one of %v", []DiscoveryVersion{
+			DiscoveryMethodV1,
+			DiscoveryMethodV2,
+		})
+	}
+}
+
+func (dv DiscoveryVersion) Type() string {
+	return "DiscoveryVersion "
+}

--- a/pkg/discover/version.go
+++ b/pkg/discover/version.go
@@ -20,7 +20,7 @@ var (
 )
 
 func (dv DiscoveryVersion) String() string {
-	return fmt.Sprintf("v%d", (dv))
+	return fmt.Sprintf("%d", (dv))
 }
 
 func (dv *DiscoveryVersion) Set(v string) error {


### PR DESCRIPTION
This PR removes the second request to SMD to create the `EthernetInterface`s, which is not necessary since SMD now creates the interfaces with the discovery output included in the `RedfishEndpoint` data.

One thing to note here is that the `SchemaVersion` has no impact on whether the `EthernetInterface`s are added to SMD. Instead, the `SchemaVersion` determines whether to use the old versus current output from Magellan (see [note](https://github.com/OpenCHAMI/magellan?tab=readme-ov-file#openchami-magellan) in README).