### PR TITLE
fix(smd): `--cluster-uri` panic (and remove `io/ioutil`)

### DIFF
--- a/cmd/discover/static/static.go
+++ b/cmd/discover/static/static.go
@@ -77,8 +77,7 @@ See ochami-discover(1) for more details.`,
 			}
 
 			// This endpoint requires authentication, so a token is needed
-			cli.SetToken(cmd)
-			cli.CheckToken(cmd)
+			cli.HandleToken(cmd)
 
 			// Create client to make request to SMD
 			smdClient, err := smd.NewClient(smdBaseURI, cli.Insecure)
@@ -575,6 +574,7 @@ See ochami-discover(1) for more details.`,
 	staticCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
 	staticCmd.Flags().VarP(&cli.FormatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
 	staticCmd.Flags().Bool("overwrite", false, "overwrite any existing information instead of failing")
+	staticCmd.Flags().String("uri", "", "absolute base URI or relative base path of SMD")
 
 	staticCmd.RegisterFlagCompletionFunc("format-input", cli.CompletionFormatData)
 	staticCmd.RegisterFlagCompletionFunc("discovery-version", cli.CompletionDiscoveryVersion)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -357,20 +357,25 @@ func GetBaseURI(cmd *cobra.Command, serviceName config.ServiceName) (string, err
 	// previously-set values while leaving unspecified ones alone.
 	if cmd.Flag("cluster-uri").Changed || (cmd.Flag("uri") != nil && cmd.Flag("uri").Changed) {
 		log.Logger.Debug().Msg("using base URI passed on command line")
-		ccc := config.ConfigClusterConfig{URI: cmd.Flag("cluster-uri").Value.String()}
-		switch serviceName {
-		case config.ServiceBoot:
-			ccc.BootService.URI = cmd.Flag("uri").Value.String()
-		case config.ServiceBSS:
-			ccc.BSS.URI = cmd.Flag("uri").Value.String()
-		case config.ServiceCloudInit:
-			ccc.CloudInit.URI = cmd.Flag("uri").Value.String()
-		case config.ServicePCS:
-			ccc.PCS.URI = cmd.Flag("uri").Value.String()
-		case config.ServiceSMD:
-			ccc.SMD.URI = cmd.Flag("uri").Value.String()
-		default:
-			return "", fmt.Errorf("unknown service %q specified when generating base URI", serviceName)
+		var ccc config.ConfigClusterConfig
+		if cmd.Flag("cluster-uri").Changed {
+			ccc.URI = cmd.Flag("cluster-uri").Value.String()
+		}
+		if cmd.Flag("uri") != nil && cmd.Flag("uri").Changed {
+			switch serviceName {
+			case config.ServiceBoot:
+				ccc.BootService.URI = cmd.Flag("uri").Value.String()
+			case config.ServiceBSS:
+				ccc.BSS.URI = cmd.Flag("uri").Value.String()
+			case config.ServiceCloudInit:
+				ccc.CloudInit.URI = cmd.Flag("uri").Value.String()
+			case config.ServicePCS:
+				ccc.PCS.URI = cmd.Flag("uri").Value.String()
+			case config.ServiceSMD:
+				ccc.SMD.URI = cmd.Flag("uri").Value.String()
+			default:
+				return "", fmt.Errorf("unknown service %q specified when generating base URI", serviceName)
+			}
 		}
 		clusterConfig = clusterConfig.MergeURIConfig(ccc)
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -303,7 +302,7 @@ func (oc *OchamiClient) MakeRequest(method, uri string, headers *HTTPHeaders, bo
 		if resBodyLen > 0 {
 			var resBodyCopy bytes.Buffer
 			resBodyReader := io.TeeReader(res.Body, &resBodyCopy)
-			resBodyBytes, err := ioutil.ReadAll(resBodyReader)
+			resBodyBytes, err := io.ReadAll(resBodyReader)
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to read body for debug message")
 			}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -7,7 +7,6 @@ package client
 
 import (
 	"errors"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -158,7 +157,7 @@ func TestFileToHTTPBody(t *testing.T) {
 	// Prepare a temp JSON file
 	dir := t.TempDir()
 	path := filepath.Join(dir, "payload.json")
-	if err := ioutil.WriteFile(path, []byte(`{"n":42}`), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(`{"n":42}`), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
@@ -207,7 +206,7 @@ func TestReadPayload(t *testing.T) {
 	// Prepare a temp JSON file
 	dir := t.TempDir()
 	path := filepath.Join(dir, "data.json")
-	if err := ioutil.WriteFile(path, []byte(`{"k":7}`), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(`{"k":7}`), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
@@ -280,19 +279,19 @@ func TestReadPayloadSlice(t *testing.T) {
 	// Prepare temp files
 	dir := t.TempDir()
 	jsonSinglePath := filepath.Join(dir, "single.json")
-	if err := ioutil.WriteFile(jsonSinglePath, []byte(`{"k":7}`), 0o644); err != nil {
+	if err := os.WriteFile(jsonSinglePath, []byte(`{"k":7}`), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 	jsonArrayPath := filepath.Join(dir, "array.json")
-	if err := ioutil.WriteFile(jsonArrayPath, []byte(`[{"k":1},{"k":2}]`), 0o644); err != nil {
+	if err := os.WriteFile(jsonArrayPath, []byte(`[{"k":1},{"k":2}]`), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 	yamlSinglePath := filepath.Join(dir, "single.yaml")
-	if err := ioutil.WriteFile(yamlSinglePath, []byte("k: 9\n"), 0o644); err != nil {
+	if err := os.WriteFile(yamlSinglePath, []byte("k: 9\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 	yamlArrayPath := filepath.Join(dir, "array.yaml")
-	if err := ioutil.WriteFile(yamlArrayPath, []byte("- k: 3\n- k: 4\n"), 0o644); err != nil {
+	if err := os.WriteFile(yamlArrayPath, []byte("- k: 3\n- k: 4\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 


### PR DESCRIPTION
## Pull Request Template

Thank you for your contribution! Please ensure the following before submitting:

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [ ] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass  
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Description

Replaces #89 with implementation from https://github.com/OpenCHAMI/ochami/pull/89#discussion_r3290891629.

Add check in `GetBaseURI()` to see if `--uri` was set before attempting to use its value.

Also remove the now-deprecated `io/ioutil` package, replacing with `io` and `os`.

Fixes #54 

### Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
