### PR TITLE
fix(discover): send EthernetInterfaces on version 1 instead of 2

### DIFF
--- a/cmd/discover-static.go
+++ b/cmd/discover-static.go
@@ -244,8 +244,9 @@ See ochami-discover(1) for more details.`,
 			ifaceErrs           []error
 			ifaceErr            error
 		)
-		// get discovery version value (err handled in cmd.Args)
-		if discoveryVersion == discover.DiscoveryMethodV2 {
+		// Get discovery version value (err handled in cmd.Args).
+		// Send EthernetInterfaces to SMD if discoverVersion is 1.
+		if discoveryVersion == discover.DiscoveryMethodV1 {
 			if cmd.Flag("overwrite").Changed {
 				// SMD's EthernetInterface API does not allow the PUT
 				// method. Instead, we loop over each ethernet interface


### PR DESCRIPTION
The check to send the extra EthernetInterfaces to SMD was erroneously set to happen with discovery version 2 instead of 1. This commit changes it to 1.

To test, ensure that `--discovery-version 1` produces 409 errors with SMD >= v2.19.0 and does not with `--discovery-version 2` (or not passing `--discovery-version` since 2 is the default). Both versions should work with SMD versions < v2.19.0, though `EthernetInterface`s for type `Node` will not be created when using discovery version 2.