### PR TITLE
feat(discovery): support multiple SMD groups during static discovery

### DIFF
--- a/man/ochami-discover.1.sc
+++ b/man/ochami-discover.1.sc
@@ -26,7 +26,8 @@ nodes:
   xname: x1000c1s7b0n0
   bmc_mac: de:ca:fc:0f:ee:ee
   bmc_ip: 172.16.0.101
-  group: compute
+  groups:
+  - compute
   interfaces:
   - mac_addr: de:ad:be:ee:ee:f1
     ip_addrs:
@@ -56,8 +57,10 @@ is used as the unique identifier for the node within the Component that gets
 created for node.
 - *bmc_mac* - MAC address of node's BMC.
 - *bmc_ip* - Desired IP address of node's BMC.
-- *group* - Optional group to add node to. This will get created during
-discovery if it does not exist.
+- *group* - *DEPRECATED.* Use *groups* instead. *group* will be removed in a
+future release.
+- *groups* - Optional list of groups to add node to. These will get created
+during discovery if they do not exist.
 - *interfaces* - A list of network interfaces for the node.
     - *mac_addr* - MAC address of network interface.
     - *ip_addrs* - List of IP addresses assigned to interface.

--- a/pkg/discover/discover.go
+++ b/pkg/discover/discover.go
@@ -35,13 +35,14 @@ func (nl NodeList) String() string {
 // Node represents a node entry in a payload file. Multiple of these are send to
 // SMD to "discover" them.
 type Node struct {
-	Name   string  `json:"name" yaml:"name"`
-	NID    int64   `json:"nid" yaml:"nid"`
-	Xname  string  `json:"xname" yaml:"xname"`
-	Group  string  `json:"group" yaml:"group"`
-	BMCMac string  `json:"bmc_mac" yaml:"bmc_mac"`
-	BMCIP  string  `json:"bmc_ip" yaml:"bmc_ip"`
-	Ifaces []Iface `json:"interfaces" yaml:"interfaces"`
+	Name   string   `json:"name" yaml:"name"`
+	NID    int64    `json:"nid" yaml:"nid"`
+	Xname  string   `json:"xname" yaml:"xname"`
+	Group  string   `json:"group" yaml:"group"` // DEPRECATED
+	Groups []string `json:"groups" yaml:"groups"`
+	BMCMac string   `json:"bmc_mac" yaml:"bmc_mac"`
+	BMCIP  string   `json:"bmc_ip" yaml:"bmc_ip"`
+	Ifaces []Iface  `json:"interfaces" yaml:"interfaces"`
 }
 
 func (n Node) String() string {
@@ -240,4 +241,16 @@ func DiscoveryInfoV2(baseURI string, nl NodeList) (smd.ComponentSlice, smd.Redfi
 		rfes.RedfishEndpoints = append(rfes.RedfishEndpoints, rfe)
 	}
 	return comps, rfes, ifaces, nil
+}
+
+// AddMemberToGroup adds xname to group, ensuring deduplication.
+func AddMemberToGroup(group smd.Group, xname string) smd.Group {
+	for _, x := range group.Members.IDs {
+		if x == xname {
+			return group
+		}
+	}
+	g := group
+	g.Members.IDs = append(g.Members.IDs, xname)
+	return g
 }

--- a/pkg/discover/discover.go
+++ b/pkg/discover/discover.go
@@ -113,8 +113,11 @@ func DiscoveryInfoV2(baseURI string, nl NodeList) (smd.ComponentSlice, smd.Redfi
 		return comps, rfes, ifaces, fmt.Errorf("invalid URI: %s", baseURI)
 	}
 
-	// Deduplication map for Components
-	compMap := make(map[string]string)
+	var (
+		compMap    = make(map[string]string) // Deduplication map for SMD Components
+		systemMap  = make(map[string]string) // Deduplication map for BMC Systems
+		managerMap = make(map[string]string) // Deduplication map for BMC Managers
+	)
 	for _, node := range nl.Nodes {
 		log.Logger.Debug().Msgf("generating component structure for node with xname %s", node.Xname)
 		if _, ok := compMap[node.Xname]; !ok {
@@ -149,10 +152,6 @@ func DiscoveryInfoV2(baseURI string, nl NodeList) (smd.ComponentSlice, smd.Redfi
 		rfe.MACAddr = node.BMCMac
 		rfe.IPAddress = node.BMCIP
 		rfe.SchemaVersion = 1 // Tells SMD to use new (v2) parsing code
-
-		// Deduplication maps for fake BMC Managers and Systems
-		systemMap := make(map[string]string)
-		managerMap := make(map[string]string)
 
 		// Create fake BMC "System" for node if it doesn't already exist
 		if _, ok := systemMap[node.Xname]; !ok {

--- a/pkg/discover/discover_test.go
+++ b/pkg/discover/discover_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/openchami/schemas/schemas"
+
+	"github.com/OpenCHAMI/ochami/pkg/client/smd"
 )
 
 func TestNodeList_String(t *testing.T) {
@@ -219,5 +221,53 @@ func TestDiscoveryInfoV2_Success(t *testing.T) {
 		if ip.IPAddress != orig.IPAddr || ip.Network != orig.Network {
 			t.Errorf("IPAddresses[%d] = %+v, want %+v", i, ip, orig)
 		}
+	}
+}
+
+func TestAddMemberToGroup(t *testing.T) {
+	newGroup := func(members []string) smd.Group {
+		var g smd.Group
+		g.Members.IDs = members
+		return g
+	}
+	tests := []struct {
+		name     string
+		group    smd.Group
+		xname    string
+		expected smd.Group
+	}{
+		{
+			name:     "add new member to empty group",
+			group:    newGroup([]string{}),
+			xname:    "x1000c0s0b0n0",
+			expected: newGroup([]string{"x1000c0s0b0n0"}),
+		},
+		{
+			name:     "add new member to non-empty group",
+			group:    newGroup([]string{"x1000c0s0b0n0", "x1000c0s0b1n0"}),
+			xname:    "x1000c0s0b2n0",
+			expected: newGroup([]string{"x1000c0s0b0n0", "x1000c0s0b1n0", "x1000c0s0b2n0"}),
+		},
+		{
+			name:     "member already exists in group",
+			group:    newGroup([]string{"x1000c0s0b0n0", "x1000c0s0b1n0"}),
+			xname:    "x1000c0s0b1n0",
+			expected: newGroup([]string{"x1000c0s0b0n0", "x1000c0s0b1n0"}),
+		},
+		{
+			name:     "add member when group has one element",
+			group:    newGroup([]string{"x1000c0s0b0n0"}),
+			xname:    "x1000c0s0b1n0",
+			expected: newGroup([]string{"x1000c0s0b0n0", "x1000c0s0b1n0"}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AddMemberToGroup(tt.group, tt.xname)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("AddMemberToGroup() = %+v, want %+v", got, tt.expected)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Closes #32 

## Changes

- Add `groups` directive to static discovery specification to specify a list of groups to add a node to during discovery.
  - These groups will get created in SMD.
- Deprecate `group` directive in static discovery specification.
  - Add deprecation warnings for `group` and remove it from examples
  - If used with `groups`, the group specified is merged with the `groups` list
  - `group` will be removed in a future release of `ochami`
- Refactor deduplication maps to be defined outside of node loop (https://github.com/OpenCHAMI/ochami/pull/47#discussion_r2305426503)

## Testing

Write a `nodes.yaml` that includes combinations of `groups` and `group` and attempt static discovery via `ochami discover static -f yaml -d @nodes.yaml`.

- `groups` only:
  ```yaml
  nodes:
  ...
   - name: node01
     groups:
       - group1
       - group2
     ...
  ```
  **Result:** `node01` should be added to groups `group1` and `group2`, which get added to SMD.
- `group` only:
  ```yaml
  nodes:
  ...
   - name: node01
     group: group1
     ...
  ```
  **Result:** `node01` should be added to group `group1`, which gets added to SMD. The `ochami` command should display a warning that `group` was used for `node01` and that it is deprecated.
- `group` and `groups`:

  **CASE 1:** `group` is also a member of `groups`

  ```yaml
  nodes:
  ...
   - name: node01
     group: group1
     groups:
       - group1
       - group2
     ...
  ```

  **Result:** `node01` should be added to groups `group1` and `group2`, which get added to SMD. The `ochami` command should display a warning that `group` was used for `node01` and that it is deprecated.

  **CASE 2:** `group` is not a member of `groups`

  ```yaml
  nodes:
  ...
   - name: node01
     group: group3
     groups:
       - group1
       - group2
     ...
  ```
  **Result:** `node01` should be added to groups `group1`, `group2`, and `group3`, which get added to SMD. The `ochami` command should display a warning that `group` was used for `node01` and that it is deprecated.

## Notes

- If using SMD < v2.19.0, use `--discovery-version 1` so that the creation of `EthernetInterface`s for type `Node` works during discovery.
  - Needs #52 to be merged.
