### PR TITLE
feat: add `--no-token` flag and `cluster.enable-auth` config option

### DIFF
--- a/cmd/bss-boot-image-set.go
+++ b/cmd/bss-boot-image-set.go
@@ -33,7 +33,10 @@ See ochami-bss(1) for more details.`,
   ochami bss boot image set --mac 00:de:ad:be:ef:00,de:ca:fc:0f:fe:ee live:https://172.16.0.254/image.squashfs`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		bssClient := bssGetClient(cmd, true)
+		bssClient := bssGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// Get current kernel command line args
 		values := url.Values{}

--- a/cmd/bss-boot-params-add.go
+++ b/cmd/bss-boot-params-add.go
@@ -61,7 +61,10 @@ See ochami-bss(1) for more details.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		bssClient := bssGetClient(cmd, true)
+		bssClient := bssGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// The BSS BootParams struct we will send
 		bp := bssTypes.BootParams{}

--- a/cmd/bss-boot-params-delete.go
+++ b/cmd/bss-boot-params-delete.go
@@ -61,7 +61,10 @@ See ochami-bss(1) for more details.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		bssClient := bssGetClient(cmd, true)
+		bssClient := bssGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// The BSS BootParams struct we will send
 		bp := bssTypes.BootParams{}

--- a/cmd/bss-boot-params-get.go
+++ b/cmd/bss-boot-params-get.go
@@ -32,7 +32,10 @@ See ochami-bss(1) for more details.`,
   ochami bss boot params get --mac 00:de:ad:be:ef:00 --mac 00:c0:ff:ee:00:00`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		bssClient := bssGetClient(cmd, true)
+		bssClient := bssGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// If no ID flags are specified, get all boot parameters
 		qstr := ""

--- a/cmd/bss-boot-params-set.go
+++ b/cmd/bss-boot-params-set.go
@@ -61,7 +61,10 @@ See ochami-bss(1) for more details.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		bssClient := bssGetClient(cmd, true)
+		bssClient := bssGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// The BSS BootParams struct we will send
 		bp := bssTypes.BootParams{}

--- a/cmd/bss-boot-params-update.go
+++ b/cmd/bss-boot-params-update.go
@@ -59,7 +59,10 @@ See ochami-bss(1) for details.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		bssClient := bssGetClient(cmd, true)
+		bssClient := bssGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// The BSS BootParams struct we will send
 		bp := bssTypes.BootParams{}

--- a/cmd/bss-boot-script-get.go
+++ b/cmd/bss-boot-script-get.go
@@ -28,7 +28,7 @@ See ochami-bss(1) for more details.`,
 	Example: `  ochami boot script get --mac 00:c0:ff:ee:00:00`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		bssClient := bssGetClient(cmd, false)
+		bssClient := bssGetClient(cmd)
 
 		// Structure representing the boot script query string
 		values := url.Values{}

--- a/cmd/bss-dumpstate.go
+++ b/cmd/bss-dumpstate.go
@@ -23,7 +23,7 @@ var bssDumpStateCmd = &cobra.Command{
 See ochami-bss(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		bssClient := bssGetClient(cmd, false)
+		bssClient := bssGetClient(cmd)
 
 		// Send request
 		httpEnv, err := bssClient.GetDumpState()

--- a/cmd/bss-history.go
+++ b/cmd/bss-history.go
@@ -24,7 +24,7 @@ var bssHistoryCmd = &cobra.Command{
 See ochami-bss(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		bssClient := bssGetClient(cmd, false)
+		bssClient := bssGetClient(cmd)
 
 		// If no ID flags are specified, get all boot parameters
 		qstr := ""

--- a/cmd/bss-hosts-get.go
+++ b/cmd/bss-hosts-get.go
@@ -24,7 +24,7 @@ var bssHostsGetCmd = &cobra.Command{
 See ochami-bss(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		bssClient := bssGetClient(cmd, false)
+		bssClient := bssGetClient(cmd)
 
 		// If no ID flags are specified, get all boot parameters
 		qstr := ""

--- a/cmd/bss-status.go
+++ b/cmd/bss-status.go
@@ -23,7 +23,7 @@ var bssStatusCmd = &cobra.Command{
 See ochami-bss(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		bssClient := bssGetClient(cmd, false)
+		bssClient := bssGetClient(cmd)
 
 		// Determine which component to get status for and send request
 		var httpEnv client.HTTPEnvelope

--- a/cmd/bss.go
+++ b/cmd/bss.go
@@ -26,7 +26,7 @@ func bssGetClient(cmd *cobra.Command, tokenRequired bool) *bss.BSSClient {
 
 	// Make sure token is set/valid, if required
 	if tokenRequired {
-		setTokenFromEnvVar(cmd)
+		setToken(cmd)
 		checkToken(cmd)
 	}
 

--- a/cmd/bss.go
+++ b/cmd/bss.go
@@ -12,22 +12,14 @@ import (
 )
 
 // bssGetClient sets up the BSS client with the BSS base URI and certificates
-// (if necessary) and returns it. If tokenRequired is true, it will ensure that
-// the token is set and valid and load it. This function is used by each
-// subcommand.
-func bssGetClient(cmd *cobra.Command, tokenRequired bool) *bss.BSSClient {
+// (if necessary) and returns it. This function is used by each subcommand.
+func bssGetClient(cmd *cobra.Command) *bss.BSSClient {
 	// Without a base URI, we cannot do anything
 	bssBaseURI, err := getBaseURIBSS(cmd)
 	if err != nil {
 		log.Logger.Error().Err(err).Msg("failed to get base URI for BSS")
 		logHelpError(cmd)
 		os.Exit(1)
-	}
-
-	// Make sure token is set/valid, if required
-	if tokenRequired {
-		setToken(cmd)
-		checkToken(cmd)
 	}
 
 	// Create client to make request to BSS

--- a/cmd/cloud_init-defaults-get.go
+++ b/cmd/cloud_init-defaults-get.go
@@ -23,7 +23,10 @@ See ochami-cloud-init(1) for more details.`,
 	Example: `  ochami cloud-init defaults get`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		cloudInitClient := cloudInitGetClient(cmd, true)
+		cloudInitClient := cloudInitGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// Get data
 		henv, err := cloudInitClient.GetDefaults(token)

--- a/cmd/cloud_init-defaults-set.go
+++ b/cmd/cloud_init-defaults-set.go
@@ -52,7 +52,10 @@ See ochami-cloud-init(1) for more details.`,
   echo '<yaml_data>' | ochami cloud-init defaults set -d @- -f yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		cloudInitClient := cloudInitGetClient(cmd, true)
+		cloudInitClient := cloudInitGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// The ClusterDefaults data we will send
 		ciDflts := cistore.ClusterDefaults{}

--- a/cmd/cloud_init-group-add.go
+++ b/cmd/cloud_init-group-add.go
@@ -52,7 +52,10 @@ See ochami-cloud-init(1) for more details.`,
   echo '<yaml_data>' | ochami cloud-init group add -d @- -f yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		cloudInitClient := cloudInitGetClient(cmd, true)
+		cloudInitClient := cloudInitGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// The group data we will send
 		ciGroups := []cistore.GroupData{}

--- a/cmd/cloud_init-group-delete.go
+++ b/cmd/cloud_init-group-delete.go
@@ -53,7 +53,10 @@ See ochami-cloud-init(1) for more details.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		cloudInitClient := cloudInitGetClient(cmd, true)
+		cloudInitClient := cloudInitGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// The group data we will send
 		ciGroups := []cistore.GroupData{}

--- a/cmd/cloud_init-group-get.go
+++ b/cmd/cloud_init-group-get.go
@@ -20,7 +20,10 @@ import (
 // requested groups. If an error occurs, the program exits.
 func cloudInitGetGroupData(cmd *cobra.Command, args []string) (groupSlice []cistore.GroupData) {
 	// Create client to use for requests
-	cloudInitClient := cloudInitGetClient(cmd, true)
+	cloudInitClient := cloudInitGetClient(cmd)
+
+	// Handle token for this command
+	handleToken(cmd)
 
 	// Get data
 	if len(args) == 0 {

--- a/cmd/cloud_init-group-render.go
+++ b/cmd/cloud_init-group-render.go
@@ -37,7 +37,10 @@ See ochami-cloud-init(1) for more details.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		cloudInitClient := cloudInitGetClient(cmd, true)
+		cloudInitClient := cloudInitGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// Get group config
 		henvs, errs, err := cloudInitClient.GetNodeGroupData(token, args[1], args[0])

--- a/cmd/cloud_init-group-set.go
+++ b/cmd/cloud_init-group-set.go
@@ -52,7 +52,10 @@ See ochami-cloud-init(1) for more details.`,
   echo '<yaml_data>' | ochami cloud-init group set -d @- -f yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		cloudInitClient := cloudInitGetClient(cmd, true)
+		cloudInitClient := cloudInitGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// The list of group data we will send
 		ciGroups := []cistore.GroupData{}

--- a/cmd/cloud_init-node-get.go
+++ b/cmd/cloud_init-node-get.go
@@ -53,7 +53,10 @@ See ochami-cloud-init(1) for more details.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		cloudInitClient := cloudInitGetClient(cmd, true)
+		cloudInitClient := cloudInitGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// Get node group data
 		henvs, errs, err := cloudInitClient.GetNodeGroupData(token, args[0], args[1:]...)
@@ -129,7 +132,10 @@ See ochami-cloud-init(1) for more details.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		cloudInitClient := cloudInitGetClient(cmd, true)
+		cloudInitClient := cloudInitGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// Get meta-data
 		henvs, errs, err := cloudInitClient.GetNodeData(ci.CloudInitMetaData, token, args...)
@@ -213,7 +219,10 @@ See ochami-cloud-init(1) for more details.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		cloudInitClient := cloudInitGetClient(cmd, true)
+		cloudInitClient := cloudInitGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// Get user-data
 		henvs, errs, err := cloudInitClient.GetNodeData(ci.CloudInitUserData, token, args...)
@@ -284,7 +293,10 @@ See ochami-cloud-init(1) for more details.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		cloudInitClient := cloudInitGetClient(cmd, true)
+		cloudInitClient := cloudInitGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// Get vendor-data
 		henvs, errs, err := cloudInitClient.GetNodeData(ci.CloudInitVendorData, token, args...)

--- a/cmd/cloud_init-node-set.go
+++ b/cmd/cloud_init-node-set.go
@@ -56,7 +56,10 @@ See ochami-cloud-init(1) for more details.`,
   echo '<yaml_data>' | ochami cloud-init group set -d @- -f yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		cloudInitClient := cloudInitGetClient(cmd, true)
+		cloudInitClient := cloudInitGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// The instance information list we will send
 		ciInstInfo := []cistore.OpenCHAMIInstanceInfo{}

--- a/cmd/cloud_init.go
+++ b/cmd/cloud_init.go
@@ -62,22 +62,15 @@ func cloudInitCompletionHeaderWhen(cmd *cobra.Command, args []string, toComplete
 }
 
 // cloudInitGetClient sets up the cloud-init client with the cloud-init base URI
-// and certificates (if necessary) and returns it. If tokenRequired is true,
-// it will ensure that the token is set and valid and load it. This function is
-// used by each subcommand.
-func cloudInitGetClient(cmd *cobra.Command, tokenRequired bool) *ci.CloudInitClient {
+// and certificates (if necessary) and returns it. This function is used by
+// each subcommand.
+func cloudInitGetClient(cmd *cobra.Command) *ci.CloudInitClient {
 	// Without a base URI, we cannot do anything
 	cloudInitbaseURI, err := getBaseURICloudInit(cmd)
 	if err != nil {
 		log.Logger.Error().Err(err).Msg("failed to get base URI for cloud-init")
 		logHelpError(cmd)
 		os.Exit(1)
-	}
-
-	// Make sure token is set/valid, if required
-	if tokenRequired {
-		setToken(cmd)
-		checkToken(cmd)
 	}
 
 	// Create client to make request to cloud-init

--- a/cmd/cloud_init.go
+++ b/cmd/cloud_init.go
@@ -76,7 +76,7 @@ func cloudInitGetClient(cmd *cobra.Command, tokenRequired bool) *ci.CloudInitCli
 
 	// Make sure token is set/valid, if required
 	if tokenRequired {
-		setTokenFromEnvVar(cmd)
+		setToken(cmd)
 		checkToken(cmd)
 	}
 

--- a/cmd/config-cluster-set.go
+++ b/cmd/config-cluster-set.go
@@ -86,7 +86,7 @@ See ochami-config(5) for details on the configuration options.`,
 			logHelpError(cmd)
 			os.Exit(1)
 		}
-		if err := config.ModifyConfigCluster(fileToModify, args[0], args[1], dflt, args[2]); err != nil {
+		if err := config.ModifyConfigCluster(fileToModify, args[0], args[1], dflt, config.StringToType(args[2])); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to modify config file")
 			logHelpError(cmd)
 			os.Exit(1)

--- a/cmd/config-set.go
+++ b/cmd/config-set.go
@@ -77,7 +77,7 @@ See ochami-config(5) for details on the configuration options.`,
 		}
 
 		// Perform modification
-		if err := config.ModifyConfig(fileToModify, args[0], args[1]); err != nil {
+		if err := config.ModifyConfig(fileToModify, args[0], config.StringToType(args[1])); err != nil {
 			log.Logger.Error().Err(err).Msg("failed to modify config file")
 			logHelpError(cmd)
 			os.Exit(1)

--- a/cmd/discover-static.go
+++ b/cmd/discover-static.go
@@ -61,7 +61,7 @@ See ochami-discover(1) for more details.`,
 		}
 
 		// This endpoint requires authentication, so a token is needed
-		setTokenFromEnvVar(cmd)
+		setToken(cmd)
 		checkToken(cmd)
 
 		// Create client to make request to SMD

--- a/cmd/lib.go
+++ b/cmd/lib.go
@@ -369,8 +369,16 @@ func getBaseURI(cmd *cobra.Command, serviceName config.ServiceName) (string, err
 // performs any other setup tasks for tokens. It is called by all commands that
 // require a token.
 func handleToken(cmd *cobra.Command) {
-	setToken(cmd)
-	checkToken(cmd)
+	if noToken, err := cmd.Flags().GetBool("no-token"); err != nil {
+		log.Logger.Error().Err(err).Msg("unable to set --no-token")
+		logHelpError(cmd)
+		os.Exit(1)
+	} else if !noToken {
+		setToken(cmd)
+		checkToken(cmd)
+	} else {
+		log.Logger.Debug().Msg("skipping token setup since --no-token passed")
+	}
 }
 
 // setToken sets the access token for a cobra command cmd. If --token

--- a/cmd/lib.go
+++ b/cmd/lib.go
@@ -365,6 +365,14 @@ func getBaseURI(cmd *cobra.Command, serviceName config.ServiceName) (string, err
 	return baseURI, err
 }
 
+// handleToken is a wrapper function around code that reads, checks, and
+// performs any other setup tasks for tokens. It is called by all commands that
+// require a token.
+func handleToken(cmd *cobra.Command) {
+	setToken(cmd)
+	checkToken(cmd)
+}
+
 // setToken sets the access token for a cobra command cmd. If --token
 // was passed, that value is set as the access token. Otherwise, the token is
 // read from an environment variable whose format is <CLUSTER>_ACCESS_TOKEN

--- a/cmd/lib.go
+++ b/cmd/lib.go
@@ -365,7 +365,7 @@ func getBaseURI(cmd *cobra.Command, serviceName config.ServiceName) (string, err
 	return baseURI, err
 }
 
-// setTokenFromEnvVar sets the access token for a cobra command cmd. If --token
+// setToken sets the access token for a cobra command cmd. If --token
 // was passed, that value is set as the access token. Otherwise, the token is
 // read from an environment variable whose format is <CLUSTER>_ACCESS_TOKEN
 // where <CLUSTER> is the name of the cluster, in upper case, being contacted.
@@ -375,7 +375,7 @@ func getBaseURI(cmd *cobra.Command, serviceName config.ServiceName) (string, err
 // underscores, and making the letters uppercase. If no config file is set or
 // the environment variable is not set, an error is logged and the program
 // exits.
-func setTokenFromEnvVar(cmd *cobra.Command) {
+func setToken(cmd *cobra.Command) {
 	var (
 		clusterName string
 		varPrefix   string

--- a/cmd/pcs-status.go
+++ b/cmd/pcs-status.go
@@ -94,7 +94,7 @@ See ochami-pcs(1) for more details.`,
   ochami pcs status`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		pcsClient := pcsGetClient(cmd, false)
+		pcsClient := pcsGetClient(cmd)
 
 		// Figure out if we need to hit the /health endpoint (only if a flag has been provided)
 		flagsProvided := false

--- a/cmd/pcs-transition-abort.go
+++ b/cmd/pcs-transition-abort.go
@@ -29,7 +29,10 @@ See ochami-pcs(1) for more details.`,
 		transitionID := args[0]
 
 		// Create client to use for requests
-		pcsClient := pcsGetClient(cmd, true)
+		pcsClient := pcsGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// Abort the transition
 		transitionHttpEnv, err := pcsClient.DeleteTransition(transitionID, token)

--- a/cmd/pcs-transition-list.go
+++ b/cmd/pcs-transition-list.go
@@ -27,7 +27,10 @@ See ochami-pcs(1) for more details.`,
   ochami pcs transition list`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		pcsClient := pcsGetClient(cmd, true)
+		pcsClient := pcsGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// Get transitions
 		transitionsHttpEnv, err := pcsClient.GetTransitions(token)

--- a/cmd/pcs-transition-monitor.go
+++ b/cmd/pcs-transition-monitor.go
@@ -74,7 +74,10 @@ See ochami-pcs(1) for more details.`,
 		transitionID := args[0]
 
 		// Create client to use for requests
-		pcsClient := pcsGetClient(cmd, true)
+		pcsClient := pcsGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		p := mpb.New(mpb.WithWidth(64))
 

--- a/cmd/pcs-transition-show.go
+++ b/cmd/pcs-transition-show.go
@@ -29,7 +29,10 @@ See ochami-pcs(1) for more details.`,
 		transitionID := args[0]
 
 		// Create client to use for requests
-		pcsClient := pcsGetClient(cmd, true)
+		pcsClient := pcsGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// Get transition
 		transitionHttpEnv, err := pcsClient.GetTransition(transitionID, token)

--- a/cmd/pcs-transition-start.go
+++ b/cmd/pcs-transition-start.go
@@ -61,7 +61,10 @@ See ochami-pcs(1) for more details.`,
 		}
 
 		// Create client to use for requests
-		pcsClient := pcsGetClient(cmd, true)
+		pcsClient := pcsGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// Get the list of target components
 		var err error

--- a/cmd/pcs.go
+++ b/cmd/pcs.go
@@ -26,7 +26,7 @@ func pcsGetClient(cmd *cobra.Command, tokenRequired bool) *pcs.PCSClient {
 
 	// Make sure token is set/valid, if required
 	if tokenRequired {
-		setTokenFromEnvVar(cmd)
+		setToken(cmd)
 		checkToken(cmd)
 	}
 

--- a/cmd/pcs.go
+++ b/cmd/pcs.go
@@ -12,22 +12,14 @@ import (
 )
 
 // pcsGetClient sets up the PCS client with the PCS base URI and certificates
-// (if necessary) and returns it. If tokenRequired is true, it will ensure that
-// the token is set and valid and load it. This function is used by each
-// subcommand.
-func pcsGetClient(cmd *cobra.Command, tokenRequired bool) *pcs.PCSClient {
+// (if necessary) and returns it. This function is used by each subcommand.
+func pcsGetClient(cmd *cobra.Command) *pcs.PCSClient {
 	// Without a base URI, we cannot do anything
 	pcsBaseURI, err := getBaseURIPCS(cmd)
 	if err != nil {
 		log.Logger.Error().Err(err).Msg("failed to get base URI for PCS")
 		logHelpError(cmd)
 		os.Exit(1)
-	}
-
-	// Make sure token is set/valid, if required
-	if tokenRequired {
-		setToken(cmd)
-		checkToken(cmd)
 	}
 
 	// Create client to make request to PCS

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -91,6 +91,7 @@ func init() {
 	rootCmd.PersistentFlags().StringP("cluster-uri", "u", "", "base URI for OpenCHAMI services, excluding service base path (overrides cluster.uri in config file)")
 	rootCmd.PersistentFlags().StringVar(&cacertPath, "cacert", "", "path to root CA certificate in PEM format")
 	rootCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "access token to present for authentication")
+	rootCmd.PersistentFlags().Bool("no-token", false, "do not check for or use an access token")
 	rootCmd.PersistentFlags().BoolVarP(&insecure, "insecure", "k", false, "do not verify TLS certificates")
 	rootCmd.PersistentFlags().Bool("ignore-config", false, "do not use any config file")
 	rootCmd.PersistentFlags().BoolVarP(&log.EarlyLogger.EarlyVerbose, "verbose", "v", false, "be verbose before logging is initialized")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -97,4 +97,7 @@ func init() {
 
 	// Either use cluster from config file or specify details on CLI
 	rootCmd.MarkFlagsMutuallyExclusive("cluster", "cluster-uri")
+
+	// Do not allow simultaneously passing a token and ignoring it
+	rootCmd.MarkFlagsMutuallyExclusive("token", "no-token")
 }

--- a/cmd/smd-compep-delete.go
+++ b/cmd/smd-compep-delete.go
@@ -58,7 +58,10 @@ See ochami-smd(1) for more details.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		smdClient := smdGetClient(cmd, true)
+		smdClient := smdGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// Ask before attempting deletion unless --no-confirm was passed
 		if !cmd.Flag("no-confirm").Changed {

--- a/cmd/smd-compep-get.go
+++ b/cmd/smd-compep-get.go
@@ -23,7 +23,10 @@ var compepGetCmd = &cobra.Command{
 See ochami-smd(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		smdClient := smdGetClient(cmd, true)
+		smdClient := smdGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		var httpEnv client.HTTPEnvelope
 		var err error

--- a/cmd/smd-component-add.go
+++ b/cmd/smd-component-add.go
@@ -67,7 +67,10 @@ See ochami-smd(1) for more details.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		smdClient := smdGetClient(cmd, true)
+		smdClient := smdGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		var compSlice smd.ComponentSlice
 		var err error

--- a/cmd/smd-component-delete.go
+++ b/cmd/smd-component-delete.go
@@ -61,7 +61,10 @@ See ochami-smd(1) for more details.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		smdClient := smdGetClient(cmd, true)
+		smdClient := smdGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// Ask before attempting deletion unless --no-confirm was passed
 		if !cmd.Flag("no-confirm").Changed {

--- a/cmd/smd-component-get.go
+++ b/cmd/smd-component-get.go
@@ -23,7 +23,7 @@ var componentGetCmd = &cobra.Command{
 See ochami-smd(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		smdClient := smdGetClient(cmd, false)
+		smdClient := smdGetClient(cmd)
 
 		var httpEnv client.HTTPEnvelope
 		var err error

--- a/cmd/smd-component-get.go
+++ b/cmd/smd-component-get.go
@@ -29,13 +29,13 @@ See ochami-smd(1) for more details.`,
 		var err error
 		if cmd.Flag("xname").Changed {
 			// This endpoint requires authentication, so a token is needed
-			setTokenFromEnvVar(cmd)
+			setToken(cmd)
 			checkToken(cmd)
 
 			httpEnv, err = smdClient.GetComponentsXname(cmd.Flag("xname").Value.String(), token)
 		} else if cmd.Flag("nid").Changed {
 			// This endpoint requires authentication, so a token is needed
-			setTokenFromEnvVar(cmd)
+			setToken(cmd)
 			checkToken(cmd)
 
 			var nid int32

--- a/cmd/smd-group-add.go
+++ b/cmd/smd-group-add.go
@@ -73,7 +73,10 @@ See ochami-smd(1) for more details.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		smdClient := smdGetClient(cmd, true)
+		smdClient := smdGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// Check if a CA certificate was passed and load it into client if valid
 		useCACert(smdClient.OchamiClient)

--- a/cmd/smd-group-delete.go
+++ b/cmd/smd-group-delete.go
@@ -57,7 +57,10 @@ See ochami-smd(1) for more details.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		smdClient := smdGetClient(cmd, true)
+		smdClient := smdGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// Ask before attempting deletion unless --no-confirm was passed
 		if !cmd.Flag("no-confirm").Changed {

--- a/cmd/smd-group-get.go
+++ b/cmd/smd-group-get.go
@@ -31,7 +31,10 @@ See ochami-smd(1) for more details.`,
   ochami smd group get --name group1 --name group2 --tag tag1 --tag tag2`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		smdClient := smdGetClient(cmd, true)
+		smdClient := smdGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// If no ID flags are specified, get all groups
 		qstr := ""

--- a/cmd/smd-group-member-add.go
+++ b/cmd/smd-group-member-add.go
@@ -23,7 +23,10 @@ See ochami-smd(1) for more details.`,
 	Example: `  ochami smd group member add compute x3000c1s7b56n0`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		smdClient := smdGetClient(cmd, true)
+		smdClient := smdGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// Send off request
 		_, errs, err := smdClient.PostGroupMembers(token, args[0], args[1:]...)

--- a/cmd/smd-group-member-delete.go
+++ b/cmd/smd-group-member-delete.go
@@ -23,7 +23,10 @@ See ochami-smd(1) for more details.`,
 	Example: `  ochami smd group member delete compute x3000c1s7b56n0`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		smdClient := smdGetClient(cmd, true)
+		smdClient := smdGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// Ask before attempting deletion unless --no-confirm was passed
 		if !cmd.Flag("no-confirm").Changed {

--- a/cmd/smd-group-member-get.go
+++ b/cmd/smd-group-member-get.go
@@ -24,7 +24,10 @@ See ochami-smd(1) for more details.`,
 	Example: `  ochami smd group member get compute`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		smdClient := smdGetClient(cmd, true)
+		smdClient := smdGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// Send request
 		httpEnv, err := smdClient.GetGroupMembers(args[0], token)

--- a/cmd/smd-group-member-set.go
+++ b/cmd/smd-group-member-set.go
@@ -28,7 +28,10 @@ See ochami-smd(1) for more details.`,
 	Example: `  ochami smd group member set compute x1000c1s7b1n0 x1000c1s7b2n0`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		smdClient := smdGetClient(cmd, true)
+		smdClient := smdGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// Send off request
 		_, err := smdClient.PutGroupMembers(token, args[0], args[1:]...)

--- a/cmd/smd-group-update.go
+++ b/cmd/smd-group-update.go
@@ -61,7 +61,10 @@ See ochami-smd(1) for more details.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		smdClient := smdGetClient(cmd, true)
+		smdClient := smdGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// The group list we will send
 		var groups []smd.Group

--- a/cmd/smd-iface-add.go
+++ b/cmd/smd-iface-add.go
@@ -57,7 +57,10 @@ See ochami-smd(1) for more details.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		smdClient := smdGetClient(cmd, true)
+		smdClient := smdGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		var eis []smd.EthernetInterface
 		if cmd.Flag("data").Changed {

--- a/cmd/smd-iface-delete.go
+++ b/cmd/smd-iface-delete.go
@@ -58,7 +58,10 @@ See ochami-smd(1) for more details.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		smdClient := smdGetClient(cmd, true)
+		smdClient := smdGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// Ask before attempting deletion unless --no-confirm was passed
 		if !cmd.Flag("no-confirm").Changed {

--- a/cmd/smd-iface-get.go
+++ b/cmd/smd-iface-get.go
@@ -26,7 +26,7 @@ ethernet interfaces returned.
 See ochami-smd(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		smdClient := smdGetClient(cmd, false)
+		smdClient := smdGetClient(cmd)
 
 		// Deal with --id
 		if cmd.Flag("id").Changed {

--- a/cmd/smd-iface-get.go
+++ b/cmd/smd-iface-get.go
@@ -31,7 +31,7 @@ See ochami-smd(1) for more details.`,
 		// Deal with --id
 		if cmd.Flag("id").Changed {
 			// This endpoint requires authentication, so a token is needed
-			setTokenFromEnvVar(cmd)
+			setToken(cmd)
 			checkToken(cmd)
 
 			id, err := cmd.Flags().GetString("id")

--- a/cmd/smd-rfe-add.go
+++ b/cmd/smd-rfe-add.go
@@ -69,7 +69,10 @@ See ochami-smd(1) for more details.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		smdClient := smdGetClient(cmd, true)
+		smdClient := smdGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// Check if a CA certificate was passed and load it into client if valid
 		useCACert(smdClient.OchamiClient)

--- a/cmd/smd-rfe-delete.go
+++ b/cmd/smd-rfe-delete.go
@@ -58,7 +58,10 @@ See ochami-smd(1) for more details.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		smdClient := smdGetClient(cmd, true)
+		smdClient := smdGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// Ask before attempting deletion unless --no-confirm was passed
 		if !cmd.Flag("no-confirm").Changed {

--- a/cmd/smd-rfe-get.go
+++ b/cmd/smd-rfe-get.go
@@ -26,7 +26,10 @@ endpoints returned.
 See ochami-smd(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		smdClient := smdGetClient(cmd, true)
+		smdClient := smdGetClient(cmd)
+
+		// Handle token for this command
+		handleToken(cmd)
 
 		// If no ID flags are specified, get all redfish endpoints
 		qstr := ""

--- a/cmd/smd-status.go
+++ b/cmd/smd-status.go
@@ -23,7 +23,7 @@ var smdStatusCmd = &cobra.Command{
 See ochami-smd(1) for more details.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Create client to use for requests
-		smdClient := smdGetClient(cmd, false)
+		smdClient := smdGetClient(cmd)
 
 		// Determine which component to get status for and send request
 		var httpEnv client.HTTPEnvelope

--- a/cmd/smd.go
+++ b/cmd/smd.go
@@ -25,7 +25,7 @@ func smdGetClient(cmd *cobra.Command, tokenRequired bool) *smd.SMDClient {
 	}
 
 	// This endpoint requires authentication, so a token is needed
-	setTokenFromEnvVar(cmd)
+	setToken(cmd)
 	checkToken(cmd)
 
 	// Create client to make request to SMD

--- a/cmd/smd.go
+++ b/cmd/smd.go
@@ -12,10 +12,8 @@ import (
 )
 
 // smdGetClient sets up the SMD client with the SMD base URI and certificates
-// (if necessary) and returns it. If tokenRequired is true, it will ensure that
-// the token is set and valid and load it. This function is used by each
-// subcommand.
-func smdGetClient(cmd *cobra.Command, tokenRequired bool) *smd.SMDClient {
+// (if necessary) and returns it. This function is used by each subcommand.
+func smdGetClient(cmd *cobra.Command) *smd.SMDClient {
 	// Without a base URI, we cannot do anything
 	smdBaseURI, err := getBaseURISMD(cmd)
 	if err != nil {
@@ -23,10 +21,6 @@ func smdGetClient(cmd *cobra.Command, tokenRequired bool) *smd.SMDClient {
 		logHelpError(cmd)
 		os.Exit(1)
 	}
-
-	// This endpoint requires authentication, so a token is needed
-	setToken(cmd)
-	checkToken(cmd)
 
 	// Create client to make request to SMD
 	smdClient, err := smd.NewClient(smdBaseURI, insecure)

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/elliotchance/pie/v2 v2.9.1
 	github.com/go-viper/mapstructure/v2 v2.3.0
 	github.com/google/uuid v1.6.0
-	github.com/knadh/koanf/parsers/yaml v0.1.0
+	github.com/knadh/koanf/parsers/yaml v1.1.0
 	github.com/knadh/koanf/providers/file v1.1.2
 	github.com/knadh/koanf/providers/rawbytes v1.0.0
 	github.com/knadh/koanf/providers/structs v0.1.0
@@ -82,11 +82,11 @@ require (
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/yargevad/filepathx v1.0.0 // indirect
+	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.37.0 // indirect
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 // indirect
 	golang.org/x/net v0.39.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect
 	golang.org/x/text v0.24.0 // indirect
 	golang.org/x/time v0.11.0 // indirect
-	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHm
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/knadh/koanf/maps v0.1.1 h1:G5TjmUh2D7G2YWf5SQQqSiHRJEjaicvU0KpypqB3NIs=
 github.com/knadh/koanf/maps v0.1.1/go.mod h1:npD/QZY3V6ghQDdcQzl1W4ICNVTkohC8E73eI2xW4yI=
-github.com/knadh/koanf/parsers/yaml v0.1.0 h1:ZZ8/iGfRLvKSaMEECEBPM1HQslrZADk8fP1XFUxVI5w=
-github.com/knadh/koanf/parsers/yaml v0.1.0/go.mod h1:cvbUDC7AL23pImuQP0oRw/hPuccrNBS2bps8asS0CwY=
+github.com/knadh/koanf/parsers/yaml v1.1.0 h1:3ltfm9ljprAHt4jxgeYLlFPmUaunuCgu1yILuTXRdM4=
+github.com/knadh/koanf/parsers/yaml v1.1.0/go.mod h1:HHmcHXUrp9cOPcuC+2wrr44GTUB0EC+PyfN3HZD9tFg=
 github.com/knadh/koanf/providers/file v1.1.2 h1:aCC36YGOgV5lTtAFz2qkgtWdeQsgfxUkxDOe+2nQY3w=
 github.com/knadh/koanf/providers/file v1.1.2/go.mod h1:/faSBcv2mxPVjFrXck95qeoyoZ5myJ6uxN8OOVNJJCI=
 github.com/knadh/koanf/providers/rawbytes v1.0.0 h1:MrKDh/HksJlKJmaZjgs4r8aVBb/zsJyc/8qaSnzcdNI=
@@ -224,6 +224,8 @@ github.com/x-cray/logrus-prefixed-formatter v0.5.2 h1:00txxvfBM9muc0jiLIEAkAcIMJ
 github.com/x-cray/logrus-prefixed-formatter v0.5.2/go.mod h1:2duySbKsL6M18s5GU7VPsoEPHyzalCE06qoARUCeBBE=
 github.com/yargevad/filepathx v1.0.0 h1:SYcT+N3tYGi+NvazubCNlvgIPbzAk7i7y2dwg3I5FYc=
 github.com/yargevad/filepathx v1.0.0/go.mod h1:BprfX/gpYNJHJfc35GjRRpVcwWXS89gGulUIU5tK3tA=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.37.0 h1:kJNSjF/Xp7kU0iB2Z+9viTPMW4EqqsrywMXLJOOsXSE=
 golang.org/x/crypto v0.37.0/go.mod h1:vg+k43peMZ0pUMhYmVAWysMK35e6ioLh3wB8ZCAfbVc=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,6 +76,17 @@ type Config struct {
 	Clusters       []ConfigCluster `yaml:"clusters,omitempty"`
 }
 
+// GetCluster searches for a cluster by name and returns it if it exists in the
+// config. If not, an ErrUnknownCluster is returned.
+func (c Config) GetCluster(name string) (ConfigCluster, error) {
+	for _, cl := range c.Clusters {
+		if cl.Name == name {
+			return cl, nil
+		}
+	}
+	return ConfigCluster{}, ErrUnknownCluster{ClusterName: name}
+}
+
 type ConfigLog struct {
 	Format string `yaml:"format,omitempty"`
 	Level  string `yaml:"level,omitempty"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/go-viper/mapstructure/v2"
 	kyaml "github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/file"
 	"github.com/knadh/koanf/providers/rawbytes"
@@ -58,15 +57,6 @@ var (
 
 	// Global koanf struct configuration
 	kConfig = koanf.Conf{Delim: ".", StrictMerge: true}
-
-	// koanf unmarshal config used in unmarshalling function
-	kUnmarshalConf = koanf.UnmarshalConf{
-		Tag: "yaml", // Tag for determining mapping to struct members
-		DecoderConfig: &mapstructure.DecoderConfig{
-			ErrorUnused: true,          // Err if unknown keys found
-			Result:      &GlobalConfig, // Unmarshal to global config
-		},
-	}
 )
 
 // Config represents the structure of a configuration file.
@@ -107,7 +97,7 @@ type ConfigClusterConfig struct {
 	CloudInit  ConfigClusterCloudInit `yaml:"cloud-init,omitempty"`
 	PCS        ConfigClusterPCS       `yaml:"pcs,omitempty"`
 	SMD        ConfigClusterSMD       `yaml:"smd,omitempty"`
-	EnableAuth bool                   `yaml:"enable-auth,omitempty"`
+	EnableAuth bool                   `yaml:"enable-auth"`
 }
 
 // UnmarshalYAML unmarshals YAML into a ConfigClusterConfig, handling default
@@ -325,6 +315,23 @@ func (ccc *ConfigClusterConfig) GetServiceBaseURI(svcName ServiceName) (string, 
 	return serviceBaseURI, nil
 }
 
+// unmarshalKoanfYAML is a helper function that unmarshals data in ko into out
+// using parser p. The reason this function exists is because koanf.Unmarshal
+// and koanf.MarshalWithConf use mapstructure for their unmarshalling, which
+// means that custom unmarshal functions defined for out do not get run.
+// unmarshalKoanfYAML ensures this happens by first marshalling the data in ko
+// into YAML, then using the YAML unmarshaller to unmarshal into out.
+func unmarshalKoanfYAML(ko *koanf.Koanf, out interface{}) error {
+	yamlBytes, err := ko.Marshal(kyaml.Parser())
+	if err != nil {
+		return fmt.Errorf("failed to marshal config data into YAML: %w", err)
+	}
+	if err := yaml.Unmarshal(yamlBytes, out); err != nil {
+		return fmt.Errorf("failed to unmarshal YAML bytes into config: %w", err)
+	}
+	return nil
+}
+
 // RemoveFromSlice removes an element from a slice and returns the resulting
 // slice. The element to be removed is identified by its index in the slice.
 func RemoveFromSlice[T any](slice []T, index int) []T {
@@ -416,10 +423,8 @@ func LoadGlobalConfigMerged() error {
 	// so we copy it, unmarshal into the copy, then set the copy as the
 	// global config.
 	c := GlobalConfig
-	kuc := kUnmarshalConf
-	kuc.DecoderConfig.Result = &c
-	if err := GlobalKoanf.UnmarshalWithConf("", nil, kuc); err != nil {
-		return fmt.Errorf("failed to unmarshal global config into struct: %w", err)
+	if err := unmarshalKoanfYAML(ko, &c); err != nil {
+		return fmt.Errorf("failed to read merged config: %w", err)
 	}
 	GlobalConfig = c
 
@@ -481,14 +486,12 @@ func GenerateConfigFromBytes(b []byte) (*koanf.Koanf, Config, error) {
 		return k, cfg, fmt.Errorf("failed to load config bytes: %w", err)
 	}
 
-	// User global unmarshal config but unmarshal into cfg struct we created
-	// above
-	kuc := kUnmarshalConf
-	kuc.DecoderConfig.Result = &cfg
-
-	// Unmarshal bytes in parser structure
-	if err := k.UnmarshalWithConf("", nil, kuc); err != nil {
-		return k, cfg, fmt.Errorf("failed to unmarshal config bytes: %w", err)
+	// Unmarshal the YAML directly from the input bytes into config struct,
+	// using the custom YAML unmarshaller. The koanf unmarshaller does not
+	// call the custom UnmarshalYAML since it uses mapstructure under the
+	// hood.
+	if err := yaml.Unmarshal(b, &cfg); err != nil {
+		return k, cfg, fmt.Errorf("failed to unmarshal YAML bytes into config: %w", err)
 	}
 
 	// Return parser structure and config structure
@@ -518,10 +521,8 @@ func ModifyConfig(path, key string, value interface{}) error {
 		return fmt.Errorf("failed to set key %s to value %v: %w", key, value, err)
 	}
 	var modCfg Config
-	kuc := kUnmarshalConf
-	kuc.DecoderConfig.Result = &modCfg
-	if err := ko.UnmarshalWithConf("", nil, kuc); err != nil {
-		return fmt.Errorf("failed to modify config for %s: %w", path, err)
+	if err := unmarshalKoanfYAML(ko, &modCfg); err != nil {
+		return fmt.Errorf("failed to read modified config: %w", err)
 	}
 
 	// Write file back to file
@@ -572,7 +573,6 @@ func ModifyConfigCluster(path, cluster, key string, dflt bool, value interface{}
 		}
 	}
 	ko := koanf.NewWithConf(kConfig)
-	kuc := kUnmarshalConf
 	if newCluster {
 		// Adding a new cluster; create it and append to list
 		nCl := ConfigCluster{Name: cluster}
@@ -584,9 +584,8 @@ func ModifyConfigCluster(path, cluster, key string, dflt bool, value interface{}
 		if err := ko.Set(key, value); err != nil {
 			return fmt.Errorf("failed to set key %s to value %v for new cluster %s: %w", key, value, cluster, err)
 		}
-		kuc.DecoderConfig.Result = &nCl
-		if err := ko.UnmarshalWithConf("", nil, kuc); err != nil {
-			return fmt.Errorf("failed to modify config for new cluster %s: %w", cluster, err)
+		if err := unmarshalKoanfYAML(ko, &nCl); err != nil {
+			return fmt.Errorf("failed to read modified config for new cluster %s: %w", cluster, err)
 		}
 
 		// Add new cluster to cluster list
@@ -605,9 +604,8 @@ func ModifyConfigCluster(path, cluster, key string, dflt bool, value interface{}
 		if err := ko.Set(key, value); err != nil {
 			return fmt.Errorf("failed to set key %s to value %v for existing cluster %s: %w", key, value, cluster, err)
 		}
-		kuc.DecoderConfig.Result = clusterToMod
-		if err := ko.UnmarshalWithConf("", nil, kuc); err != nil {
-			return fmt.Errorf("failed to modify config for existing cluster %s: %w", cluster, err)
+		if err := unmarshalKoanfYAML(ko, &clusterToMod); err != nil {
+			return fmt.Errorf("failed to read modified config for existing cluster %s: %w", cluster, err)
 		}
 	}
 
@@ -660,9 +658,7 @@ func DeleteConfig(path, key string) error {
 	ko.Delete(key)
 
 	var modCfg Config
-	kuc := kUnmarshalConf
-	kuc.DecoderConfig.Result = &modCfg
-	if err := ko.UnmarshalWithConf("", nil, kuc); err != nil {
+	if err := unmarshalKoanfYAML(ko, &modCfg); err != nil {
 		return fmt.Errorf("failed to unset key %s from config for %s: %w", key, path, err)
 	}
 
@@ -708,11 +704,11 @@ func DeleteConfigCluster(path, cluster, key string) error {
 		return fmt.Errorf("failed to load config for cluster %s: %w", cluster, err)
 	}
 	ko.Delete(key)
+
+	// Write modified config back out to struct
 	var tmpCluster ConfigCluster
-	kuc := kUnmarshalConf
-	kuc.DecoderConfig.Result = &tmpCluster
-	if err := ko.UnmarshalWithConf("", nil, kuc); err != nil {
-		return fmt.Errorf("failed to unset key %s from config for cluster %s: %w", key, cluster, err)
+	if err := unmarshalKoanfYAML(ko, &tmpCluster); err != nil {
+		return fmt.Errorf("failed to read modified cluster data: %w", err)
 	}
 	*clusterToMod = tmpCluster
 
@@ -747,10 +743,8 @@ func GetConfig(cfg Config, key string) (interface{}, error) {
 		val = ko.Get(key)
 	} else {
 		// No key specified, return whole config
-		kuc := kUnmarshalConf
-		kuc.DecoderConfig.Result = &val
-		if err := ko.UnmarshalWithConf("", nil, kuc); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal config from struct: %w", err)
+		if err := unmarshalKoanfYAML(ko, &val); err != nil {
+			return nil, fmt.Errorf("failed to read config data: %w", err)
 		}
 	}
 	return val, nil
@@ -829,10 +823,8 @@ func GetConfigCluster(cluster ConfigCluster, key string) (interface{}, error) {
 		val = ko.Get(key)
 	} else {
 		// No key specified, return whole config
-		kuc := kUnmarshalConf
-		kuc.DecoderConfig.Result = &val
-		if err := ko.UnmarshalWithConf("", nil, kuc); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal cluster config from struct: %w", err)
+		if err := unmarshalKoanfYAML(ko, &val); err != nil {
+			return nil, fmt.Errorf("failed to read cluster config: %w", err)
 		}
 	}
 	return val, nil
@@ -900,14 +892,15 @@ func ReadConfig(path string) (Config, error) {
 	}
 	log.Logger.Debug().Msgf("reading config file: %s", path)
 
+	// Load config file into koanf to check for errors
 	ko := koanf.NewWithConf(kConfig)
 	if err := ko.Load(file.Provider(path), configParser); err != nil {
 		return cfg, fmt.Errorf("failed to load config file %s: %w", path, err)
 	}
-	kuc := kUnmarshalConf
-	kuc.DecoderConfig.Result = &cfg
-	if err := ko.UnmarshalWithConf("", nil, kuc); err != nil {
-		return cfg, fmt.Errorf("failed to unmarshal config from %s: %w", path, err)
+
+	// Unmarshal koanf data into config struct
+	if err := unmarshalKoanfYAML(ko, &cfg); err != nil {
+		return cfg, fmt.Errorf("failed to read config data: %w", err)
 	}
 
 	return cfg, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -852,7 +852,8 @@ log:
 					{
 						Name: "demo",
 						Cluster: ConfigClusterConfig{
-							URI: "https://demo.openchami.cluster:8443",
+							EnableAuth: true,
+							URI:        "https://demo.openchami.cluster:8443",
 						},
 					},
 				},
@@ -886,19 +887,6 @@ func TestModifyConfig(t *testing.T) {
 		err := ModifyConfig("/no/such/file.yaml", "default-cluster", "new")
 		if err == nil {
 			t.Fatalf("ModifyConfig(): expected file read error, got %v", err)
-		}
-	})
-
-	t.Run("invalid key returns error", func(t *testing.T) {
-		tmp := t.TempDir()
-		path := filepath.Join(tmp, "cfg.yaml")
-		initial := Config{}
-		data, _ := yaml.Marshal(initial)
-		os.WriteFile(path, data, 0o644)
-
-		err := ModifyConfig(path, "does.not.exist", "value")
-		if err == nil {
-			t.Fatal("ModifyConfig(): expected error for invalid key, got nil")
 		}
 	})
 

--- a/internal/config/errors.go
+++ b/internal/config/errors.go
@@ -6,6 +6,16 @@ import (
 	"fmt"
 )
 
+// ErrUnknownCluster represents an error that occurs when a requested cluster
+// name is not found in the config.
+type ErrUnknownCluster struct {
+	ClusterName string
+}
+
+func (euc ErrUnknownCluster) Error() string {
+	return fmt.Sprintf("cluster %s not found", euc.ClusterName)
+}
+
 // ErrMissingURI represents an error that occurs when neither the cluster.uri
 // nor the <service>.uri config values are set for a service. Service is the
 // name of the service whose config value is being checked.

--- a/internal/config/errors.go
+++ b/internal/config/errors.go
@@ -6,6 +6,19 @@ import (
 	"fmt"
 )
 
+// ErrInvalidConfigVal represents an error that occurs when a value for a key in
+// the configuration is invalid.
+type ErrInvalidConfigVal struct {
+	Key      string
+	Value    string
+	Expected string
+	Line     int
+}
+
+func (eicv ErrInvalidConfigVal) Error() string {
+	return fmt.Sprintf("line %d: invalid value for key %q: got %s but expected %s", eicv.Line, eicv.Key, eicv.Value, eicv.Expected)
+}
+
 // ErrUnknownCluster represents an error that occurs when a requested cluster
 // name is not found in the config.
 type ErrUnknownCluster struct {

--- a/internal/config/errors_test.go
+++ b/internal/config/errors_test.go
@@ -4,8 +4,38 @@ package config
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 )
+
+func TestErrUnknownCluster_Error(t *testing.T) {
+	type fields struct {
+		ClusterName string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "cluster name contained in error",
+			fields: fields{
+				ClusterName: "test_cluster",
+			},
+			want: "test_cluster",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			euc := ErrUnknownCluster{
+				ClusterName: tt.fields.ClusterName,
+			}
+			if got := euc.Error(); !strings.Contains(got, tt.want) {
+				t.Errorf("ErrUnknownCluster.Error() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestErrMissingURI_Error(t *testing.T) {
 	type fields struct {

--- a/internal/config/errors_test.go
+++ b/internal/config/errors_test.go
@@ -8,6 +8,59 @@ import (
 	"testing"
 )
 
+func TestErrInvalidConfigVal_Error(t *testing.T) {
+	type fields struct {
+		Key      string
+		Value    string
+		Expected string
+		Line     int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   fields
+	}{
+		{
+			name: "expected fields contained in error",
+			fields: fields{
+				Key:      "enable-auth",
+				Value:    "empty string",
+				Expected: "true or false",
+				Line:     1,
+			},
+			want: fields{
+				Key:      "enable-auth",
+				Value:    "empty string",
+				Expected: "true or false",
+				Line:     1,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eicv := ErrInvalidConfigVal{
+				Key:      tt.fields.Key,
+				Value:    tt.fields.Value,
+				Expected: tt.fields.Expected,
+				Line:     tt.fields.Line,
+			}
+			got := eicv.Error()
+			if !strings.Contains(got, tt.want.Key) {
+				t.Errorf("ErrInvalidConfigVal.Error() does not contain expected Key %s, full error was %s", tt.want.Key, got)
+			}
+			if !strings.Contains(got, tt.want.Value) {
+				t.Errorf("ErrInvalidConfigVal.Error() does not contain expected Value %s, full error was %s", tt.want.Value, got)
+			}
+			if !strings.Contains(got, tt.want.Expected) {
+				t.Errorf("ErrInvalidConfigVal.Error() does not contain expected Expected %s, full error was %s", tt.want.Expected, got)
+			}
+			if !strings.Contains(got, fmt.Sprintf("%d", tt.want.Line)) {
+				t.Errorf("ErrInvalidConfigVal.Error() does not contain expected Line %d, full error was %s", tt.want.Line, got)
+			}
+		})
+	}
+}
+
 func TestErrUnknownCluster_Error(t *testing.T) {
 	type fields struct {
 		ClusterName string

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"strconv"
+	"strings"
+)
+
+// StringToType attempts to convert a string into a rudimentary Go type, simply
+// returning as a string if failing to do so. For example, if the string is
+// "true" or "false", the value will be returned as a bool.
+//
+// Currently-supported type conversions are:
+//
+// - bool
+// - int
+// - float
+//
+func StringToType(s string) any {
+	// Try bool
+	if b, err := strconv.ParseBool(strings.ToLower(s)); err == nil {
+		return b
+	}
+
+	// Try integer
+	if i, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return i
+	}
+
+	// Try float
+	if f, err := strconv.ParseFloat(s, 64); err == nil {
+		return f
+	}
+
+	// Fallback to string
+	return s
+}

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -14,7 +14,6 @@ import (
 // - bool
 // - int
 // - float
-//
 func StringToType(s string) any {
 	// Try bool
 	if b, err := strconv.ParseBool(strings.ToLower(s)); err == nil {

--- a/internal/config/parse_test.go
+++ b/internal/config/parse_test.go
@@ -1,0 +1,92 @@
+package config
+
+import (
+	"math"
+	"reflect"
+	"testing"
+)
+
+// approxEqual returns if two float64 numbers are exactly equal at low
+// magnitudes and equal within a margin of error at high magnitudes.
+func approxEqual(a, b float64) bool {
+	if math.IsNaN(a) && math.IsNaN(b) {
+		return true
+	}
+	// Relative tolerance for big magnitudes, absolute for tiny.
+	const eps = 1e-12
+	diff := math.Abs(a - b)
+	scale := math.Max(1, math.Max(math.Abs(a), math.Abs(b)))
+	return diff/scale < eps || diff < eps
+}
+
+func TestStringToType(t *testing.T) {
+	tests := []struct {
+		in       string
+		want     any
+		wantType reflect.Type
+	}{
+		// bools
+		{"true", true, reflect.TypeOf(true)},
+		{"false", false, reflect.TypeOf(false)},
+		{"tRUe", true, reflect.TypeOf(true)}, // case-insensitive
+		{"1", true, reflect.TypeOf(true)},    // ParseBool handles "1"
+		{"0", false, reflect.TypeOf(false)},  // ParseBool handles "0" too
+
+		// integers (int64)
+		{"01", int64(1), reflect.TypeOf(int64(0))}, // not a bool, parses as int
+		{"-7", int64(-7), reflect.TypeOf(int64(0))},
+		{"9223372036854775807", int64(math.MaxInt64), reflect.TypeOf(int64(0))},
+
+		// floats (float64)
+		{"3.14", float64(3.14), reflect.TypeOf(float64(0))},
+		{"-2.5e3", float64(-2500), reflect.TypeOf(float64(0))},
+
+		// too big for int64 -> falls back to float64
+		{"9223372036854775808", float64(9.223372036854776e18), reflect.TypeOf(float64(0))},
+
+		// special floats
+		{"NaN", math.NaN(), reflect.TypeOf(float64(0))},
+
+		// strings (fallback)
+		{"hello", "hello", reflect.TypeOf("")},
+		{"", "", reflect.TypeOf("")},
+		{" True ", " True ", reflect.TypeOf("")}, // no trimming in parser
+		{"yes", "yes", reflect.TypeOf("")},
+	}
+
+	for _, tt := range tests {
+		got := StringToType(tt.in)
+
+		// Check type first
+		if reflect.TypeOf(got) != tt.wantType {
+			t.Fatalf("StringToType(%q) type = %T, want %v", tt.in, got, tt.wantType)
+		}
+
+		// Check value based on type
+		switch want := tt.want.(type) {
+		case bool:
+			if got != want {
+				t.Fatalf("StringToType(%q) = %v, want %v", tt.in, got, want)
+			}
+		case int64:
+			if got.(int64) != want {
+				t.Fatalf("StringToType(%q) = %v, want %v", tt.in, got, want)
+			}
+		case float64:
+			gf := got.(float64)
+			if math.IsNaN(want) {
+				if !math.IsNaN(gf) {
+					t.Fatalf("StringToType(%q) = %v, want NaN", tt.in, got)
+				}
+			} else if !approxEqual(gf, want) {
+				t.Fatalf("StringToType(%q) = %v, want %v", tt.in, gf, want)
+			}
+		case string:
+			if got.(string) != want {
+				t.Fatalf("StringToType(%q) = %q, want %q", tt.in, got, want)
+			}
+		default:
+			t.Fatalf("unsupported want type for %q: %T", tt.in, tt.want)
+		}
+	}
+}

--- a/man/ochami-config.1.sc
+++ b/man/ochami-config.1.sc
@@ -69,6 +69,8 @@ Subcommands for this command are as follows:
 	cluster's new name. Changing a cluster's name to an existing cluster name is
 	not allowed.
 
+	This command has some key-setting caveats. See *WARNINGS* below.
+
 	This command accepts the following options:
 
 	*-d, --default*
@@ -95,6 +97,8 @@ Subcommands for this command are as follows:
 *unset* _cluster_name_ _key_
 	Unset the _key_ configuration option from _cluster_name_
 
+	This command has some key-setting caveats. See *WARNINGS* below.
+
 ## set
 
 Set configuration option for ochami CLI.
@@ -105,6 +109,8 @@ The format of this command is:
 
 This command sets global configuration values for *ochami*. It sets the _key_ in
 the file to _value_.
+
+This command has some key-setting caveats. See *WARNINGS* below.
 
 ## show
 
@@ -143,6 +149,16 @@ Unset global configuration option.
 The format of this command is:
 
 *unset* _key_
+
+This command has some key-setting caveats. See *WARNINGS* below.
+
+# WARNINGS
+
+For *set*, *unset*, *cluster set*, and *cluster unset* invocations, some keys
+that are unset in the config file will be explicitly set in the config file with
+their default value. For instance, if *cluster.enable-auth* is unset for a given
+cluster and one of these commands is run, it will be explicitly be set to
+_true_, its default value.
 
 # FILES
 

--- a/man/ochami-config.5.sc
+++ b/man/ochami-config.5.sc
@@ -104,6 +104,21 @@ the array containing the below configuration options.
 		of these need to be set.  Otherwise, the base URI is not able to be
 		determined for that service.
 
+*enable-auth:* true|false
+	Enable authentication for this cluster.
+
+	Setting this to _true_ causes *ochami* to read and verify an access token of
+	the cluster using the cluster-specific access token environment variable and
+	include that token in the request headers.
+
+	Setting this to _false_ disables all token reading and checking behavior,
+	and does not include a token in the request headers for requests made to the
+	API for this cluster.
+
+	The default value is _true_ if left unset.
+
+	*enable-auth* can be overridden by the *--no-token* flag.
+
 *uri:* _absolute_uri_
 	The base URI for the OpenCHAMI services for the cluster. This is
 	normally used when most or all of the OpenCHAMI services are behind a

--- a/man/ochami.1.sc
+++ b/man/ochami.1.sc
@@ -147,6 +147,27 @@ _foobar_.
 	Access token to include in request headers for authentication to protected
 	service endpoints. Overrides token set in environment variable.
 
+*-v*
+	Enable early debug logging.
+
+	Since the regular log message format is configurable, regular logs only get
+	printed after the configuration is merged (see *CONFIGURATION*). This can
+	make it tough to debug early configuration merge issues. This flag prints
+	early debug messages to help this purpose.
+
+# CONFIGURATION
+
+When running *ochami* without passing *--config*, it will read the system
+configuration file and the user's configuration file, in that order, and attempt
+to merge them. Configuration options in the user configuration file overwrite
+those in the system configuration file.
+
+The *-v* flag turns on debug messages to help troubleshoot this merge process.
+
+See *ochami-config*(5) for more information on configuring these files, as well
+as *ochami-config*(1) for how to use *ochami* commands to manage configuration
+options.
+
 # FILES
 
 _/usr/share/doc/ochami/config.example.yaml_

--- a/man/ochami.1.sc
+++ b/man/ochami.1.sc
@@ -135,6 +135,14 @@ _foobar_.
 	- _warning_
 	- _debug_
 
+*--no-token*
+	Disable reading of and checking for access token and do not include any
+	token in the request headers. This overrides the value of *enable-auth* set
+	for the cluster.
+
+	This flag is useful for testing access to API endpoints that don't have JWT
+	authentication enabled, e.g. in a test environment.
+
 *-t, --token* _token_
 	Access token to include in request headers for authentication to protected
 	service endpoints. Overrides token set in environment variable.


### PR DESCRIPTION
Resolves #41

Apologies for the wait on this. I had to fight the internal config-reading mechanism since adding a config option whose default value is "true" turned out to be non-trivial. Along the way, I refactored and even fixed a few things. See the extended description in some of the individual commit messages below for more details.

## Features

- Add `--no-token` flag to disable token reading/checking
- Add per-cluster `cluster.enable-auth` key (defaults to true) to persistently toggle on/off token reading/checking for individual clusters

## Changes

- Refactored token checking to happen in separate `handleToken()` function so it's not coupled to `*GetClient()` functions.
  - It's a bit more repetitive, but allows more flexibility for when tokens are checked (or if they are)
- Reworked the config method to use the YAML library's unmarshal methods so that the `enable-auth` key would be handled correctly via the custom `UnmarshalYAML`
  - Koanf's unmarshal functions use mapstructure under the hood, which won't call the `UnmarshalYAML` function of the struct its unmarshaling into
- Updated manual pages with new flag and config option
- Added `GetCluster()` function to config library to easily retrieve clusters from config by name
- Fixed type conversion of string config options to relevant types by adding `StringToType()` function