### PR TITLE
ci: add auto-generated PR build containers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,10 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: stable
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Checkout repo
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,13 +4,17 @@
 
 name: Build
 on:
-  push:
-    branches:
-      - main
   pull_request:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR Number to build (optional, for manual PR builds)'
+        required: false
+        type: string
 
 permissions:
-  contents: write
+  contents: write # For creating temporary local Git tags
+  packages: write # For pushing PR container
 
 jobs:
   build-goreleaser:
@@ -20,10 +24,18 @@ jobs:
         run: |
           sudo apt update
           sudo apt install scdoc
+
       - name: Set up latest stable Go
         uses: actions/setup-go@v6
         with:
           go-version: stable
+
+      - name: Docker Login
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -33,16 +45,35 @@ jobs:
         with:
           fetch-tags: 1
           fetch-depth: 0
+
+      - name: Create Tag for PR
+        if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.pr_number != '')
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          PR_NUM="${{ github.event.number }}"
+          if [[ "${{ inputs.pr_number }}" != "" ]]; then
+            PR_NUM="${{ inputs.pr_number }}"
+          fi
+          git tag -f -a v0.0.0-pr-${PR_NUM} -m "pr-${PR_NUM} Build"
+
       - name: Set build environment variables
         run: |
-          echo GOVERSION=$(go env GOVERSION) >> $GITHUB_ENV
-          echo BUILD_HOST=$(hostname) >> $GITHUB_ENV
-          echo BUILD_USER=$(whoami) >> $GITHUB_ENV
+          echo "GOVERSION=$(go env GOVERSION)" >> $GITHUB_ENV
+          echo "BUILD_HOST=$(hostname)" >> $GITHUB_ENV
+          echo "BUILD_USER=$(whoami)" >> $GITHUB_ENV
+          echo "IS_PR_BUILD=true" >> $GITHUB_ENV
+          if [[ "${{ inputs.pr_number }}" != "" ]]; then
+            echo "DOCKER_TAG=pr-${{ inputs.pr_number }}" >> $GITHUB_ENV
+          else
+            echo "DOCKER_TAG=pr-${{ github.event.number }}" >> $GITHUB_ENV
+          fi
+
       - name: Build with goreleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           version: '~> v2'
-          args: release --snapshot --clean --skip publish
+          args: release --clean --skip announce,validate,aur
         id: goreleaser
   build-make:
     runs-on: ubuntu-latest

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -7,6 +7,12 @@ name: Cleanup
 on:
   pull_request:
     types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR Number to clean container tags (optional, for manual PR cleaning)'
+        required: false
+        type: string
 
 permissions:
   packages: write       # Delete from ghcr.io
@@ -19,7 +25,11 @@ jobs:
       - name: Get PR number
         id: pr
         run: |
-          echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          if [[ "${{ inputs.pr_number }}" != "" ]]; then
+            echo "number=pr-${{ inputs.pr_number }}" >> $GITHUB_ENV
+          else
+            echo "number=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+          fi
 
       - name: Delete PR container images
         continue-on-error: true
@@ -27,7 +37,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUM=${{ steps.pr.outputs.number }}
-          PACKAGE_NAME="ochami"
+          PACKAGE_NAME="${{ github.event.repository.name }}"
           ORG_NAME="${{ github.repository_owner }}"
 
           echo "Cleaning up container images for PR ${PR_NUM}..."

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: © 2025 OpenCHAMI a Series of LF Projects, LLC
+#
+# SPDX-License-Identifier: MIT
+
+name: Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  packages: write       # Delete from ghcr.io
+  pull-requests: write  # Post cleanup confirmation
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR number
+        id: pr
+        run: |
+          echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+
+      - name: Delete PR container images
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUM=${{ steps.pr.outputs.number }}
+          PACKAGE_NAME="ochami"
+          ORG_NAME="${{ github.repository_owner }}"
+
+          echo "Cleaning up container images for PR ${PR_NUM}..."
+
+          # Function to delete a specific tag
+          delete_tag() {
+            local tag=$1
+            echo "Attempting to delete tag: ${tag}"
+
+            # Get all versions of the package
+            VERSIONS=$(gh api --paginate "/orgs/${ORG_NAME}/packages/container/${PACKAGE_NAME}/versions" --jq '.[] | select(.metadata.container.tags[] | contains("'${tag}'")) | .id')
+
+            if [ -z "$VERSIONS" ]; then
+              echo "No version found for tag ${tag}"
+              return
+            fi
+
+            # Delete each version with this tag
+            for VERSION_ID in $VERSIONS; do
+              echo "Deleting version ID: ${VERSION_ID}"
+              gh api --method DELETE "/orgs/${ORG_NAME}/packages/container/${PACKAGE_NAME}/versions/${VERSION_ID}" || echo "Failed to delete version ${VERSION_ID}"
+            done
+          }
+
+          # Delete PR-specific tags
+          delete_tag "pr-${PR_NUM}"
+          delete_tag "pr-${PR_NUM}-amd64"
+          delete_tag "pr-${PR_NUM}-arm64"
+
+          echo "Cleanup completed for PR ${PR_NUM}"
+
+      - name: Post cleanup confirmation
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = ${{ steps.pr.outputs.number }};
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: `PR artifacts have been cleaned up. Container images \`pr-${prNumber}\` have been removed from ghcr.io.\n\n*Note: GitHub Actions artifacts will expire automatically after 30 days.*`
+            });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Checkout repo
         uses: actions/checkout@v6
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,6 +32,7 @@ builds:
       - arm64
     goamd64:
       - v1
+      - v3
     goarm64:
       - v8.0
     env:
@@ -45,7 +46,7 @@ archives:
     name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
+      {{- if eq .Arch "amd64" }}x86_64{{- if .Amd64 }}{{ .Amd64 }}{{- end }}
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
@@ -157,7 +158,7 @@ dockers:
     goamd64: v3
     build_flag_templates:
       - '--pull'
-      - '--platform=linux/arm64'
+      - '--platform=linux/amd64'
       - '--label=org.opencontainers.image.created={{ .Date }}'
       - '--label=org.opencontainers.image.title={{ .ProjectName }}'
       - '--label=org.opencontainers.image.revision={{ .FullCommit }}'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -172,7 +172,7 @@ dockers:
     goarch: arm64
     build_flag_templates:
       - "--pull"
-      - "--platform=linux/amd64"
+      - "--platform=linux/arm64"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.title={{ .ProjectName }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -149,51 +149,55 @@ aurs:
 dockers:
   - dockerfile: goreleaser.dockerfile
     image_templates:
-      - &amd64_linux_image ghcr.io/openchami/{{ .ProjectName }}:{{ .Tag }}-amd64
-      - ghcr.io/openchami/{{ .ProjectName }}:v{{ .Major }}-amd64
-      - ghcr.io/openchami/{{ .ProjectName }}:v{{ .Major }}.{{ .Minor }}-amd64
+      - &amd64_linux_image 'ghcr.io/openchami/{{ .ProjectName }}:{{ if eq .Env.IS_PR_BUILD "true" }}{{ .Env.DOCKER_TAG }}{{ else }}{{ .Tag }}{{ end }}-amd64'
+      - '{{ if ne .Env.IS_PR_BUILD "true" }}ghcr.io/openchami/{{ .ProjectName }}:v{{ .Major }}-amd64{{ end }}'
+      - '{{ if ne .Env.IS_PR_BUILD "true" }}ghcr.io/openchami/{{ .ProjectName }}:v{{ .Major }}.{{ .Minor }}-amd64{{ end }}'
     use: buildx
     goarch: amd64
+    goamd64: v3
     build_flag_templates:
-      - "--pull"
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.created={{ .Date }}"
-      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
-      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - '--pull'
+      - '--platform=linux/arm64'
+      - '--label=org.opencontainers.image.created={{ .Date }}'
+      - '--label=org.opencontainers.image.title={{ .ProjectName }}'
+      - '--label=org.opencontainers.image.revision={{ .FullCommit }}'
+      - '--label=org.opencontainers.image.version={{ .Version }}'
     extra_files:
       - LICENSES/MIT.txt
   - dockerfile: goreleaser.dockerfile
     image_templates:
-      - &arm64v8_linux_image ghcr.io/openchami/{{ .ProjectName }}:{{ .Tag }}-arm64
-      - ghcr.io/openchami/{{ .ProjectName }}:v{{ .Major }}-arm64
-      - ghcr.io/openchami/{{ .ProjectName }}:v{{ .Major }}.{{ .Minor }}-arm64
+      - &arm64v8_linux_image 'ghcr.io/openchami/{{ .ProjectName }}:{{ if eq .Env.IS_PR_BUILD "true" }}{{ .Env.DOCKER_TAG }}{{ else }}{{ .Tag }}{{ end }}-arm64'
+      - '{{ if ne .Env.IS_PR_BUILD "true" }}ghcr.io/openchami/{{ .ProjectName }}:v{{ .Major }}-arm64{{ end }}'
+      - '{{ if ne .Env.IS_PR_BUILD "true" }}ghcr.io/openchami/{{ .ProjectName }}:v{{ .Major }}.{{ .Minor }}-arm64{{ end }}'
     use: buildx
     goarch: arm64
     build_flag_templates:
-      - "--pull"
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.created={{ .Date }}"
-      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
-      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - '--pull'
+      - '--platform=linux/arm64'
+      - '--label=org.opencontainers.image.created={{ .Date }}'
+      - '--label=org.opencontainers.image.title={{ .ProjectName }}'
+      - '--label=org.opencontainers.image.revision={{ .FullCommit }}'
+      - '--label=org.opencontainers.image.version={{ .Version }}'
     extra_files:
       - LICENSES/MIT.txt
 
 docker_manifests:
-  - name_template: "ghcr.io/openchami/{{ .ProjectName }}:latest"
+  - name_template: '{{ if ne .Env.IS_PR_BUILD \"true\" }}ghcr.io/openchami/{{ .ProjectName }}:latest{{ end }}'
+    skip_push: '{{ eq .Env.IS_PR_BUILD "true" }}'
     image_templates:
       - *amd64_linux_image
       - *arm64v8_linux_image
-  - name_template: "ghcr.io/openchami/{{ .ProjectName }}:{{ .Tag }}"
+  - name_template: 'ghcr.io/openchami/{{ .ProjectName }}:{{ if eq .Env.IS_PR_BUILD "true" }}{{ .Env.DOCKER_TAG }}{{ else }}{{ .Tag }}{{ end }}'
     image_templates:
       - *amd64_linux_image
       - *arm64v8_linux_image
-  - name_template: "ghcr.io/openchami/{{ .ProjectName }}:{{ .Major }}"
+  - name_template: '{{ if ne .Env.IS_PR_BUILD "true" }}ghcr.io/openchami/{{ .ProjectName }}:{{ .Major }}{{ end }}'
+    skip_push: '{{ eq .Env.IS_PR_BUILD "true" }}'
     image_templates:
       - *amd64_linux_image
       - *arm64v8_linux_image
-  - name_template: "ghcr.io/openchami/{{ .ProjectName }}:{{ .Major }}.{{ .Minor }}"
+  - name_template: '{{ if ne .Env.IS_PR_BUILD "true" }}ghcr.io/openchami/{{ .ProjectName }}:{{ .Major }}.{{ .Minor }}{{ end }}'
+    skip_push: '{{ eq .Env.IS_PR_BUILD "true" }}'
     image_templates:
       - *amd64_linux_image
       - *arm64v8_linux_image
@@ -202,11 +206,12 @@ checksum:
   name_template: checksums.txt
 
 snapshot:
-  version_template: "{{ incpatch .Version }}-next"
+  version_template: '{{ if eq .Env.IS_PR_BUILD "true" }}{{ .Tag }}{{ else }}{{ incpatch .Version }}-next{{ end }}'
 
 release:
+  disable: '{{ if eq .Env.IS_PR_BUILD "true" }}true{{ else }}false{{ end }}'
   github:
   draft: true
-  name_template: "v{{ .Version }}"
+  name_template: 'v{{ .Version }}'
   prerelease: auto
   mode: replace

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN make
 # STAGE 2: Application
 #
 
-FROM cgr.dev/chainguard/wolfi-base
+FROM --platform=$TARGETPLATFORM cgr.dev/chainguard/wolfi-base
 
 RUN apk add --no-cache tini
 


### PR DESCRIPTION
## Pull Request Template

Thank you for your contribution! Please ensure the following before submitting:

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [ ] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass  
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Description

Auto-generate OCI container with a `pr-<pr_number>` tag on pull requests to be able to be pulled during testing in order to avoid having to manually build it.

Also add a cleanup job that deletes PR container tags after it is closed.

Also fix some previously-uncaught Goreleaser issues:

- `linux/amd64` on arm64 container builds
- add `--platform=$TARGETPLATFORM` to multi-stage Dockerfile.

### Type of Change

- [x] Bug fix  
- [x] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
