### PR TITLE
fix(cmd/boot): improvements to issues discovered while implementing metadata commands

### DIFF
--- a/cmd/boot/bmc/add.go
+++ b/cmd/boot/bmc/add.go
@@ -65,7 +65,9 @@ See ochami-boot(1) for more details.`,
 
   # Add BMCs using data from stdin
   echo '<json_data>' | ochami boot bmc add -d @-
-  echo '<yaml_data>' | ochami boot bmc add -d @- -f yaml`,
+  echo '<json_data>' | ochami boot bmc add
+  echo '<yaml_data>' | ochami boot bmc add -d @- -f yaml
+  echo '<yaml_data>' | ochami boot bmc add -f yaml`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Create client to use for requests
 			bootServiceClient := boot_service_lib.GetClient(cmd)
@@ -75,7 +77,11 @@ See ochami-boot(1) for more details.`,
 
 			// Read node data
 			bmcs := []boot_service_client.CreateBMCRequest{}
-			cli.HandlePayloadSlice[boot_service_client.CreateBMCRequest](cmd, &bmcs)
+			if cmd.Flag("data").Changed {
+				cli.HandlePayloadSlice[boot_service_client.CreateBMCRequest](cmd, &bmcs)
+			} else {
+				cli.HandlePayloadStdinSlice[boot_service_client.CreateBMCRequest](cmd, &bmcs)
+			}
 
 			// Send off requests
 			bmcsCreated, errs, err := bootServiceClient.AddBMCs(cli.Token, bmcs)
@@ -105,8 +111,6 @@ See ochami-boot(1) for more details.`,
 	// Create flags
 	bootBmcAddCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
 	bootBmcAddCmd.Flags().VarP(&cli.FormatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
-
-	bootBmcAddCmd.MarkFlagsOneRequired("data")
 
 	bootBmcAddCmd.RegisterFlagCompletionFunc("format-input", cli.CompletionFormatData)
 

--- a/cmd/boot/bmc/add.go
+++ b/cmd/boot/bmc/add.go
@@ -20,8 +20,8 @@ func newCmdBootBmcAdd() *cobra.Command {
 	var bootBmcAddCmd = &cobra.Command{
 		Use:   "add",
 		Args:  cobra.NoArgs,
-		Short: "Add a new BMC to boot-service",
-		Long: `Add a new BMC to boot-service.
+		Short: "Add one or more BMCs to boot-service",
+		Long: `Add one or more BMCs to boot-service.
 
 See ochami-boot(1) for more details.`,
 		Example: `  # Add BMC using payload data

--- a/cmd/boot/bmc/add.go
+++ b/cmd/boot/bmc/add.go
@@ -27,37 +27,37 @@ See ochami-boot(1) for more details.`,
 		Example: `  # Add BMC using payload data
   ochami boot bmc add -d \
     '{
-      "xname": "x1000c0s0b0",
-      "description": "This node's BMC",
-      "interface": {
-        "type": "management",
-        "mac": "de:ca:fc:0f:fe:e1",
-        "ip": "172.16.0.254"
-      }
-    }'
+       "xname": "x1000c0s0b0",
+       "description": "This node's BMC",
+       "interface": {
+         "type": "management",
+         "mac": "de:ca:fc:0f:fe:e1",
+         "ip": "172.16.0.254"
+       }
+     }'
 
   # Add multiple BMCs using payload data
   ochami boot bmc add -d \
     '[
-      {
-        "xname": "x1000c0s0b0",
-        "description": "Node 1's BMC",
-        "interface": {
-          "type": "management",
-          "mac": "de:ca:fc:0f:fe:e1",
-          "ip": "172.16.0.1"
-        }
-      },
-      {
-        "xname": "x1000c0s0b1",
-        "description": "Node 2's BMC",
-        "interface": {
-          "type": "management",
-          "mac": "de:ca:fc:0f:fe:e2",
-          "ip": "172.16.0.2"
-        }
-      }
-    ]'
+       {
+         "xname": "x1000c0s0b0",
+         "description": "Node 1's BMC",
+         "interface": {
+           "type": "management",
+           "mac": "de:ca:fc:0f:fe:e1",
+           "ip": "172.16.0.1"
+         }
+       },
+       {
+         "xname": "x1000c0s0b1",
+         "description": "Node 2's BMC",
+         "interface": {
+           "type": "management",
+           "mac": "de:ca:fc:0f:fe:e2",
+           "ip": "172.16.0.2"
+         }
+       }
+     ]'
 
   # Add BMCs using input payload file
   ochami boot bmc add -d @payload.json

--- a/cmd/boot/bmc/delete.go
+++ b/cmd/boot/bmc/delete.go
@@ -39,6 +39,21 @@ See ochami-boot(1) for more details.`,
 			// Handle token for this command
 			cli.HandleToken(cmd)
 
+			// Ask before attempting deletion unless --no-confirm was passed
+			if !cmd.Flag("no-confirm").Changed {
+				log.Logger.Debug().Msg("--no-confirm not passed, prompting user to confirm deletion")
+				respDelete, err := cli.Ios.LoopYesNo("Really delete?")
+				if err != nil {
+					log.Logger.Error().Err(err).Msg("failed to fetch user input")
+					os.Exit(1)
+				} else if !respDelete {
+					log.Logger.Info().Msg("user aborted BMC deletion")
+					os.Exit(0)
+				} else {
+					log.Logger.Debug().Msg("user answered affirmatively to delete BMC(s)")
+				}
+			}
+
 			// Send off requests
 			bmcsDeleted, errs, err := bootServiceClient.DeleteBMCs(cli.Token, args)
 			if err != nil {

--- a/cmd/boot/bmc/delete.go
+++ b/cmd/boot/bmc/delete.go
@@ -33,14 +33,13 @@ See ochami-boot(1) for more details.`,
   # Don't confirm deletion
   ochami boot bmc delete --no-confirm bmc-773d99bf`,
 		Run: func(cmd *cobra.Command, args []string) {
-			// Create client to use for requests
-			bootServiceClient := boot_service_lib.GetClient(cmd)
-
-			// Handle token for this command
-			cli.HandleToken(cmd)
-
 			// Ask before attempting deletion unless --no-confirm was passed
-			if !cmd.Flag("no-confirm").Changed {
+			noConfirm, err := cmd.Flags().GetBool("no-confirm")
+			if err != nil {
+				log.Logger.Error().Err(err).Msg("failed to get --no-confirm")
+				os.Exit(1)
+			}
+			if !noConfirm {
 				log.Logger.Debug().Msg("--no-confirm not passed, prompting user to confirm deletion")
 				respDelete, err := cli.Ios.LoopYesNo("Really delete?")
 				if err != nil {
@@ -53,6 +52,12 @@ See ochami-boot(1) for more details.`,
 					log.Logger.Debug().Msg("user answered affirmatively to delete BMC(s)")
 				}
 			}
+
+			// Create client to use for requests
+			bootServiceClient := boot_service_lib.GetClient(cmd)
+
+			// Handle token for this command
+			cli.HandleToken(cmd)
 
 			// Send off requests
 			bmcsDeleted, errs, err := bootServiceClient.DeleteBMCs(cli.Token, args)

--- a/cmd/boot/bmc/get.go
+++ b/cmd/boot/bmc/get.go
@@ -25,7 +25,7 @@ func newCmdBootBmcGet() *cobra.Command {
 
 See ochami-boot(1) for more details.`,
 		Example: `  # Get info about a BMC
-  ochami boot node get bmc-773d99bf`,
+  ochami boot bmc get bmc-773d99bf`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Create client to use for requests
 			bootServiceClient := boot_service_lib.GetClient(cmd)

--- a/cmd/boot/bmc/patch.go
+++ b/cmd/boot/bmc/patch.go
@@ -42,7 +42,7 @@ the manual, key-value patch method using dot notation (e.g. key.subkey=value)
 is used.
 
 Otherwise, stdin and/or --data can be used to pass in raw patch data, using
---patch-format to specify the patch format (see examples below).
+--patch-method to specify the patch format (see examples below).
 
 --format-input can only be used with stdin/--data. It can be used to tell
 ochami to use a different format (e.g. YAML) for the data input for either
@@ -79,8 +79,8 @@ See ochami-boot(1) for more details.`,
 
 			var patchData map[string]interface{}
 			if cmd.Flag("set").Changed || cmd.Flag("unset").Changed || cmd.Flag("add").Changed || cmd.Flag("remove").Changed {
-				if cmd.Flag("patch-format").Changed && formatPatch != client.PatchMethodKeyVal {
-					log.Logger.Warn().Msg("overriding --patch-format since --set/--unset/--add/--remove was passed")
+				if cmd.Flag("patch-method").Changed && formatPatch != client.PatchMethodKeyVal {
+					log.Logger.Warn().Msg("overriding --patch-method since --set/--unset/--add/--remove was passed")
 				}
 
 				pd, err := client.NewKeyValPatch(setList, unsetList, addList, removeList)

--- a/cmd/boot/bmc/patch.go
+++ b/cmd/boot/bmc/patch.go
@@ -41,12 +41,12 @@ If --set/--unset/--add/--remove are specified or --patch-method is 'keyval',
 the manual, key-value patch method using dot notation (e.g. key.subkey=value)
 is used.
 
-Otherwise, --data can be used to pass in raw patch data, using --patch-format
-to specify the patch format (see examples below).
+Otherwise, stdin and/or --data can be used to pass in raw patch data, using
+--patch-format to specify the patch format (see examples below).
 
---format-input can only be used with --data. It can be used to tell ochami to
-use a different format (e.g. YAML) for the data input for either of these
-methods.
+--format-input can only be used with stdin/--data. It can be used to tell
+ochami to use a different format (e.g. YAML) for the data input for either
+of these methods.
 
 See ochami-boot(1) for more details.`,
 		Example: `  # Patch using JSON patch (RFC 6902)
@@ -67,7 +67,9 @@ See ochami-boot(1) for more details.`,
 
   # Patch using stdin
   echo '<json_data>' | ochami boot bmc patch bmc-773d99bf -d @-
-  echo '<yaml_data>' | ochami boot bmc patch bmc-773d99bf -f yaml -d @-`,
+  echo '<json_data>' | ochami boot bmc patch bmc-773d99bf
+  echo '<yaml_data>' | ochami boot bmc patch bmc-773d99bf -d @- -f yaml
+  echo '<yaml_data>' | ochami boot bmc patch bmc-773d99bf -f yaml`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Create client to use for requests
 			bootServiceClient := boot_service_lib.GetClient(cmd)
@@ -89,7 +91,11 @@ See ochami-boot(1) for more details.`,
 				}
 				patchData = pd
 			} else {
-				cli.HandlePayload(cmd, &patchData)
+				if cmd.Flag("data").Changed {
+					cli.HandlePayload(cmd, &patchData)
+				} else {
+					cli.HandlePayloadStdin(cmd, &patchData)
+				}
 			}
 
 			bmcPatched, err := bootServiceClient.PatchBMC(cli.Token, formatPatch, args[0], patchData)
@@ -116,7 +122,6 @@ See ochami-boot(1) for more details.`,
 		bootBmcPatchCmd.MarkFlagsMutuallyExclusive("format-input", flag)
 		bootBmcPatchCmd.MarkFlagsMutuallyExclusive("data", flag)
 	}
-	bootBmcPatchCmd.MarkFlagsOneRequired("data", "set", "unset", "add", "remove")
 
 	bootBmcPatchCmd.RegisterFlagCompletionFunc("format-input", cli.CompletionFormatData)
 

--- a/cmd/boot/bmc/set.go
+++ b/cmd/boot/bmc/set.go
@@ -27,14 +27,14 @@ See ochami-boot(1) for more details.`,
 		Example: `  # Set BMC details using payload data
   ochami boot bmc set bmc-773d99bf -d \
     '{
-      "xname": "x1000c0s0b0",
-      "description": "This node's BMC",
-      "interface": {
-        "type": "management",
-        "mac": "de:ca:fc:0f:fe:e1",
-        "ip": "172.16.0.254"
-      }
-    }'
+       "xname": "x1000c0s0b0",
+       "description": "This node's BMC",
+       "interface": {
+         "type": "management",
+         "mac": "de:ca:fc:0f:fe:e1",
+         "ip": "172.16.0.254"
+       }
+     }'
 
   # Set BMC details using input payload file
   ochami boot bmc set -d @payload.json bmc-773d99bf

--- a/cmd/boot/bmc/set.go
+++ b/cmd/boot/bmc/set.go
@@ -42,7 +42,9 @@ See ochami-boot(1) for more details.`,
 
   # Set BMC details using data from stdin
   echo '<json_data>' | ochami boot bmc set -d @- bmc-773d99bf
-  echo '<yaml_data>' | ochami boot bmc set -d @- -f yaml bmc-773d99bf`,
+  echo '<json_data>' | ochami boot bmc set bmc-773d99bf
+  echo '<yaml_data>' | ochami boot bmc set -d @- -f yaml bmc-773d99bf
+  echo '<yaml_data>' | ochami boot bmc set -f yaml bmc-773d99bf`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Create client to use for requests
 			bootServiceClient := boot_service_lib.GetClient(cmd)
@@ -52,7 +54,11 @@ See ochami-boot(1) for more details.`,
 
 			// Read BMC data
 			bmc := boot_service_client.UpdateBMCRequest{}
-			cli.HandlePayload(cmd, &bmc)
+			if cmd.Flag("data").Changed {
+				cli.HandlePayload(cmd, &bmc)
+			} else {
+				cli.HandlePayloadStdin(cmd, &bmc)
+			}
 
 			// Send off requests
 			bmcSet, err := bootServiceClient.SetBMC(cli.Token, args[0], bmc)
@@ -69,8 +75,6 @@ See ochami-boot(1) for more details.`,
 	// Create flags
 	bootBmcSetCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
 	bootBmcSetCmd.Flags().VarP(&cli.FormatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
-
-	bootBmcSetCmd.MarkFlagsOneRequired("data")
 
 	bootBmcSetCmd.RegisterFlagCompletionFunc("format-input", cli.CompletionFormatData)
 

--- a/cmd/boot/config/add.go
+++ b/cmd/boot/config/add.go
@@ -27,46 +27,46 @@ See ochami-boot(1) for more details.`,
 		Example: `  # Add boot configuration using payload data
   ochami boot config add -d \
     '{
-      "hosts": [
-        "item1",
-        "item2"
-      ],
-      "macs": [
-        "de:ca:fc:0f:fe:e1",
-        "de:ca:fc:0f:fe:e2"
-      ],
-      "nids": [
-        1,
-        2
-      ],
-      "groups": [
-        "group1",
-        "group2"
-      ],
-      "kernel": "http://s3.openchami.cluster/kernels/vmlinuz1",
-      "initrd": "http://s3.openchami.cluster/initrds/initramfs1.img",
-      "params": "console=tty0,115200n8 console=ttyS0,115200n8",
-      "priority": 42
-    }'
+       "hosts": [
+         "item1",
+         "item2"
+       ],
+       "macs": [
+         "de:ca:fc:0f:fe:e1",
+         "de:ca:fc:0f:fe:e2"
+       ],
+       "nids": [
+         1,
+         2
+       ],
+       "groups": [
+         "group1",
+         "group2"
+       ],
+       "kernel": "http://s3.openchami.cluster/kernels/vmlinuz1",
+       "initrd": "http://s3.openchami.cluster/initrds/initramfs1.img",
+       "params": "console=tty0,115200n8 console=ttyS0,115200n8",
+       "priority": 42
+     }'
 
   # Add multiple boot configurations using payload data
   ochami boot config add -d \
     '[
-      {
-        "hosts": ["host1"],
-        "kernel": "http://s3.openchami.cluster/kernels/vmlinuz1",
-        "initrd": "http://s3.openchami.cluster/initrds/initramfs1.img",
-        "params": "console=tty0,115200n8 console=ttyS0,115200n8",
-        "priority": 42
-      },
-      {
-        "macs": ["de:ca:fc:0f:fe:ee"],
-        "kernel": "http://s3.openchami.cluster/kernels/vmlinuz2",
-        "initrd": "http://s3.openchami.cluster/initrds/initramfs2.img",
-        "params": "ip=dhcp",
-        "priority": 43
-      }
-    ]'
+       {
+         "hosts": ["host1"],
+         "kernel": "http://s3.openchami.cluster/kernels/vmlinuz1",
+         "initrd": "http://s3.openchami.cluster/initrds/initramfs1.img",
+         "params": "console=tty0,115200n8 console=ttyS0,115200n8",
+         "priority": 42
+       },
+       {
+         "macs": ["de:ca:fc:0f:fe:ee"],
+         "kernel": "http://s3.openchami.cluster/kernels/vmlinuz2",
+         "initrd": "http://s3.openchami.cluster/initrds/initramfs2.img",
+         "params": "ip=dhcp",
+         "priority": 43
+       }
+     ]'
 
   # Add boot configuration using input payload file
   ochami boot config add -d @payload.json

--- a/cmd/boot/config/add.go
+++ b/cmd/boot/config/add.go
@@ -74,7 +74,9 @@ See ochami-boot(1) for more details.`,
 
   # Add boot configuration using data from stdin
   echo '<json_data>' | ochami boot config add -d @-
-  echo '<yaml_data>' | ochami boot config add -d @- -f yaml`,
+  echo '<json_data>' | ochami boot config add
+  echo '<yaml_data>' | ochami boot config add -d @- -f yaml
+  echo '<yaml_data>' | ochami boot config add -f yaml`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Create client to use for requests
 			bootServiceClient := boot_service_lib.GetClient(cmd)
@@ -84,7 +86,11 @@ See ochami-boot(1) for more details.`,
 
 			// Read boot configuration data
 			bcs := []boot_service_client.CreateBootConfigurationRequest{}
-			cli.HandlePayloadSlice[boot_service_client.CreateBootConfigurationRequest](cmd, &bcs)
+			if cmd.Flag("data").Changed {
+				cli.HandlePayloadSlice[boot_service_client.CreateBootConfigurationRequest](cmd, &bcs)
+			} else {
+				cli.HandlePayloadStdinSlice[boot_service_client.CreateBootConfigurationRequest](cmd, &bcs)
+			}
 
 			// Send off requests
 			cfgsCreated, errs, err := bootServiceClient.AddBootConfigs(cli.Token, bcs)
@@ -114,8 +120,6 @@ See ochami-boot(1) for more details.`,
 	// Create flags
 	bootConfigAddCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
 	bootConfigAddCmd.Flags().VarP(&cli.FormatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
-
-	bootConfigAddCmd.MarkFlagsOneRequired("data")
 
 	bootConfigAddCmd.RegisterFlagCompletionFunc("format-input", cli.CompletionFormatData)
 

--- a/cmd/boot/config/delete.go
+++ b/cmd/boot/config/delete.go
@@ -39,6 +39,21 @@ See ochami-boot(1) for more details.`,
 			// Handle token for this command
 			cli.HandleToken(cmd)
 
+			// Ask before attempting deletion unless --no-confirm was passed
+			if !cmd.Flag("no-confirm").Changed {
+				log.Logger.Debug().Msg("--no-confirm not passed, prompting user to confirm deletion")
+				respDelete, err := cli.Ios.LoopYesNo("Really delete?")
+				if err != nil {
+					log.Logger.Error().Err(err).Msg("failed to fetch user input")
+					os.Exit(1)
+				} else if !respDelete {
+					log.Logger.Info().Msg("user aborted boot config deletion")
+					os.Exit(0)
+				} else {
+					log.Logger.Debug().Msg("user answered affirmatively to delete boot config(s)")
+				}
+			}
+
 			// Send off requests
 			bcfgsDeleted, errs, err := bootServiceClient.DeleteBootConfigs(cli.Token, args)
 			if err != nil {

--- a/cmd/boot/config/delete.go
+++ b/cmd/boot/config/delete.go
@@ -33,14 +33,13 @@ See ochami-boot(1) for more details.`,
   # Don't confirm deletion
   ochami boot config delete --no-confirm boo-ebf2a27a`,
 		Run: func(cmd *cobra.Command, args []string) {
-			// Create client to use for requests
-			bootServiceClient := boot_service_lib.GetClient(cmd)
-
-			// Handle token for this command
-			cli.HandleToken(cmd)
-
 			// Ask before attempting deletion unless --no-confirm was passed
-			if !cmd.Flag("no-confirm").Changed {
+			noConfirm, err := cmd.Flags().GetBool("no-confirm")
+			if err != nil {
+				log.Logger.Error().Err(err).Msg("failed to get --no-confirm")
+				os.Exit(1)
+			}
+			if !noConfirm {
 				log.Logger.Debug().Msg("--no-confirm not passed, prompting user to confirm deletion")
 				respDelete, err := cli.Ios.LoopYesNo("Really delete?")
 				if err != nil {
@@ -53,6 +52,12 @@ See ochami-boot(1) for more details.`,
 					log.Logger.Debug().Msg("user answered affirmatively to delete boot config(s)")
 				}
 			}
+
+			// Create client to use for requests
+			bootServiceClient := boot_service_lib.GetClient(cmd)
+
+			// Handle token for this command
+			cli.HandleToken(cmd)
 
 			// Send off requests
 			bcfgsDeleted, errs, err := bootServiceClient.DeleteBootConfigs(cli.Token, args)

--- a/cmd/boot/config/patch.go
+++ b/cmd/boot/config/patch.go
@@ -42,7 +42,7 @@ the manual, key-value patch method using dot notation (e.g. key.subkey=value)
 is used.
 
 Otherwise, stdin and/or --data can be used to pass in raw patch data, using
---patch-format to specify the patch format (see examples below).
+--patch-method to specify the patch format (see examples below).
 
 --format-input can only be used with stdin/--data. It can be used to tell
 ochami to use a different format (e.g. YAML) for the data input for either of
@@ -80,8 +80,8 @@ See ochami-boot(1) for more details.`,
 
 			var patchData map[string]interface{}
 			if cmd.Flag("set").Changed || cmd.Flag("unset").Changed || cmd.Flag("add").Changed || cmd.Flag("remove").Changed {
-				if cmd.Flag("patch-format").Changed && formatPatch != client.PatchMethodKeyVal {
-					log.Logger.Warn().Msg("overriding --patch-format since --set/--unset/--add/--remove was passed")
+				if cmd.Flag("patch-method").Changed && formatPatch != client.PatchMethodKeyVal {
+					log.Logger.Warn().Msg("overriding --patch-method since --set/--unset/--add/--remove was passed")
 				}
 
 				pd, err := client.NewKeyValPatch(setList, unsetList, addList, removeList)

--- a/cmd/boot/config/patch.go
+++ b/cmd/boot/config/patch.go
@@ -41,12 +41,12 @@ If --set/--unset/--add/--remove are specified or --patch-method is 'keyval',
 the manual, key-value patch method using dot notation (e.g. key.subkey=value)
 is used.
 
-Otherwise, --data can be used to pass in raw patch data, using --patch-format
-to specify the patch format (see examples below).
+Otherwise, stdin and/or --data can be used to pass in raw patch data, using
+--patch-format to specify the patch format (see examples below).
 
---format-input can only be used with --data. It can be used to tell ochami to
-use a different format (e.g. YAML) for the data input for either of these
-methods.
+--format-input can only be used with stdin/--data. It can be used to tell
+ochami to use a different format (e.g. YAML) for the data input for either of
+these methods.
 
 See ochami-boot(1) for more details.`,
 		Example: `  # Patch using JSON patch (RFC 6902)
@@ -68,7 +68,9 @@ See ochami-boot(1) for more details.`,
 
   # Patch using stdin
   echo '<json_data>' | ochami boot config patch boo-914afad2 -d @-
-  echo '<yaml_data>' | ochami boot config patch boo-914afad2 -f yaml -d @-`,
+  echo '<json_data>' | ochami boot config patch boo-914afad2
+  echo '<yaml_data>' | ochami boot config patch boo-914afad2 -d @- -f yaml
+  echo '<yaml_data>' | ochami boot config patch boo-914afad2 -f yaml`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Create client to use for requests
 			bootServiceClient := boot_service_lib.GetClient(cmd)
@@ -90,7 +92,11 @@ See ochami-boot(1) for more details.`,
 				}
 				patchData = pd
 			} else {
-				cli.HandlePayload(cmd, &patchData)
+				if cmd.Flag("data").Changed {
+					cli.HandlePayload(cmd, &patchData)
+				} else {
+					cli.HandlePayloadStdin(cmd, &patchData)
+				}
 			}
 
 			cfgPatched, err := bootServiceClient.PatchBootConfig(cli.Token, formatPatch, args[0], patchData)
@@ -117,7 +123,6 @@ See ochami-boot(1) for more details.`,
 		bootConfigPatchCmd.MarkFlagsMutuallyExclusive("format-input", flag)
 		bootConfigPatchCmd.MarkFlagsMutuallyExclusive("data", flag)
 	}
-	bootConfigPatchCmd.MarkFlagsOneRequired("data", "set", "unset", "add", "remove")
 
 	bootConfigPatchCmd.RegisterFlagCompletionFunc("format-input", cli.CompletionFormatData)
 

--- a/cmd/boot/config/set.go
+++ b/cmd/boot/config/set.go
@@ -27,27 +27,27 @@ See ochami-boot(1) for more details.`,
 		Example: `  # Set boot configuration using payload data
   ochami boot config set boo-914afad2 -d \
     '{
-      "hosts": [
-        "item1",
-        "item2"
-      ],
-      "macs": [
-        "de:ca:fc:0f:fe:e1",
-        "de:ca:fc:0f:fe:e2"
-      ],
-      "nids": [
-        1,
-        2
-      ],
-      "groups": [
-        "group1",
-        "group2"
-      ],
-      "kernel": "http://s3.openchami.cluster/kernels/vmlinuz1",
-      "initrd": "http://s3.openchami.cluster/initrds/initramfs1.img",
-      "params": "console=tty0,115200n8 console=ttyS0,115200n8",
-      "priority": 42
-    }'
+       "hosts": [
+         "item1",
+         "item2"
+       ],
+       "macs": [
+         "de:ca:fc:0f:fe:e1",
+         "de:ca:fc:0f:fe:e2"
+       ],
+       "nids": [
+         1,
+         2
+       ],
+       "groups": [
+         "group1",
+         "group2"
+       ],
+       "kernel": "http://s3.openchami.cluster/kernels/vmlinuz1",
+       "initrd": "http://s3.openchami.cluster/initrds/initramfs1.img",
+       "params": "console=tty0,115200n8 console=ttyS0,115200n8",
+       "priority": 42
+     }'
 
   # Set boot configuration using input payload file
   ochami boot config set -d @payload.json boo-914afad2

--- a/cmd/boot/config/set.go
+++ b/cmd/boot/config/set.go
@@ -55,7 +55,9 @@ See ochami-boot(1) for more details.`,
 
   # Set boot configuration using data from stdin
   echo '<json_data>' | ochami boot config set -d @- boo-914afad2
-  echo '<yaml_data>' | ochami boot config set -d @- -f yaml boo-914afad2`,
+  echo '<json_data>' | ochami boot config set boo-914afad2
+  echo '<yaml_data>' | ochami boot config set -d @- -f yaml boo-914afad2
+  echo '<yaml_data>' | ochami boot config set -f yaml boo-914afad2`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Create client to use for requests
 			bootServiceClient := boot_service_lib.GetClient(cmd)
@@ -65,7 +67,11 @@ See ochami-boot(1) for more details.`,
 
 			// Read boot configuration data
 			bcs := boot_service_client.UpdateBootConfigurationRequest{}
-			cli.HandlePayload(cmd, &bcs)
+			if cmd.Flag("data").Changed {
+				cli.HandlePayload(cmd, &bcs)
+			} else {
+				cli.HandlePayloadStdin(cmd, &bcs)
+			}
 
 			// Send off requests
 			cfgSet, err := bootServiceClient.SetBootConfig(cli.Token, args[0], bcs)
@@ -82,8 +88,6 @@ See ochami-boot(1) for more details.`,
 	// Create flags
 	bootConfigSetCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
 	bootConfigSetCmd.Flags().VarP(&cli.FormatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
-
-	bootConfigSetCmd.MarkFlagsOneRequired("data")
 
 	bootConfigSetCmd.RegisterFlagCompletionFunc("format-input", cli.CompletionFormatData)
 

--- a/cmd/boot/node/add.go
+++ b/cmd/boot/node/add.go
@@ -83,7 +83,9 @@ See ochami-boot(1) for more details.`,
 
   # Add nodes using data from stdin
   echo '<json_data>' | ochami boot node add -d @-
-  echo '<yaml_data>' | ochami boot node add -d @- -f yaml`,
+  echo '<json_data>' | ochami boot node add
+  echo '<yaml_data>' | ochami boot node add -d @- -f yaml
+  echo '<yaml_data>' | ochami boot node add -f yaml`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Create client to use for requests
 			bootServiceClient := boot_service_lib.GetClient(cmd)
@@ -93,7 +95,11 @@ See ochami-boot(1) for more details.`,
 
 			// Read node data
 			nodes := []boot_service_client.CreateNodeRequest{}
-			cli.HandlePayloadSlice[boot_service_client.CreateNodeRequest](cmd, &nodes)
+			if cmd.Flag("data").Changed {
+				cli.HandlePayloadSlice[boot_service_client.CreateNodeRequest](cmd, &nodes)
+			} else {
+				cli.HandlePayloadStdinSlice[boot_service_client.CreateNodeRequest](cmd, &nodes)
+			}
 
 			// Send off requests
 			nodesCreated, errs, err := bootServiceClient.AddNodes(cli.Token, nodes)
@@ -123,8 +129,6 @@ See ochami-boot(1) for more details.`,
 	// Create flags
 	bootNodeAddCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
 	bootNodeAddCmd.Flags().VarP(&cli.FormatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
-
-	bootNodeAddCmd.MarkFlagsOneRequired("data")
 
 	bootNodeAddCmd.RegisterFlagCompletionFunc("format-input", cli.CompletionFormatData)
 

--- a/cmd/boot/node/add.go
+++ b/cmd/boot/node/add.go
@@ -27,55 +27,55 @@ See ochami-boot(1) for more details.`,
 		Example: `  # Add node using payload data
   ochami boot node add -d \
     '{
-      "xname": "x1000c0s0b0n0",
-      "nid": 42,
-      "bootMac": "de:ca:fc:0f:fe:e1",
-      "role": "example-role",
-      "subRole": "example-subrole",
-      "hostname": "ex01.example.org",
-      "interfaces": [
-        {
-          "type": "management",
-          "mac": "de:ca:fc:0f:fe:e1",
-          "ip": "172.16.0.1"
-        }
-      ],
-      "groups": [
-        "group1",
-        "group2"
-      ]
-    }'
+       "xname": "x1000c0s0b0n0",
+       "nid": 42,
+       "bootMac": "de:ca:fc:0f:fe:e1",
+       "role": "example-role",
+       "subRole": "example-subrole",
+       "hostname": "ex01.example.org",
+       "interfaces": [
+         {
+           "type": "management",
+           "mac": "de:ca:fc:0f:fe:e1",
+           "ip": "172.16.0.1"
+         }
+       ],
+       "groups": [
+         "group1",
+         "group2"
+       ]
+     }'
 
   # Add multiple nodes using payload data
   ochami boot node add -d \
     '[
-      {
-        "xname": "x1000c0s0b0n0",
-        "nid": 42,
-        "bootMac": "de:ca:fc:0f:fe:e1",
-        "hostname": "ex01.example.org",
-        "interfaces": [
-          {
-            "type": "management",
-            "mac": "de:ca:fc:0f:fe:e1",
-            "ip": "172.16.0.1"
-          }
-        ]
-      },
-      {
-        "xname": "x1000c0s0b0n1",
-        "nid": 43,
-        "bootMac": "de:ca:fc:0f:fe:e2",
-        "hostname": "ex02.example.org",
-        "interfaces": [
-          {
-            "type": "management",
-            "mac": "de:ca:fc:0f:fe:e2",
-            "ip": "172.16.0.2"
-          }
-        ]
-      }
-    ]'
+       {
+         "xname": "x1000c0s0b0n0",
+         "nid": 42,
+         "bootMac": "de:ca:fc:0f:fe:e1",
+         "hostname": "ex01.example.org",
+         "interfaces": [
+           {
+             "type": "management",
+             "mac": "de:ca:fc:0f:fe:e1",
+             "ip": "172.16.0.1"
+           }
+         ]
+       },
+       {
+         "xname": "x1000c0s0b0n1",
+         "nid": 43,
+         "bootMac": "de:ca:fc:0f:fe:e2",
+         "hostname": "ex02.example.org",
+         "interfaces": [
+           {
+             "type": "management",
+             "mac": "de:ca:fc:0f:fe:e2",
+             "ip": "172.16.0.2"
+           }
+         ]
+       }
+     ]'
 
   # Add nodes using input payload file
   ochami boot node add -d @payload.json

--- a/cmd/boot/node/delete.go
+++ b/cmd/boot/node/delete.go
@@ -33,14 +33,13 @@ See ochami-boot(1) for more details.`,
   # Don't confirm deletion
   ochami boot node delete --no-confirm nod-bc76f7f2`,
 		Run: func(cmd *cobra.Command, args []string) {
-			// Create client to use for requests
-			bootServiceClient := boot_service_lib.GetClient(cmd)
-
-			// Handle token for this command
-			cli.HandleToken(cmd)
-
 			// Ask before attempting deletion unless --no-confirm was passed
-			if !cmd.Flag("no-confirm").Changed {
+			noConfirm, err := cmd.Flags().GetBool("no-confirm")
+			if err != nil {
+				log.Logger.Error().Err(err).Msg("failed to get --no-confirm")
+				os.Exit(1)
+			}
+			if !noConfirm {
 				log.Logger.Debug().Msg("--no-confirm not passed, prompting user to confirm deletion")
 				respDelete, err := cli.Ios.LoopYesNo("Really delete?")
 				if err != nil {
@@ -53,6 +52,12 @@ See ochami-boot(1) for more details.`,
 					log.Logger.Debug().Msg("user answered affirmatively to delete node(s)")
 				}
 			}
+
+			// Create client to use for requests
+			bootServiceClient := boot_service_lib.GetClient(cmd)
+
+			// Handle token for this command
+			cli.HandleToken(cmd)
 
 			// Send off requests
 			nodesDeleted, errs, err := bootServiceClient.DeleteNodes(cli.Token, args)

--- a/cmd/boot/node/delete.go
+++ b/cmd/boot/node/delete.go
@@ -39,6 +39,21 @@ See ochami-boot(1) for more details.`,
 			// Handle token for this command
 			cli.HandleToken(cmd)
 
+			// Ask before attempting deletion unless --no-confirm was passed
+			if !cmd.Flag("no-confirm").Changed {
+				log.Logger.Debug().Msg("--no-confirm not passed, prompting user to confirm deletion")
+				respDelete, err := cli.Ios.LoopYesNo("Really delete?")
+				if err != nil {
+					log.Logger.Error().Err(err).Msg("failed to fetch user input")
+					os.Exit(1)
+				} else if !respDelete {
+					log.Logger.Info().Msg("user aborted node deletion")
+					os.Exit(0)
+				} else {
+					log.Logger.Debug().Msg("user answered affirmatively to delete node(s)")
+				}
+			}
+
 			// Send off requests
 			nodesDeleted, errs, err := bootServiceClient.DeleteNodes(cli.Token, args)
 			if err != nil {

--- a/cmd/boot/node/patch.go
+++ b/cmd/boot/node/patch.go
@@ -42,7 +42,7 @@ the manual, key-value patch method using dot notation (e.g. key.subkey=value)
 is used.
 
 Otherwise, stdin and/or --data can be used to pass in raw patch data, using
---patch-format to specify the patch format (see examples below).
+--patch-method to specify the patch format (see examples below).
 
 --format-input can only be used with stdin/--data. It can be used to tell
 ochami to use a different format (e.g. YAML) for the data input for either of
@@ -80,8 +80,8 @@ See ochami-boot(1) for more details.`,
 
 			var patchData map[string]interface{}
 			if cmd.Flag("set").Changed || cmd.Flag("unset").Changed || cmd.Flag("add").Changed || cmd.Flag("remove").Changed {
-				if cmd.Flag("patch-format").Changed && formatPatch != client.PatchMethodKeyVal {
-					log.Logger.Warn().Msg("overriding --patch-format since --set/--unset/--add/--remove was passed")
+				if cmd.Flag("patch-method").Changed && formatPatch != client.PatchMethodKeyVal {
+					log.Logger.Warn().Msg("overriding --patch-method since --set/--unset/--add/--remove was passed")
 				}
 
 				pd, err := client.NewKeyValPatch(setList, unsetList, addList, removeList)

--- a/cmd/boot/node/patch.go
+++ b/cmd/boot/node/patch.go
@@ -41,12 +41,12 @@ If --set/--unset/--add/--remove are specified or --patch-method is 'keyval',
 the manual, key-value patch method using dot notation (e.g. key.subkey=value)
 is used.
 
-Otherwise, --data can be used to pass in raw patch data, using --patch-format
-to specify the patch format (see examples below).
+Otherwise, stdin and/or --data can be used to pass in raw patch data, using
+--patch-format to specify the patch format (see examples below).
 
---format-input can only be used with --data. It can be used to tell ochami to
-use a different format (e.g. YAML) for the data input for either of these
-methods.
+--format-input can only be used with stdin/--data. It can be used to tell
+ochami to use a different format (e.g. YAML) for the data input for either of
+these methods.
 
 See ochami-boot(1) for more details.`,
 		Example: `  # Patch using JSON patch (RFC 6902)
@@ -68,7 +68,9 @@ See ochami-boot(1) for more details.`,
 
   # Patch using stdin
   echo '<json_data>' | ochami boot node patch nod-bc76f7f2 -d @-
-  echo '<yaml_data>' | ochami boot node patch nod-bc76f7f2 -f yaml -d @-`,
+  echo '<json_data>' | ochami boot node patch nod-bc76f7f2
+  echo '<yaml_data>' | ochami boot node patch nod-bc76f7f2 -d @- -f yaml
+  echo '<yaml_data>' | ochami boot node patch nod-bc76f7f2 -f yaml`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Create client to use for requests
 			bootServiceClient := boot_service_lib.GetClient(cmd)
@@ -90,7 +92,11 @@ See ochami-boot(1) for more details.`,
 				}
 				patchData = pd
 			} else {
-				cli.HandlePayload(cmd, &patchData)
+				if cmd.Flag("data").Changed {
+					cli.HandlePayload(cmd, &patchData)
+				} else {
+					cli.HandlePayloadStdin(cmd, &patchData)
+				}
 			}
 
 			nodePatched, err := bootServiceClient.PatchNode(cli.Token, formatPatch, args[0], patchData)
@@ -117,7 +123,6 @@ See ochami-boot(1) for more details.`,
 		bootNodePatchCmd.MarkFlagsMutuallyExclusive("format-input", flag)
 		bootNodePatchCmd.MarkFlagsMutuallyExclusive("data", flag)
 	}
-	bootNodePatchCmd.MarkFlagsOneRequired("data", "set", "unset", "add", "remove")
 
 	bootNodePatchCmd.RegisterFlagCompletionFunc("format-input", cli.CompletionFormatData)
 

--- a/cmd/boot/node/set.go
+++ b/cmd/boot/node/set.go
@@ -27,24 +27,24 @@ See ochami-boot(1) for more details.`,
 		Example: `  # Set node details using payload data
   ochami boot node set nod-bc76f7f2 -d \
     '{
-      "xname": "x1000c0s0b0n0",
-      "nid": 42,
-      "bootMac": "de:ca:fc:0f:fe:e1",
-      "role": "example-role",
-      "subRole": "example-subrole",
-      "hostname": "ex01.example.org",
-      "interfaces": [
-        {
-          "type": "management",
-          "mac": "de:ca:fc:0f:fe:e1",
-          "ip": "172.16.0.1"
-        }
-      ],
-      "groups": [
-        "group1",
-        "group2"
-      ]
-    }'
+       "xname": "x1000c0s0b0n0",
+       "nid": 42,
+       "bootMac": "de:ca:fc:0f:fe:e1",
+       "role": "example-role",
+       "subRole": "example-subrole",
+       "hostname": "ex01.example.org",
+       "interfaces": [
+         {
+           "type": "management",
+           "mac": "de:ca:fc:0f:fe:e1",
+           "ip": "172.16.0.1"
+         }
+       ],
+       "groups": [
+         "group1",
+         "group2"
+       ]
+     }'
 
   # Set boot configuration using input payload file
   ochami boot node set -d @payload.json nod-bc76f7f2

--- a/cmd/boot/node/set.go
+++ b/cmd/boot/node/set.go
@@ -52,7 +52,9 @@ See ochami-boot(1) for more details.`,
 
   # Set boot configuration using data from stdin
   echo '<json_data>' | ochami boot node set -d @- nod-bc76f7f2
-  echo '<yaml_data>' | ochami boot node set -d @- -f yaml nod-bc76f7f2`,
+  echo '<json_data>' | ochami boot node set nod-bc76f7f2
+  echo '<yaml_data>' | ochami boot node set -d @- -f yaml nod-bc76f7f2
+  echo '<yaml_data>' | ochami boot node set -f yaml nod-bc76f7f2`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Create client to use for requests
 			bootServiceClient := boot_service_lib.GetClient(cmd)
@@ -62,7 +64,11 @@ See ochami-boot(1) for more details.`,
 
 			// Read node data
 			node := boot_service_client.UpdateNodeRequest{}
-			cli.HandlePayload(cmd, &node)
+			if cmd.Flag("data").Changed {
+				cli.HandlePayload(cmd, &node)
+			} else {
+				cli.HandlePayloadStdin(cmd, &node)
+			}
 
 			// Send off requests
 			nodeSet, err := bootServiceClient.SetNode(cli.Token, args[0], node)
@@ -79,8 +85,6 @@ See ochami-boot(1) for more details.`,
 	// Create flags
 	bootNodeSetCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
 	bootNodeSetCmd.Flags().VarP(&cli.FormatInput, "format-input", "f", "format of input payload data (json,json-pretty,yaml)")
-
-	bootNodeSetCmd.MarkFlagsOneRequired("data")
 
 	bootNodeSetCmd.RegisterFlagCompletionFunc("format-input", cli.CompletionFormatData)
 

--- a/internal/cli/boot_service/boot_service.go
+++ b/internal/cli/boot_service/boot_service.go
@@ -15,8 +15,9 @@ import (
 	"github.com/OpenCHAMI/ochami/pkg/client/boot_service"
 )
 
-// GetClient sets up the BSS client with the BSS base URI and certificates
-// (if necessary) and returns it. This function is used by each subcommand.
+// GetClient sets up the boot-service client with the boot-service base URI and
+// certificates (if necessary) and returns it. This function is used by each
+// subcommand.
 func GetClient(cmd *cobra.Command) *boot_service.BootServiceClient {
 	// Without a base URI, we cannot do anything
 	bootServiceBaseURI, err := cli.GetBaseURIBootService(cmd)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,7 +30,7 @@ import (
 type ServiceName string
 
 const (
-	ServiceBoot      ServiceName = ""
+	ServiceBoot      ServiceName = "boot-service"
 	ServiceBSS       ServiceName = "bss"
 	ServiceCloudInit ServiceName = "cloud-init"
 	ServicePCS       ServiceName = "pcs"
@@ -38,7 +38,7 @@ const (
 )
 
 const (
-	DefaultBasePathBootService = "/boot"
+	DefaultBasePathBootService = "/boot-service"
 	DefaultBasePathBSS         = "/boot/v1"
 	DefaultBasePathCloudInit   = "/cloud-init"
 	DefaultBasePathPCS         = "/"
@@ -278,6 +278,11 @@ func (ccc *ConfigClusterConfig) MergeURIConfig(c ConfigClusterConfig) ConfigClus
 		newCCC.BSS = ConfigClusterBSS{URI: c.BSS.URI}
 	} else {
 		newCCC.BSS.URI = compare(ccc.BSS.URI, c.BSS.URI)
+	}
+	if ccc.BootService == (ConfigClusterBootService{}) {
+		newCCC.BootService = ConfigClusterBootService{URI: c.BootService.URI}
+	} else {
+		newCCC.BootService.URI = compare(ccc.BootService.URI, c.BootService.URI)
 	}
 	if ccc.CloudInit == (ConfigClusterCloudInit{}) {
 		newCCC.CloudInit = ConfigClusterCloudInit{URI: c.CloudInit.URI}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -696,6 +696,63 @@ func TestConfigClusterConfig_GetServiceBaseURI(t *testing.T) {
 	}
 }
 
+func TestConfigClusterConfig_BootServiceBaseURIAndMerge(t *testing.T) {
+	t.Run("default boot-service path with cluster", func(t *testing.T) {
+		ccc := ConfigClusterConfig{URI: "https://cluster.local/api"}
+		got, err := ccc.GetServiceBaseURI(ServiceBoot)
+		if err != nil {
+			t.Fatalf("GetServiceBaseURI(ServiceBoot) unexpected error = %v", err)
+		}
+		want := "https://cluster.local/api" + DefaultBasePathBootService
+		if got != want {
+			t.Fatalf("GetServiceBaseURI(ServiceBoot) = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("absolute boot-service override", func(t *testing.T) {
+		ccc := ConfigClusterConfig{BootService: ConfigClusterBootService{URI: "https://boot.example.com/boot-service"}}
+		got, err := ccc.GetServiceBaseURI(ServiceBoot)
+		if err != nil {
+			t.Fatalf("GetServiceBaseURI(ServiceBoot) unexpected error = %v", err)
+		}
+		want := "https://boot.example.com/boot-service"
+		if got != want {
+			t.Fatalf("GetServiceBaseURI(ServiceBoot) = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("relative boot-service override with cluster", func(t *testing.T) {
+		ccc := ConfigClusterConfig{URI: "https://cluster.local/api", BootService: ConfigClusterBootService{URI: "/custom-boot"}}
+		got, err := ccc.GetServiceBaseURI(ServiceBoot)
+		if err != nil {
+			t.Fatalf("GetServiceBaseURI(ServiceBoot) unexpected error = %v", err)
+		}
+		want := "https://cluster.local/api/custom-boot"
+		if got != want {
+			t.Fatalf("GetServiceBaseURI(ServiceBoot) = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("merge boot-service URI", func(t *testing.T) {
+		old := ConfigClusterConfig{URI: "https://cluster.local", BootService: ConfigClusterBootService{URI: "/old-boot"}}
+		newCfg := ConfigClusterConfig{BootService: ConfigClusterBootService{URI: "/new-boot"}}
+		got := old.MergeURIConfig(newCfg)
+		if got.BootService.URI != "/new-boot" {
+			t.Fatalf("BootService.URI = %q, want /new-boot", got.BootService.URI)
+		}
+	})
+
+	t.Run("boot-service api version unmarshals", func(t *testing.T) {
+		var c ConfigClusterConfig
+		if err := yaml.Unmarshal([]byte("boot-service:\n  api-version: v1beta2\n"), &c); err != nil {
+			t.Fatalf("yaml.Unmarshal unexpected error = %v", err)
+		}
+		if c.BootService.APIVersion != "v1beta2" {
+			t.Fatalf("BootService.APIVersion = %q, want v1beta2", c.BootService.APIVersion)
+		}
+	})
+}
+
 func TestRemoveFromSlice(t *testing.T) {
 	type args struct {
 		slice []interface{}

--- a/man/ochami-boot.1.sc
+++ b/man/ochami-boot.1.sc
@@ -286,10 +286,10 @@ Subcommands for this command are as follows:
 		(automatic if any of
 		*--add*/*--remove*/*--set*/*--unset* are specified).
 
-*set* [-f _format_] < _file_++
-*set* [-f _format_] -d @_file_++
-*set* [-f _format_] -d @- < _file_++
-*set* [-f _format_] -d _data_
+*set* [-f _format_] _uid_ < _file_++
+*set* [-f _format_] -d @_file_ _uid_++
+*set* [-f _format_] -d @- _uid_ < _file_++
+*set* [-f _format_] -d _data_ _uid_
 	Set the specification of a BMC identified by _uid_. The entire
 	specification for the BMC is replaced with the specification that is passed.
 
@@ -466,10 +466,10 @@ Subcommands for this command are as follows:
 		(automatic if any of
 		*--add*/*--remove*/*--set*/*--unset* are specified).
 
-*set* [-f _format_] < _file_++
-*set* [-f _format_] -d @_file_++
-*set* [-f _format_] -d @- < _file_++
-*set* [-f _format_] -d _data_
+*set* [-f _format_] _uid_ < _file_++
+*set* [-f _format_] -d @_file_ _uid_++
+*set* [-f _format_] -d @- _uid_ < _file_++
+*set* [-f _format_] -d _data_ _uid_
 	Set the specification of a boot configuration identified by _uid_. The
 	entire specification for the boot configuration gets replaced with the
 	specification that is passed.
@@ -643,10 +643,10 @@ Subcommands for this command are as follows:
 		(automatic if any of
 		*--add*/*--remove*/*--set*/*--unset* are specified).
 
-*set* [-f _format_] < _file_++
-*set* [-f _format_] -d @_file_++
-*set* [-f _format_] -d @- < _file_++
-*set* [-f _format_] -d _data_
+*set* [-f _format_] _uid_ < _file_++
+*set* [-f _format_] -d @_file_ _uid_++
+*set* [-f _format_] -d @- _uid_ < _file_++
+*set* [-f _format_] -d _data_ _uid_
 	Set the specification of a node identified by _uid_. The entire
 	specification for the node is replaced with the specification that is
 	passed.

--- a/man/ochami-boot.1.sc
+++ b/man/ochami-boot.1.sc
@@ -156,14 +156,14 @@ Subcommands for this command are as follows:
 *add* [-f _format_] -d _data_
 	Add one or more BMC specifications to boot-service.
 
-	In the first form of the command, raw data is passed as an argument to be
-	the payload.
+	In the first and third forms of the command, data is read from standard
+	input.
 
 	In the second form of the command, a file containing the payload data is
 	passed.
 
-	In the third form of the command, the payload data is read from standard
-	input.
+	In the fourth form of the command, the payload is passed raw on the command
+	line.
 
 	This command sends a POST request to boot-service's BMC endpoint.
 
@@ -293,14 +293,14 @@ Subcommands for this command are as follows:
 	Set the specification of a BMC identified by _uid_. The entire
 	specification for the BMC is replaced with the specification that is passed.
 
-	In the first form of the command, raw data is passed as an argument to be
-	the payload.
+	In the first and third forms of the command, data is read from standard
+	input.
 
 	In the second form of the command, a file containing the payload data is
 	passed.
 
-	In the third form of the command, the payload data is read from standard
-	input.
+	In the fourth form of the command, the payload is passed raw on the command
+	line.
 
 	This command sends a PUT request to boot-service's BMC endpoint.
 
@@ -333,14 +333,14 @@ Subcommands for this command are as follows:
 	configuration already exists for the specified components, this command will
 	fail.
 
-	In the first form of the command, raw data is passed as an argument to be
-	the payload.
+	In the first and third forms of the command, data is read from standard
+	input.
 
 	In the second form of the command, a file containing the payload data is
 	passed.
 
-	In the third form of the command, the payload data is read from standard
-	input.
+	In the fourth form of the command, the payload is passed raw on the command
+	line.
 
 	This command sends a POST request to boot-service's /bootconfiguration
 	endpoint.
@@ -474,14 +474,14 @@ Subcommands for this command are as follows:
 	entire specification for the boot configuration gets replaced with the
 	specification that is passed.
 
-	In the first form of the command, raw data is passed as an argument to be
-	the payload.
+	In the first and third forms of the command, data is read from standard
+	input.
 
 	In the second form of the command, a file containing the payload data is
 	passed.
 
-	In the third form of the command, the payload data is read from standard
-	input.
+	In the fourth form of the command, the payload is passed raw on the command
+	line.
 
 	This command sends a PUT request to boot-service's /bootconfiguration/_uid_
 	endpoint.
@@ -513,14 +513,14 @@ Subcommands for this command are as follows:
 *add* [-f _format_] -d _data_
 	Add one or more nodes to boot-service.
 
-	In the first form of the command, raw data is passed as an argument to be
-	the payload.
+	In the first and third forms of the command, data is read from standard
+	input.
 
 	In the second form of the command, a file containing the payload data is
 	passed.
 
-	In the third form of the command, the payload data is read from standard
-	input.
+	In the fourth form of the command, the payload is passed raw on the command
+	line.
 
 	This command sends a POST request to boot-service's node endpoint.
 
@@ -651,14 +651,14 @@ Subcommands for this command are as follows:
 	specification for the node is replaced with the specification that is
 	passed.
 
-	In the first form of the command, raw data is passed as an argument to be
-	the payload.
+	In the first and third forms of the command, data is read from standard
+	input.
 
 	In the second form of the command, a file containing the payload data is
 	passed.
 
-	In the third form of the command, the payload data is read from standard
-	input.
+	In the fourth form of the command, the payload is passed raw on the command
+	line.
 
 	This command sends a PUT request to boot-service's node endpoint.
 

--- a/man/ochami-boot.1.sc
+++ b/man/ochami-boot.1.sc
@@ -438,9 +438,10 @@ Subcommands for this command are as follows:
 		(automatic if any of
 		*--add*/*--remove*/*--set*/*--unset* are specified).
 
-*set* -d _data_ [-f _format_] _uid_++
-*set* -d @_file_ [-f _format_] _uid_++
-*set* -d @- [-f _format_] _uid_ < _file_
+*set* [-f _format_] < _file_++
+*set* [-f _format_] -d @_file_++
+*set* [-f _format_] -d @- < _file_++
+*set* [-f _format_] -d _data_
 	Set the specification of a boot configuration identified by _uid_. The
 	entire specification for the boot configuration gets replaced with the
 	specification that is passed.

--- a/man/ochami-boot.1.sc
+++ b/man/ochami-boot.1.sc
@@ -614,9 +614,10 @@ Subcommands for this command are as follows:
 		(automatic if any of
 		*--add*/*--remove*/*--set*/*--unset* are specified).
 
-*set* -d _data_ [-f _format_] _uid_++
-*set* -d @_file_ [-f _format_] _uid_++
-*set* -d @- [-f _format_] _uid_ < _file_
+*set* [-f _format_] < _file_++
+*set* [-f _format_] -d @_file_++
+*set* [-f _format_] -d @- < _file_++
+*set* [-f _format_] -d _data_
 	Set the specification of a node identified by _uid_. The entire
 	specification for the node is replaced with the specification that is
 	passed.

--- a/man/ochami-boot.1.sc
+++ b/man/ochami-boot.1.sc
@@ -124,9 +124,10 @@ Manage BMCs stored in boot-service.
 
 Subcommands for this command are as follows:
 
-*add* -d _data_ [-f _format_]++
-*add* -d @_file_ [-f _format_]++
-*add* -d @- [-f _format_] < _file_
+*add* [-f _format_] < _file_++
+*add* [-f _format_] -d @_file_++
+*add* [-f _format_] -d @- < _file_++
+*add* [-f _format_] -d _data_
 	Add one or more BMC specifications to boot-service.
 
 	In the first form of the command, raw data is passed as an argument to be

--- a/man/ochami-boot.1.sc
+++ b/man/ochami-boot.1.sc
@@ -107,8 +107,8 @@ JSON form below:
 
 *--uri* _uri_
 	Specify either the absolute base URI for the service (e.g.
-	_https://foobar.openchami.cluster:8443/boot_) or a relative base path for
-	the service (e.g. _/boot_). If an absolute URI is specified, this
+	_https://foobar.openchami.cluster:8443/boot-service_) or a relative base path
+	for the service (e.g. _/boot-service_). If an absolute URI is specified, this
 	completely overrides any value set with the *--cluster-uri* flag or
 	*cluster.uri* in the config file for the cluster. If using an absolute URI,
 	it should contain the desired service's base path. If a relative path is

--- a/man/ochami-boot.1.sc
+++ b/man/ochami-boot.1.sc
@@ -6,10 +6,16 @@ ochami-boot - Communicate with the Boot Service
 
 # SYNOPSIS
 
-ochami boot bmc (add | delete | get | list | patch | set) [OPTIONS]++
-ochami boot config (add | delete | get | list | patch | set) [OPTIONS]++
-ochami boot node (add | delete | get | list | patch | set) [OPTIONS]++
-ochami boot service status [OPTIONS]
+*ochami boot* [_global-options_] _command_ [_command-options_] [_arguments_]
+
+*ochami boot* (*bmc* | *config* | *node*) *add* [-f _format_] [-d (_data_ | @_path_ | @-)]++
+*ochami boot* (*bmc* | *config* | *node*) *delete* [--no-confirm] _uid_...++
+*ochami boot* (*bmc* | *config* | *node*) *get* [-F _format_] _uid_++
+*ochami boot* (*bmc* | *config* | *node*) *list* [-F _format_]++
+*ochami boot* (*bmc* | *config* | *node*) *patch* [-f _format_] [-p _patch_method_] [-d (_data_ | @_path_ | @-)] _uid_++
+*ochami boot* (*bmc* | *config* | *node*) *patch* (--add _key_=_val_ | --remove _key_=_val_ | --set _key_=_val_ | --unset _key_)... _uid_++
+*ochami boot* (*bmc* | *config* | *node*) *set* [-f _format_] [-d (_data_ | @_path_ | @-)] _uid_++
+*ochami boot service status* [-F _format_]
 
 # DATA STRUCTURE
 
@@ -117,6 +123,26 @@ JSON form below:
 	cluster configuration options.
 
 # COMMANDS
+
+The *bmc*, *config*, and *node* commands share a common set of subcommands for
+creating, deleting, reading, listing, patching, and replacing boot-service
+resources. The *service* command provides operations for boot-service itself.
+
+[[ *Resource*
+:< *Subcommands*
+:< *Description*
+|  *bmc*
+:  *add*, *delete*, *get*, *list*, *patch*, *set*
+:  Manage BMC specifications
+|  *config*
+:  *add*, *delete*, *get*, *list*, *patch*, *set*
+:  Manage boot configurations
+|  *node*
+:  *add*, *delete*, *get*, *list*, *patch*, *set*
+:  Manage node specifications
+|  *service*
+:  *status*
+:  Check boot-service status
 
 ## bmc
 

--- a/man/ochami-boot.1.sc
+++ b/man/ochami-boot.1.sc
@@ -111,7 +111,7 @@ JSON form below:
 	base URI (set with the *--cluster-uri* flag or the *cluster.uri* cluster
 	config option), which is required to be set if a relative path is used here.
 
-	The boot service has no base path by default.
+	The boot service has a base path of */boot-service* by default.
 
 	See *ochami*(1) for *--cluster-uri* and *ochami-config*(5) for details on
 	cluster configuration options.

--- a/man/ochami-boot.1.sc
+++ b/man/ochami-boot.1.sc
@@ -376,8 +376,9 @@ Subcommands for this command are as follows:
 		- _yaml_
 
 *patch* ([--add _key_=_val_]... | [--remove _key_=_val_]... | [--set _key_=_val_]... | [--unset _key_]...) _uid_++
-*patch* [ -p _patch_method_] -d @_file_ [-f _format_] _uid_++
-*patch* [ -p _patch_method_] -d @- [-f _format_] _uid_ < _file_
+*patch* [ -f _format_] [ -p _patch_method_] -d @_file_ _uid_++
+*patch* [ -f _format_] [ -p _patch_method_] -d @- _uid_ < _file_++
+*patch* [ -f _format_] [ -p _patch_method_] _uid_ < _file_
 	Using various patch methods, patch specification for an existing boot
 	configuration identified by _uid_.
 
@@ -391,8 +392,8 @@ Subcommands for this command are as follows:
 	uses add/remove/set/unset flags to perform the patch. For _key_, dot
 	notation is used for subkeys (e.g. _key.subkey_).
 
-	In the second and third forms of the command, patch data is supplied along
-	with an optional *--patch-method* flag to specify the patch method.
+	In the second through fourth forms of the command, patch data is supplied
+	along with an optional *--patch-method* flag to specify the patch method.
 
 	This command sends a PATCH request to boot-service's
 	/bootconfiguration/_uid_ endpoint.
@@ -411,8 +412,8 @@ Subcommands for this command are as follows:
 		to change it.
 
 	*-f, --format-input* _format_
-		Format of raw data being used by *-d* as the payload. Supported formats
-		are:
+		Format of raw data being used by stdin/*-d* as the payload. Supported
+		formats are:
 
 		- _json_ (default)
 		- _yaml_

--- a/man/ochami-boot.1.sc
+++ b/man/ochami-boot.1.sc
@@ -554,8 +554,9 @@ Subcommands for this command are as follows:
 		- _yaml_
 
 *patch* ([--add _key_=_val_]... | [--remove _key_=_val_]... | [--set _key_=_val_]... | [--unset _key_]...) _uid_++
-*patch* [ -p _patch_method_] -d @_file_ [-f _format_] _uid_++
-*patch* [ -p _patch_method_] -d @- [-f _format_] _uid_ < _file_
+*patch* [ -f _format_] [ -p _patch_method_] -d @_file_ _uid_++
+*patch* [ -f _format_] [ -p _patch_method_] -d @- _uid_ < _file_++
+*patch* [ -f _format_] [ -p _patch_method_] _uid_ < _file_
 	Using various patch methods, patch the specification for an existing node
 	identified by _uid_.
 
@@ -569,8 +570,8 @@ Subcommands for this command are as follows:
 	uses add/remove/set/unset flags to perform the patch. For _key_, dot
 	notation is used for subkeys (e.g. _key.subkey_).
 
-	In the second and third forms of the command, patch data is supplied along
-	with an optional *--patch-method* flag to specify the patch method.
+	In the second through fourth forms of the command, patch data is supplied
+	along with an optional *--patch-method* flag to specify the patch method.
 
 	This command sends a PATCH request to boot-service's node endpoint.
 
@@ -588,8 +589,8 @@ Subcommands for this command are as follows:
 		to change it.
 
 	*-f, --format-input* _format_
-		Format of raw data being used by *-d* as the payload. Supported formats
-		are:
+		Format of raw data being used by stdin/*-d* as the payload. Supported
+		formats are:
 
 		- _json_ (default)
 		- _yaml_

--- a/man/ochami-boot.1.sc
+++ b/man/ochami-boot.1.sc
@@ -197,8 +197,9 @@ Subcommands for this command are as follows:
 		- _yaml_
 
 *patch* ([--add _key_=_val_]... | [--remove _key_=_val_]... | [--set _key_=_val_]... | [--unset _key_]...) _uid_++
-*patch* [ -p _patch_method_] -d @_file_ [-f _format_] _uid_++
-*patch* [ -p _patch_method_] -d @- [-f _format_] _uid_ < _file_
+*patch* [ -f _format_] [ -p _patch_method_] -d @_file_ _uid_++
+*patch* [ -f _format_] [ -p _patch_method_] -d @- _uid_ < _file_++
+*patch* [ -f _format_] [ -p _patch_method_] _uid_ < _file_
 	Using various patch methods, patch the specification for an existing BMC
 	identified by _uid_.
 
@@ -212,8 +213,8 @@ Subcommands for this command are as follows:
 	uses add/remove/set/unset flags to perform the patch. For _key_, dot
 	notation is used for subkeys (e.g. _key.subkey_).
 
-	In the second and third forms of the command, patch data is supplied along
-	with an optional *--patch-method* flag to specify the patch method.
+	In the second through fourth forms of the command, patch data is supplied
+	along with an optional *--patch-method* flag to specify the patch method.
 
 	This command sends a PATCH request to boot-service's BMC endpoint.
 
@@ -231,8 +232,8 @@ Subcommands for this command are as follows:
 		to change it.
 
 	*-f, --format-input* _format_
-		Format of raw data being used by *-d* as the payload. Supported formats
-		are:
+		Format of raw data being used by stdin/*-d* as the payload. Supported
+		formats are:
 
 		- _json_ (default)
 		- _yaml_

--- a/man/ochami-boot.1.sc
+++ b/man/ochami-boot.1.sc
@@ -259,9 +259,10 @@ Subcommands for this command are as follows:
 		(automatic if any of
 		*--add*/*--remove*/*--set*/*--unset* are specified).
 
-*set* -d _data_ [-f _format_] _uid_++
-*set* -d @_file_ [-f _format_] _uid_++
-*set* -d @- [-f _format_] _uid_ < _file_
+*set* [-f _format_] < _file_++
+*set* [-f _format_] -d @_file_++
+*set* [-f _format_] -d @- < _file_++
+*set* [-f _format_] -d _data_
 	Set the specification of a BMC identified by _uid_. The entire
 	specification for the BMC is replaced with the specification that is passed.
 

--- a/man/ochami-boot.1.sc
+++ b/man/ochami-boot.1.sc
@@ -479,9 +479,10 @@ Manage nodes stored in boot-service.
 
 Subcommands for this command are as follows:
 
-*add* -d _data_ [-f _format_]++
-*add* -d @_file_ [-f _format_]++
-*add* -d @- [-f _format_] < _file_
+*add* [-f _format_] < _file_++
+*add* [-f _format_] -d @_file_++
+*add* [-f _format_] -d @- < _file_++
+*add* [-f _format_] -d _data_
 	Add one or more nodes to boot-service.
 
 	In the first form of the command, raw data is passed as an argument to be

--- a/man/ochami-boot.1.sc
+++ b/man/ochami-boot.1.sc
@@ -298,9 +298,10 @@ Manage boot configurations stored in the boot service.
 
 Subcommands for this command are as follows:
 
-*add* -d _data_ [-f _format_]++
-*add* -d @_file_ [-f _format_]++
-*add* -d @- [-f _format_] < _file_
+*add* [-f _format_] < _file_++
+*add* [-f _format_] -d @_file_++
+*add* [-f _format_] -d @- < _file_++
+*add* [-f _format_] -d _data_
 	Add new boot configuration to be able to be used by nodes. If boot
 	configuration already exists for the specified components, this command will
 	fail.

--- a/man/ochami-config.5.sc
+++ b/man/ochami-config.5.sc
@@ -187,7 +187,7 @@ clusters:
     - cluster:
         boot-service:
           api-version: v1beta2
-          uri: https://localhost:27776/boot
+          uri: https://localhost:27776/boot-service
         bss:
           uri: https://localhost:27778/boot/v1
         cloud-init:


### PR DESCRIPTION
### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [x] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass  
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Description

This is a hodgepodge of small fixes to issues that were discovered in boot service commands/libraries/docs while implementing the up-and-coming metadata-service commands. They include:

- URI path merging for boot service (`--uri` and `--cluster-uri`), which was not occurring
- Changing default URI path from `/boot` to `/boot-service` to match default release config
- Fix spacing in multiline data to be consistent in command examples
- Remove `-d`/`--data` requirement when passing data to stdin (the flag was formerly necessary when passing data to stdin)
- Fix `--no-confirm` behavior:
  - Perform check before any client actions occur (e.g. don't ask for token until confirmed)
  - Ensure `--no-confirm=false` does not automatically comfirm
  - Add missing checks to some commands
- Clarify documentation:
  - `boot bmc add` can add more than one BMC at a time
  - Correct `--patch-format` to `--patch-format`
  - Add missing `_uid_` to `set` commands in **ochami-boot**(1)
- Add unit tests for boot-service config options

### Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
