### PR TITLE
Added support for multiple nodes per BMC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,13 @@ all: binaries
 .PHONY: binaries
 binaries: $(NAME)
 
+.PHONY: unittest
+unittest:
+ifeq ($(GO),)
+	$(error go command not found.)
+endif
+	$(GO) test -cover -v ./...
+
 .PHONY: clean
 clean:
 ifeq ($(GO),)


### PR DESCRIPTION
There is hardware that has multiple nodes per BMC. The code did not support this. It would create two RedfishEndpoints, each with one node. Instead it needed to create one RedfishEndpoint with two nodes.

## Pull Request Template

Thank you for your contribution! Please ensure the following before submitting:

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [x] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass  
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [ ] Each new/modified source file has SPDX copyright and license headers  
  - [ ] Any non-commentable files include a `<filename>.license` sidecar  
  - [ ] All referenced licenses are present in the `LICENSES/` directory  

### Description

Please include a summary of the change and which issue is fixed.  
Also include relevant motivation and context.

Fixes #([55](https://github.com/OpenCHAMI/ochami/issues/55)) - This change fixes the bug part of issue 55. There is on going discussion of changing the yaml schema for static discovery.

### Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
