### PR TITLE
feat: add BMC FQDN to static discovery nodes

### DIFF
--- a/man/ochami-discover.1.sc
+++ b/man/ochami-discover.1.sc
@@ -26,6 +26,7 @@ nodes:
   xname: x1000c1s7b0n0
   bmc_mac: de:ca:fc:0f:ee:ee
   bmc_ip: 172.16.0.101
+  bmc_fqdn: x1000c1s7b0n0.openchami.example
   groups:
   - compute
   interfaces:
@@ -57,6 +58,7 @@ is used as the unique identifier for the node within the Component that gets
 created for node.
 - *bmc_mac* - MAC address of node's BMC.
 - *bmc_ip* - Desired IP address of node's BMC.
+- *bmc_fqdn* - FQDN of node's BMC. If omitted, SMD sets this equal to the xname.
 - *group* - *DEPRECATED.* Use *groups* instead. *group* will be removed in a
 future release.
 - *groups* - Optional list of groups to add node to. These will get created

--- a/pkg/discover/discover.go
+++ b/pkg/discover/discover.go
@@ -35,19 +35,20 @@ func (nl NodeList) String() string {
 // Node represents a node entry in a payload file. Multiple of these are send to
 // SMD to "discover" them.
 type Node struct {
-	Name   string   `json:"name" yaml:"name"`
-	NID    int64    `json:"nid" yaml:"nid"`
-	Xname  string   `json:"xname" yaml:"xname"`
-	Group  string   `json:"group" yaml:"group"` // DEPRECATED
-	Groups []string `json:"groups" yaml:"groups"`
-	BMCMac string   `json:"bmc_mac" yaml:"bmc_mac"`
-	BMCIP  string   `json:"bmc_ip" yaml:"bmc_ip"`
-	Ifaces []Iface  `json:"interfaces" yaml:"interfaces"`
+	Name    string   `json:"name" yaml:"name"`
+	NID     int64    `json:"nid" yaml:"nid"`
+	Xname   string   `json:"xname" yaml:"xname"`
+	Group   string   `json:"group" yaml:"group"` // DEPRECATED
+	Groups  []string `json:"groups" yaml:"groups"`
+	BMCMac  string   `json:"bmc_mac" yaml:"bmc_mac"`
+	BMCIP   string   `json:"bmc_ip" yaml:"bmc_ip"`
+	BMCFQDN string   `json:"bmc_fqdn" yaml:"bmc_fqdn"`
+	Ifaces  []Iface  `json:"interfaces" yaml:"interfaces"`
 }
 
 func (n Node) String() string {
-	nStr := fmt.Sprintf("name=%q nid=%d xname=%s bmc_mac=%s bmc_ip=%s interfaces=[",
-		n.Name, n.NID, n.Xname, n.BMCMac, n.BMCIP)
+	nStr := fmt.Sprintf("name=%q nid=%d xname=%s bmc_mac=%s bmc_ip=%s bmc_fqdn=%s interfaces=[",
+		n.Name, n.NID, n.Xname, n.BMCMac, n.BMCIP, n.BMCFQDN)
 	for idx, iface := range n.Ifaces {
 		if idx == 0 {
 			nStr += fmt.Sprintf("iface%d={%s}", idx, iface)
@@ -151,6 +152,7 @@ func DiscoveryInfoV2(baseURI string, nl NodeList) (smd.ComponentSlice, smd.Redfi
 		rfe.ID = bmcXname
 		rfe.MACAddr = node.BMCMac
 		rfe.IPAddress = node.BMCIP
+		rfe.FQDN = node.BMCFQDN
 		rfe.SchemaVersion = 1 // Tells SMD to use new (v2) parsing code
 
 		// Create fake BMC "System" for node if it doesn't already exist

--- a/pkg/discover/discover_test.go
+++ b/pkg/discover/discover_test.go
@@ -34,12 +34,13 @@ func TestNodeList_String(t *testing.T) {
 				},
 			},
 			{
-				Name:   "nid2",
-				NID:    2,
-				Xname:  "x1000c0s1b0n0",
-				Group:  "compute",
-				BMCMac: "de:ad:be:ee:ef:01",
-				BMCIP:  "172.16.101.2",
+				Name:    "nid2",
+				NID:     2,
+				Xname:   "x1000c0s1b0n0",
+				Group:   "compute",
+				BMCMac:  "de:ad:be:ee:ef:01",
+				BMCIP:   "172.16.101.2",
+				BMCFQDN: "nid2.bmc.example.com",
 				Ifaces: []Iface{
 					{
 						MACAddr: "de:ca:fc:0f:fe:e2",
@@ -55,8 +56,8 @@ func TestNodeList_String(t *testing.T) {
 		},
 	}
 	want := `[` +
-		`node0={name="nid1" nid=1 xname=x1000c0s0b0n0 bmc_mac=de:ad:be:ee:ef:00 bmc_ip=172.16.101.1 interfaces=[iface0={mac_addr=de:ca:fc:0f:fe:e1 ip_addrs=[ip0={network="mgmt" ip_addr=172.16.100.1}]}]} ` +
-		`node1={name="nid2" nid=2 xname=x1000c0s1b0n0 bmc_mac=de:ad:be:ee:ef:01 bmc_ip=172.16.101.2 interfaces=[iface0={mac_addr=de:ca:fc:0f:fe:e2 ip_addrs=[ip0={network="mgmt" ip_addr=172.16.100.2}]}]}` +
+		`node0={name="nid1" nid=1 xname=x1000c0s0b0n0 bmc_mac=de:ad:be:ee:ef:00 bmc_ip=172.16.101.1 bmc_fqdn= interfaces=[iface0={mac_addr=de:ca:fc:0f:fe:e1 ip_addrs=[ip0={network="mgmt" ip_addr=172.16.100.1}]}]} ` +
+		`node1={name="nid2" nid=2 xname=x1000c0s1b0n0 bmc_mac=de:ad:be:ee:ef:01 bmc_ip=172.16.101.2 bmc_fqdn=nid2.bmc.example.com interfaces=[iface0={mac_addr=de:ca:fc:0f:fe:e2 ip_addrs=[ip0={network="mgmt" ip_addr=172.16.100.2}]}]}` +
 		`]`
 	if got := nl.String(); got != want {
 		t.Errorf("NodeList.String() = %q, want %q", got, want)
@@ -65,12 +66,13 @@ func TestNodeList_String(t *testing.T) {
 
 func TestNode_String(t *testing.T) {
 	node := Node{
-		Name:   "node1",
-		NID:    1,
-		Xname:  "x1000c0s0b0n0",
-		Group:  "grp",
-		BMCMac: "de:ca:fc:0f:fe:e1",
-		BMCIP:  "172.16.101.1",
+		Name:    "node1",
+		NID:     1,
+		Xname:   "x1000c0s0b0n0",
+		Group:   "grp",
+		BMCMac:  "de:ca:fc:0f:fe:e1",
+		BMCIP:   "172.16.101.1",
+		BMCFQDN: "node1.bmc.example.com",
 		Ifaces: []Iface{
 			{
 				MACAddr: "de:ad:be:ee:ef:01",
@@ -80,7 +82,7 @@ func TestNode_String(t *testing.T) {
 			},
 		},
 	}
-	want := `name="node1" nid=1 xname=x1000c0s0b0n0 bmc_mac=de:ca:fc:0f:fe:e1 bmc_ip=172.16.101.1 ` +
+	want := `name="node1" nid=1 xname=x1000c0s0b0n0 bmc_mac=de:ca:fc:0f:fe:e1 bmc_ip=172.16.101.1 bmc_fqdn=node1.bmc.example.com ` +
 		`interfaces=[iface0={mac_addr=de:ad:be:ee:ef:01 ip_addrs=[ip0={network="net" ip_addr=10.0.0.1}]}]`
 	if got := node.String(); got != want {
 		t.Errorf("Node.String() = %q, want %q", got, want)
@@ -121,12 +123,13 @@ func TestDiscoveryInfoV2_Success(t *testing.T) {
 	nl := NodeList{
 		Nodes: []Node{
 			{
-				Name:   "n42",
-				NID:    42,
-				Xname:  "invalid", // force xname->BMCXname to error & fallback
-				Group:  "g",
-				BMCMac: "de:ca:fc:0f:fe:e1",
-				BMCIP:  "172.16.101.1",
+				Name:    "n42",
+				NID:     42,
+				Xname:   "invalid", // force xname->BMCXname to error & fallback
+				Group:   "g",
+				BMCMac:  "de:ca:fc:0f:fe:e1",
+				BMCIP:   "172.16.101.1",
+				BMCFQDN: "n42.bmc.example.com",
 				Ifaces: []Iface{
 					{
 						MACAddr: "de:ad:be:ee:ef:01",
@@ -163,7 +166,7 @@ func TestDiscoveryInfoV2_Success(t *testing.T) {
 	}
 	r := rfes.RedfishEndpoints[0]
 	node := nl.Nodes[0]
-	if r.Name != node.Name || r.Type != "NodeBMC" || r.MACAddr != node.BMCMac || r.IPAddress != node.BMCIP {
+	if r.Name != node.Name || r.Type != "NodeBMC" || r.MACAddr != node.BMCMac || r.IPAddress != node.BMCIP || r.FQDN != node.BMCFQDN {
 		t.Errorf("RedfishEndpoint fields = %+v", r)
 	}
 	if r.SchemaVersion != 1 {


### PR DESCRIPTION
Add a bmc_fqdn field to the static discovery node type. Discovery sets the FQDN field of the node's generated RedfishEndpoints to this value.

This is the simpler way to handle #50, consistent with the existing node fields that bubble down to their generated RFE. IDK if we want finer-grained RFE control, but I suspect it'll be a while coming if so.

Fix #50

---

With this in place,

```
nodes:
-   bmc_ipaddr: 10.119.186.111
    bmc_fqdn: fio.example.com
    ipaddr: 10.119.4.111
    group: boo
    mac: "5e:72:59:e4:6a:a8"
    name: ba045
    nid: 45
    xname: x1451c1s0b0n0
```

```
POST /hsm/v2/Inventory/RedfishEndpoints HTTP/1.1

{"ID":"x1451c1s0b0","Type":"NodeBMC","Name":"ba045","FQDN":"fio.example.com","UUID":"3819a9a1-cbae-438b-b334-58b9d928bae4","DiscoveryInfo":{"LastAttempt":"0001-01-01T00:00:00Z"},"SchemaVersion":1,"Systems":[{"uri":"http://172.19.128.5:27779/redfish/v1/Systems/x1451c1s0b0n0","uuid":"25bc9398-c8d7-48b1-9e92-7a74f346bf5f","name":"ba045","ethernet_interfaces":null}],"Managers":[{"uri":"http://172.19.128.5:27779/redfish/v1/Managers/x1451c1s0b0","uuid":"3819a9a1-cbae-438b-b334-58b9d928bae4","name":"x1451c1s0b0","ethernet_interfaces":[{"name":"x1451c1s0b0","description":"Interface for BMC x1451c1s0b0"}],"description":"","type":"NodeBMC"}]}

HTTP/1.1 400 Bad Request
Content-Type: application/problem+json
Date: Wed, 27 Aug 2025 23:20:03 GMT
Content-Length: 165

{"type":"about:blank","title":"Bad Request","detail":"Invalid CompEthInterface MAC Address","status":400}
[{"URI":"/hsm/v2/Inventory/RedfishEndpoints/x1451c1s0b0"}]
```
Dunno what the 400's deal is--something in `discover static` if you don't provide an interface? It's not new. It still creates the RFE, so :shrug: 

```
smd=# select * from rf_endpoints where id='x1451c1s0b0';
-[ RECORD 1 ]------+----------------------------------------
id                 | x1451c1s0b0
type               | NodeBMC
name               | ba045
hostname           | fio
domain             | example.com
fqdn               | fio.example.com
ip_info            | {}
enabled            | t
uuid               | 3819a9a1-cbae-438b-b334-58b9d928bae4
user               | 
password           | 
usessdp            | f
macrequired        | f
macaddr            | 
rediscoveronupdate | f
templateid         | 
discovery_info     | {"LastDiscoveryStatus":"NotYetQueried"}
ipaddr             | 
```