### PR TITLE
fix: deletion confirmation order in `bss`, `cloud-init`, and `smd`

### DIFF
--- a/cmd/bss/boot/params/delete.go
+++ b/cmd/bss/boot/params/delete.go
@@ -84,12 +84,6 @@ See ochami-bss(1) for more details.`,
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			// Create client to use for requests
-			bssClient := bss_lib.GetClient(cmd)
-
-			// Handle token for this command
-			cli.HandleToken(cmd)
-
 			// The BSS BootParams struct we will send
 			bp := bssTypes.BootParams{}
 
@@ -155,7 +149,12 @@ See ochami-bss(1) for more details.`,
 			}
 
 			// Ask before attempting deletion unless --no-confirm was passed
-			if !cmd.Flag("no-confirm").Changed {
+			noConfirm, err := cmd.Flags().GetBool("no-confirm")
+			if err != nil {
+				log.Logger.Error().Err(err).Msg("failed to get --no-confirm")
+				os.Exit(1)
+			}
+			if !noConfirm {
 				log.Logger.Debug().Msg("--no-confirm not passed, prompting user to confirm deletion")
 				respDelete, err := cli.Ios.LoopYesNo("Really delete?")
 				if err != nil {
@@ -168,6 +167,12 @@ See ochami-bss(1) for more details.`,
 					log.Logger.Debug().Msg("User answered affirmatively to delete boot parameters")
 				}
 			}
+
+			// Create client to use for requests
+			bssClient := bss_lib.GetClient(cmd)
+
+			// Handle token for this command
+			cli.HandleToken(cmd)
 
 			// Send 'em off
 			_, err = bssClient.DeleteBootParams(bp, cli.Token)

--- a/cmd/cloud_init/group/delete.go
+++ b/cmd/cloud_init/group/delete.go
@@ -64,12 +64,6 @@ See ochami-cloud-init(1) for more details.`,
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			// Create client to use for requests
-			cloudInitClient := cloud_init_lib.GetClient(cmd)
-
-			// Handle token for this command
-			cli.HandleToken(cmd)
-
 			// The group data we will send
 			ciGroups := []cistore.GroupData{}
 
@@ -85,7 +79,12 @@ See ochami-cloud-init(1) for more details.`,
 			}
 
 			// Ask before attempting deletion unless --no-confirm was passed
-			if !cmd.Flag("no-confirm").Changed {
+			noConfirm, err := cmd.Flags().GetBool("no-confirm")
+			if err != nil {
+				log.Logger.Error().Err(err).Msg("failed to get --no-confirm")
+				os.Exit(1)
+			}
+			if !noConfirm {
 				log.Logger.Debug().Msg("--no-confirm not passed, prompting user to confirm deletion")
 				respDelete, err := cli.Ios.LoopYesNo("Really delete?")
 				if err != nil {
@@ -98,6 +97,12 @@ See ochami-cloud-init(1) for more details.`,
 					log.Logger.Debug().Msg("User answered affirmatively to delete cloud-init groups")
 				}
 			}
+
+			// Create client to use for requests
+			cloudInitClient := cloud_init_lib.GetClient(cmd)
+
+			// Handle token for this command
+			cli.HandleToken(cmd)
 
 			// Send data
 			_, errs, err := cloudInitClient.DeleteGroups(cli.Token, groupsToDel...)

--- a/cmd/smd/compep/delete.go
+++ b/cmd/smd/compep/delete.go
@@ -68,14 +68,13 @@ See ochami-smd(1) for more details.`,
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			// Create client to use for requests
-			smdClient := smd_lib.GetClient(cmd)
-
-			// Handle token for this command
-			cli.HandleToken(cmd)
-
 			// Ask before attempting deletion unless --no-confirm was passed
-			if !cmd.Flag("no-confirm").Changed {
+			noConfirm, err := cmd.Flags().GetBool("no-confirm")
+			if err != nil {
+				log.Logger.Error().Err(err).Msg("failed to get --no-confirm")
+				os.Exit(1)
+			}
+			if !noConfirm {
 				log.Logger.Debug().Msg("--no-confirm not passed, prompting user to confirm deletion")
 				var respDelete bool
 				var err error
@@ -94,6 +93,12 @@ See ochami-smd(1) for more details.`,
 					log.Logger.Debug().Msg("User answered affirmatively to delete component endpoints")
 				}
 			}
+
+			// Create client to use for requests
+			smdClient := smd_lib.GetClient(cmd)
+
+			// Handle token for this command
+			cli.HandleToken(cmd)
 
 			// Create list of xnames to delete
 			var ceSlice []sm.ComponentEndpoint

--- a/cmd/smd/component/delete.go
+++ b/cmd/smd/component/delete.go
@@ -71,14 +71,13 @@ See ochami-smd(1) for more details.`,
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			// Create client to use for requests
-			smdClient := smd_lib.GetClient(cmd)
-
-			// Handle token for this command
-			cli.HandleToken(cmd)
-
 			// Ask before attempting deletion unless --no-confirm was passed
-			if !cmd.Flag("no-confirm").Changed {
+			noConfirm, err := cmd.Flags().GetBool("no-confirm")
+			if err != nil {
+				log.Logger.Error().Err(err).Msg("failed to get --no-confirm")
+				os.Exit(1)
+			}
+			if !noConfirm {
 				log.Logger.Debug().Msg("--no-confirm not passed, prompting user to confirm deletion")
 				var respDelete bool
 				var err error
@@ -97,6 +96,12 @@ See ochami-smd(1) for more details.`,
 					log.Logger.Debug().Msg("User answered affirmatively to delete components")
 				}
 			}
+
+			// Create client to use for requests
+			smdClient := smd_lib.GetClient(cmd)
+
+			// Handle token for this command
+			cli.HandleToken(cmd)
 
 			// Create list of xnames to delete
 			var compSlice smd.ComponentSlice

--- a/cmd/smd/group/delete.go
+++ b/cmd/smd/group/delete.go
@@ -67,14 +67,13 @@ See ochami-smd(1) for more details.`,
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			// Create client to use for requests
-			smdClient := smd_lib.GetClient(cmd)
-
-			// Handle token for this command
-			cli.HandleToken(cmd)
-
 			// Ask before attempting deletion unless --no-confirm was passed
-			if !cmd.Flag("no-confirm").Changed {
+			noConfirm, err := cmd.Flags().GetBool("no-confirm")
+			if err != nil {
+				log.Logger.Error().Err(err).Msg("failed to get --no-confirm")
+				os.Exit(1)
+			}
+			if !noConfirm {
 				log.Logger.Debug().Msg("--no-confirm not passed, prompting user to confirm deletion")
 				respDelete, err := cli.Ios.LoopYesNo("Really delete?")
 				if err != nil {
@@ -87,6 +86,12 @@ See ochami-smd(1) for more details.`,
 					log.Logger.Debug().Msg("User answered affirmatively to delete groups")
 				}
 			}
+
+			// Create client to use for requests
+			smdClient := smd_lib.GetClient(cmd)
+
+			// Handle token for this command
+			cli.HandleToken(cmd)
 
 			// Create list of group labels to delete
 			var groups []smd.Group

--- a/cmd/smd/group/member/delete.go
+++ b/cmd/smd/group/member/delete.go
@@ -29,14 +29,13 @@ func newCmdGroupMemberDelete() *cobra.Command {
 See ochami-smd(1) for more details.`,
 		Example: `  ochami smd group member delete compute x3000c1s7b56n0`,
 		Run: func(cmd *cobra.Command, args []string) {
-			// Create client to use for requests
-			smdClient := smd_lib.GetClient(cmd)
-
-			// Handle token for this command
-			cli.HandleToken(cmd)
-
 			// Ask before attempting deletion unless --no-confirm was passed
-			if !cmd.Flag("no-confirm").Changed {
+			noConfirm, err := cmd.Flags().GetBool("no-confirm")
+			if err != nil {
+				log.Logger.Error().Err(err).Msg("failed to get --no-confirm")
+				os.Exit(1)
+			}
+			if !noConfirm {
 				log.Logger.Debug().Msg("--no-confirm not passed, prompting user to confirm deletion")
 				respDelete, err := cli.Ios.LoopYesNo("Really delete?")
 				if err != nil {
@@ -49,6 +48,12 @@ See ochami-smd(1) for more details.`,
 					log.Logger.Debug().Msg("User answered affirmatively to delete groups members")
 				}
 			}
+
+			// Create client to use for requests
+			smdClient := smd_lib.GetClient(cmd)
+
+			// Handle token for this command
+			cli.HandleToken(cmd)
 
 			// Perform deletion from arguments
 			_, errs, err := smdClient.DeleteGroupMembers(cli.Token, args[0], args[1:]...)

--- a/cmd/smd/iface/delete.go
+++ b/cmd/smd/iface/delete.go
@@ -68,14 +68,13 @@ See ochami-smd(1) for more details.`,
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			// Create client to use for requests
-			smdClient := smd_lib.GetClient(cmd)
-
-			// Handle token for this command
-			cli.HandleToken(cmd)
-
 			// Ask before attempting deletion unless --no-confirm was passed
-			if !cmd.Flag("no-confirm").Changed {
+			noConfirm, err := cmd.Flags().GetBool("no-confirm")
+			if err != nil {
+				log.Logger.Error().Err(err).Msg("failed to get --no-confirm")
+				os.Exit(1)
+			}
+			if !noConfirm {
 				log.Logger.Debug().Msg("--no-confirm not passed, prompting user to confirm deletion")
 				var respDelete bool
 				var err error
@@ -94,6 +93,12 @@ See ochami-smd(1) for more details.`,
 					log.Logger.Debug().Msg("User answered affirmatively to delete ethernet interfaces")
 				}
 			}
+
+			// Create client to use for requests
+			smdClient := smd_lib.GetClient(cmd)
+
+			// Handle token for this command
+			cli.HandleToken(cmd)
 
 			// Create list of ethernet interface IDs to delete
 			var eiSlice []smd.EthernetInterface

--- a/cmd/smd/rfe/delete.go
+++ b/cmd/smd/rfe/delete.go
@@ -68,14 +68,13 @@ See ochami-smd(1) for more details.`,
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			// Create client to use for requests
-			smdClient := smd_lib.GetClient(cmd)
-
-			// Handle token for this command
-			cli.HandleToken(cmd)
-
 			// Ask before attempting deletion unless --no-confirm was passed
-			if !cmd.Flag("no-confirm").Changed {
+			noConfirm, err := cmd.Flags().GetBool("no-confirm")
+			if err != nil {
+				log.Logger.Error().Err(err).Msg("failed to get --no-confirm")
+				os.Exit(1)
+			}
+			if !noConfirm {
 				log.Logger.Debug().Msg("--no-confirm not passed, prompting user to confirm deletion")
 				var respDelete bool
 				var err error
@@ -94,6 +93,12 @@ See ochami-smd(1) for more details.`,
 					log.Logger.Debug().Msg("User answered affirmatively to delete redfish endpoints")
 				}
 			}
+
+			// Create client to use for requests
+			smdClient := smd_lib.GetClient(cmd)
+
+			// Handle token for this command
+			cli.HandleToken(cmd)
 
 			// Create list of xnames to delete
 			var rfeSlice smd.RedfishEndpointSlice


### PR DESCRIPTION
### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [ ] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass  
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Description

Move `--no-confirm` check for `delete` subcommands for `bss`, `cloud-init`, and `smd` commands to the top of the command logic to prompt the user before client actions are taken. This means the user will be prompted to confirm deletion before the token is handled.

### Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
