### PR TITLE
fix(smd): cluster-uri segfault

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -368,7 +368,7 @@ func GetBaseURI(cmd *cobra.Command, serviceName config.ServiceName) (string, err
 		case config.ServicePCS:
 			ccc.PCS.URI = cmd.Flag("uri").Value.String()
 		case config.ServiceSMD:
-			ccc.SMD.URI = cmd.Flag("uri").Value.String()
+			ccc.SMD.URI = cmd.Flag("cluster-uri").Value.String()
 		default:
 			return "", fmt.Errorf("unknown service %q specified when generating base URI", serviceName)
 		}


### PR DESCRIPTION
## Pull Request Template

Thank you for your contribution! Please ensure the following before submitting:

### Checklist

- [X] My code follows the style guidelines of this project  
- [X] I have added/updated comments where needed  
- [X] I have added tests that prove my fix is effective or my feature works  
- [X] I have run `make test` (or equivalent) locally and all tests pass  
- [X] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [X] **REUSE Compliance**:  
  - [X] Each new/modified source file has SPDX copyright and license headers  
  - [X] Any non-commentable files include a `<filename>.license` sidecar  
  - [X] All referenced licenses are present in the `LICENSES/` directory  

### Description
This fixes a segfault with the `ochami discover static` command. The `GetBaseURI` function was pulling the cluster URI from a commandline flag that wasn't defined when that particular subcommand was used. Changing the flag to the correct one stops the segfault from happening.

Tested using the command given in the issue:
`ochami discover static -f yaml -d @nodes.yaml --discovery-version 1 --cluster-uri https://demo.openchami.cluster`

Fixes #54

### Type of Change

- [X] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
