### PR TITLE
feature(cloud-init): Added the ability to inject extra variables

### DIFF
--- a/cmd/cloud_init/group/render.go
+++ b/cmd/cloud_init/group/render.go
@@ -34,7 +34,13 @@ func newCmdGroupRender() *cobra.Command {
 
 See ochami-cloud-init(1) for more details.`,
 		Example: `  # Render group 'compute' cloud-init config for node x3000c0s0b0n0
-  ochami cloud-init group render compute x3000c0s0b0n0`,
+  ochami cloud-init group render compute x3000c0s0b0n0
+
+  # Render group 'compute' cloud-init config for node x1000c0s0b0n0, loading extra variables in
+  # from extra-vars.json, stdin, and directly, respectively
+  ochami-dev -k cloud-init group render --extra-vars @extra-vars.json compute x1000c0s0b0n0
+  ochami-dev -k cloud-init group render --extra-vars @- compute x1000c0s0b0n0
+  ochami-dev -k cloud-init group render --extra-vars '{"key":"value"}' compute x1000c0s0b0n0`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Create client to use for requests
 			cloudInitClient := cloud_init_lib.GetClient(cmd)

--- a/cmd/cloud_init/group/render.go
+++ b/cmd/cloud_init/group/render.go
@@ -131,7 +131,10 @@ See ochami-cloud-init(1) for more details.`,
 	}
 
 	// Create flags
+	groupRenderCmd.Flags().VarP(&cli.FormatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
 	groupRenderCmd.Flags().StringP("extra-vars", "", "", "extra variables to be passed to the template renderer or (if starting with @) file containing extra variables to be passed to the template renderer (can be - to read from stdin)")
+
+	groupRenderCmd.RegisterFlagCompletionFunc("format-input", cli.CompletionFormatData)
 
 	return groupRenderCmd
 }

--- a/cmd/cloud_init/group/render.go
+++ b/cmd/cloud_init/group/render.go
@@ -90,6 +90,25 @@ See ochami-cloud-init(1) for more details.`,
 				os.Exit(1)
 			}
 			dsWrapper["ds"] = map[string]interface{}{"meta_data": ciData}
+
+			// Read any extra variables specified (This is mostly copy-pasted from cli.HandlePayload)
+			// The primary difference is the flag name
+			extraVarsMap := make(map[string]interface{})
+			if cmd.Flag("extra-vars").Changed {
+				extraVars := cmd.Flag("extra-vars").Value.String()
+				if err := client.ReadPayload(extraVars, cli.FormatInput, &extraVarsMap); err != nil {
+					log.Logger.Error().Err(err).Msg("unable to read extra variable data or file")
+					cli.LogHelpError(cmd)
+					os.Exit(1)
+				}
+			}
+
+			// Apply extra variables to the context
+			for k, v := range extraVarsMap {
+				dsWrapper[k] = v
+			}
+
+			// Construct the context for the template
 			refData := exec.NewContext(dsWrapper)
 
 			// Render
@@ -110,6 +129,9 @@ See ochami-cloud-init(1) for more details.`,
 			out.Flush()
 		},
 	}
+
+	// Create flags
+	groupRenderCmd.Flags().StringP("extra-vars", "", "", "extra variables to be passed to the template renderer or (if starting with @) file containing extra variables to be passed to the template renderer (can be - to read from stdin)")
 
 	return groupRenderCmd
 }

--- a/cmd/cloud_init/group/render.go
+++ b/cmd/cloud_init/group/render.go
@@ -38,9 +38,9 @@ See ochami-cloud-init(1) for more details.`,
 
   # Render group 'compute' cloud-init config for node x1000c0s0b0n0, loading extra variables in
   # from extra-vars.json, stdin, and directly, respectively
-  ochami-dev -k cloud-init group render --extra-vars @extra-vars.json compute x1000c0s0b0n0
-  ochami-dev -k cloud-init group render --extra-vars @- compute x1000c0s0b0n0
-  ochami-dev -k cloud-init group render --extra-vars '{"key":"value"}' compute x1000c0s0b0n0`,
+  ochami -k cloud-init group render --extra-vars @extra-vars.json compute x1000c0s0b0n0
+  ochami -k cloud-init group render --extra-vars @- compute x1000c0s0b0n0
+  ochami -k cloud-init group render --extra-vars '{"key":"value"}' compute x1000c0s0b0n0`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Create client to use for requests
 			cloudInitClient := cloud_init_lib.GetClient(cmd)

--- a/cmd/cloud_init/group/render.go
+++ b/cmd/cloud_init/group/render.go
@@ -132,7 +132,7 @@ See ochami-cloud-init(1) for more details.`,
 
 	// Create flags
 	groupRenderCmd.Flags().VarP(&cli.FormatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
-	groupRenderCmd.Flags().StringP("extra-vars", "", "", "extra variables to be passed to the template renderer or (if starting with @) file containing extra variables to be passed to the template renderer (can be - to read from stdin)")
+	groupRenderCmd.Flags().StringP("extra-vars", "e", "", "extra variables to be passed to the template renderer or (if starting with @) file containing extra variables (can be - to read from stdin)")
 
 	groupRenderCmd.RegisterFlagCompletionFunc("format-input", cli.CompletionFormatData)
 

--- a/man/ochami-cloud-init.1.sc
+++ b/man/ochami-cloud-init.1.sc
@@ -435,6 +435,66 @@ Subcommands for this command are as follows:
 		standard input (@-). The format of the extra variables read in any of
 		these forms is JSON by default unless *-f* is specified to change it.
 
+		For example, given the following cloud-init template and assuming that
+		node *x3000c0s0b100n0* belongs to a *test* SMD group:
+
+		```
+		## template: jinja
+		#cloud-config
+		# v1.variant={{ v1.variant }}
+		{%- if v1.variant == 'suse' %}
+		{%- set def_dir = '/foo' %}
+		{%- else %}
+		{%- set def_dir = '/bar' %}
+		{%- endif %}
+		write_files:
+		  - content: |
+			   my stuff
+			path: {{ def_dir }}/myfile
+			permissions: '0644'
+			owner: 'root:root'
+		```
+
+		Running
+
+		```
+		ochami cloud-init group render -e '{"v1":{"variant":"suse"}}' test x3000c0s0b100n0
+		```
+
+		will render:
+
+		```
+		## template: jinja
+		#cloud-config
+		# v1.variant=suse
+		write_files:
+		  - content: |
+			   my stuff
+			path: /foo/myfile
+			permissions: '0644'
+			owner: 'root:root'
+		```
+
+		while running
+
+		```
+		ochami cloud-init group render -e '{"v1":{"variant":"rhel"}}' test x3000c0s0b100n0
+		```
+
+		will render:
+
+		```
+		## template: jinja
+		#cloud-config
+		# v1.variant=rhel
+		write_files:
+		  - content: |
+			   my stuff
+			path: /bar/myfile
+			permissions: '0644'
+			owner: 'root:root'
+		```
+
 	*-f, --format-input* _format_
 		Format of the extra variables being used by *-e*. Supported formats are:
 

--- a/man/ochami-cloud-init.1.sc
+++ b/man/ochami-cloud-init.1.sc
@@ -13,7 +13,7 @@ ochami cloud-init group delete [OPTIONS] ([-d (_data_ | @_path_)] [-f _format_])
 ochami cloud-init group get [OPTIONS] raw [_id_...]++
 ochami cloud-init group get [OPTIONS] config [_id_...]++
 ochami cloud-init group get [OPTIONS] meta-data [_id_...]++
-ochami cloud-init group render _group_ _id_++
+ochami cloud-init group render ([-e (_extra-variables_ | @_path_)] [-f _format_]) _group_ _id_++
 ochami cloud-init group set [OPTIONS]++
 ochami cloud-init node get group [OPTIONS] _group_ _id_...++
 ochami cloud-init node get meta-data [OPTIONS] _id_...++
@@ -426,6 +426,21 @@ Subcommands for this command are as follows:
 
 	- */cloud-init/admin/impersonation/{id}/{group}.yaml*
 	- */cloud-init/admin/impersonation/{id}/meta-data*
+
+	This command accepts the following options:
+
+	*-e, --extra-vars* (_extra-vars_ | @_path_ | @-)
+		Specify _extra-vars_ to be passed to the template, the _path_ to a
+		file to read extra variables from, or to read the extra variables from
+		standard input (@-). The format of the extra variables read in any of
+		these forms is JSON by default unless *-f* is specified to change it.
+
+	*-f, --format-input* _format_
+		Format of the extra variables being used by *-e*. Supported formats are:
+
+		- _json_ (default)
+		- _json-pretty_
+		- _yaml_
 
 *set* [-f _format_] < _file_++
 *set* [-f _format_] -d @_file_++


### PR DESCRIPTION
## Pull Request Template

Thank you for your contribution! Please ensure the following before submitting:

### Checklist

- [X] My code follows the style guidelines of this project  
- [X] I have added/updated comments where needed  
- [X] I have added tests that prove my fix is effective or my feature works  
- [X] I have run `make test` (or equivalent) locally and all tests pass  
- [X] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [X] **REUSE Compliance**:  
  - [X] Each new/modified source file has SPDX copyright and license headers  
  - [X] Any non-commentable files include a `<filename>.license` sidecar  
  - [X] All referenced licenses are present in the `LICENSES/` directory  

### Description

Adds the `--extra-vars` flag to `ochami cloud-init group render` to allow for injecting key-value pairs into the template renderer. The passed variables can be in any supported input format and can be passed directly, read from a file, or read from stdin.

Implements #82 

### Type of Change

- [X] New feature  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
