### PR TITLE
feat: add default-input/output-format options to the config file

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/OpenCHAMI/ochami/internal/cli"
+	"github.com/OpenCHAMI/ochami/internal/config"
 	"github.com/OpenCHAMI/ochami/internal/log"
 	"github.com/OpenCHAMI/ochami/internal/version"
 
@@ -50,6 +51,19 @@ See ochami-config(5) for more details on configuring the ochami config file(s).`
 			//   cli.InitConfigAndLogging(cmd, false)
 			//
 			cli.InitConfigAndLogging(cmd, true)
+
+			// Apply the default formats (if the flags aren't changed and the config option is present)
+			// Note that this doesn't cover the case where the variable is checked without the corresponding
+			// flag being defined.
+			inputFormatFlag := cmd.Flag("format-input")
+			if config.GlobalConfig.DefaultInputFormat != "" && inputFormatFlag != nil && !inputFormatFlag.Changed {
+				cli.FormatInput = config.GlobalConfig.DefaultInputFormat
+			}
+
+			outputFormatFlag := cmd.Flag("format-output")
+			if config.GlobalConfig.DefaultOutputFormat != "" && outputFormatFlag != nil && !outputFormatFlag.Changed {
+				cli.FormatOutput = config.GlobalConfig.DefaultOutputFormat
+			}
 
 			return nil
 		},

--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -36,6 +36,15 @@ log:
 # Default: 30s
 #timeout: 30s
 
+# Specify the default input and output formats if none are passed on the command
+# line. These are overridden by the *--format-input* and *--format-output* options,
+# respectively.
+# 
+# Allowed values: json, json-pretty, yaml
+# Default: json
+#default-input-format: json
+#default-output-format: json
+
 ################################################################################
 #
 # CLUSTER-SPECIFIC OPTIONS

--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -40,8 +40,11 @@ log:
 # line. These are overridden by the *--format-input* and *--format-output* options,
 # respectively.
 # 
-# Allowed values: json, json-pretty, yaml
 # Default: json
+# Supported:
+# - json
+# - json-pretty
+# - yaml
 #default-input-format: json
 #default-output-format: json
 

--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -40,11 +40,11 @@ log:
 # line. These are overridden by the *--format-input* and *--format-output* options,
 # respectively.
 # 
-# Default: json
-# Supported:
-# - json
-# - json-pretty
-# - yaml
+# Available values are:
+#
+# json (default)
+# json-pretty
+# yaml
 #default-input-format: json
 #default-output-format: json
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/OpenCHAMI/ochami/internal/log"
+	"github.com/OpenCHAMI/ochami/pkg/format"
 )
 
 type ServiceName string
@@ -70,10 +71,12 @@ var (
 
 // Config represents the structure of a configuration file.
 type Config struct {
-	Log            ConfigLog       `yaml:"log,omitempty"`
-	Timeout        time.Duration   `yaml:"timeout,omitempty"`
-	DefaultCluster string          `yaml:"default-cluster,omitempty"`
-	Clusters       []ConfigCluster `yaml:"clusters,omitempty"`
+	Log                 ConfigLog         `yaml:"log,omitempty"`
+	Timeout             time.Duration     `yaml:"timeout,omitempty"`
+	DefaultCluster      string            `yaml:"default-cluster,omitempty"`
+	DefaultInputFormat  format.DataFormat `yaml:"default-input-format,omitempty"`
+	DefaultOutputFormat format.DataFormat `yaml:"default-output-format,omitempty"`
+	Clusters            []ConfigCluster   `yaml:"clusters,omitempty"`
 }
 
 // UnmarshalYAML unmarshals YAML into a Config, handling default values. For

--- a/man/ochami-config.5.sc
+++ b/man/ochami-config.5.sc
@@ -71,6 +71,15 @@ These configuration options are global configuration options.
 
 	This option can be overridden by the *--timeout* flag.
 
+*default-input-format*: data-format
+*default-output-format*: data-format
+	Specify the default input and output formats if none are passed on the command
+	line. These are overridden by the *--format-input* and *--format-output* options,
+	respectively.
+
+	Allowed values: *json*, *json-pretty*, *yaml*
+	Default: *json*
+
 # CLUSTER CONFIGURATION
 
 These configuration options apply only to cluster configuration, i.e. under the

--- a/man/ochami-config.5.sc
+++ b/man/ochami-config.5.sc
@@ -71,14 +71,17 @@ These configuration options are global configuration options.
 
 	This option can be overridden by the *--timeout* flag.
 
-*default-input-format*: data-format
-*default-output-format*: data-format
+*default-input-format*: _data_format_
+*default-output-format*: _data_format_
 	Specify the default input and output formats if none are passed on the command
 	line. These are overridden by the *--format-input* and *--format-output* options,
 	respectively.
 
-	Allowed values: *json*, *json-pretty*, *yaml*
 	Default: *json*
+	Supported:
+	- _json_
+	- _json-pretty_
+	- _yaml_
 
 # CLUSTER CONFIGURATION
 


### PR DESCRIPTION
## Pull Request Template

Thank you for your contribution! Please ensure the following before submitting:

### Checklist

- [X] My code follows the style guidelines of this project  
- [X] I have added/updated comments where needed  
- [X] I have added tests that prove my fix is effective or my feature works  
- [X] I have run `make test` (or equivalent) locally and all tests pass  
- [X] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [X] **REUSE Compliance**:  
  - [X] Each new/modified source file has SPDX copyright and license headers  
  - [X] Any non-commentable files include a `<filename>.license` sidecar  
  - [X] All referenced licenses are present in the `LICENSES/` directory  

### Description
This pull request adds two new config options, `default-input-format` and `default-output-format`. These set the default input and output formats for when they aren't specified on the command line. They override the hard-coded default of json when specified.

Implements #30 

### Type of Change

- [ ] Bug fix  
- [X] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
