### PR TITLE
fix(cmd/boot): support array patch operations for boot resources

### DIFF
--- a/cmd/boot/bmc/patch.go
+++ b/cmd/boot/bmc/patch.go
@@ -77,17 +77,19 @@ See ochami-boot(1) for more details.`,
 			// Handle token for this command
 			cli.HandleToken(cmd)
 
-			var patchData map[string]interface{}
+			var patchData interface{}
+			patchMethod := formatPatch
 			if cmd.Flag("set").Changed || cmd.Flag("unset").Changed || cmd.Flag("add").Changed || cmd.Flag("remove").Changed {
-				if cmd.Flag("patch-method").Changed && formatPatch != client.PatchMethodKeyVal {
-					log.Logger.Warn().Msg("overriding --patch-method since --set/--unset/--add/--remove was passed")
-				}
-
-				pd, err := client.NewKeyValPatch(setList, unsetList, addList, removeList)
+				oldFormatPatch := patchMethod
+				newPatchMethod, pd, err := client.NewKeyValPatchData(setList, unsetList, addList, removeList)
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("error creating key-value patch data")
 					cli.LogHelpError(cmd)
 					os.Exit(1)
+				}
+				patchMethod = newPatchMethod
+				if cmd.Flag("patch-method").Changed && oldFormatPatch != patchMethod {
+					log.Logger.Warn().Msg("overriding --patch-method since --set/--unset/--add/--remove was passed")
 				}
 				patchData = pd
 			} else {
@@ -98,7 +100,7 @@ See ochami-boot(1) for more details.`,
 				}
 			}
 
-			bmcPatched, err := bootServiceClient.PatchBMC(cli.Token, formatPatch, args[0], patchData)
+			bmcPatched, err := bootServiceClient.PatchBMC(cli.Token, patchMethod, args[0], patchData)
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to patch BMC")
 				cli.LogHelpError(cmd)
@@ -113,7 +115,7 @@ See ochami-boot(1) for more details.`,
 	bootBmcPatchCmd.Flags().StringArrayVar(&setList, "set", nil, "set field value using dot notation (field=value)")
 	bootBmcPatchCmd.Flags().StringArrayVar(&unsetList, "unset", nil, "unset field using dot notation")
 	bootBmcPatchCmd.Flags().StringArrayVar(&addList, "add", nil, "add value to array field (field=value)")
-	bootBmcPatchCmd.Flags().StringArrayVar(&removeList, "remove", nil, "remove value from array field (field=value)")
+	bootBmcPatchCmd.Flags().StringArrayVar(&removeList, "remove", nil, "remove value from array field by index (field=index)")
 	bootBmcPatchCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
 	bootBmcPatchCmd.Flags().VarP(&cli.FormatInput, "format-input", "f", "format of input payload data for JSON patch formats (json,json-pretty,yaml)")
 	bootBmcPatchCmd.Flags().VarP(&formatPatch, "patch-method", "p", "type of patch to use (rfc6902,rfc7386,keyval)")

--- a/cmd/boot/config/patch.go
+++ b/cmd/boot/config/patch.go
@@ -78,17 +78,19 @@ See ochami-boot(1) for more details.`,
 			// Handle token for this command
 			cli.HandleToken(cmd)
 
-			var patchData map[string]interface{}
+			var patchData interface{}
+			patchMethod := formatPatch
 			if cmd.Flag("set").Changed || cmd.Flag("unset").Changed || cmd.Flag("add").Changed || cmd.Flag("remove").Changed {
-				if cmd.Flag("patch-method").Changed && formatPatch != client.PatchMethodKeyVal {
-					log.Logger.Warn().Msg("overriding --patch-method since --set/--unset/--add/--remove was passed")
-				}
-
-				pd, err := client.NewKeyValPatch(setList, unsetList, addList, removeList)
+				oldFormatPatch := patchMethod
+				newPatchMethod, pd, err := client.NewKeyValPatchData(setList, unsetList, addList, removeList)
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("error creating key-value patch data")
 					cli.LogHelpError(cmd)
 					os.Exit(1)
+				}
+				patchMethod = newPatchMethod
+				if cmd.Flag("patch-method").Changed && oldFormatPatch != patchMethod {
+					log.Logger.Warn().Msg("overriding --patch-method since --set/--unset/--add/--remove was passed")
 				}
 				patchData = pd
 			} else {
@@ -99,7 +101,7 @@ See ochami-boot(1) for more details.`,
 				}
 			}
 
-			cfgPatched, err := bootServiceClient.PatchBootConfig(cli.Token, formatPatch, args[0], patchData)
+			cfgPatched, err := bootServiceClient.PatchBootConfig(cli.Token, patchMethod, args[0], patchData)
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to patch boot configuration")
 				cli.LogHelpError(cmd)
@@ -114,7 +116,7 @@ See ochami-boot(1) for more details.`,
 	bootConfigPatchCmd.Flags().StringArrayVar(&setList, "set", nil, "set field value using dot notation (field=value)")
 	bootConfigPatchCmd.Flags().StringArrayVar(&unsetList, "unset", nil, "unset field using dot notation")
 	bootConfigPatchCmd.Flags().StringArrayVar(&addList, "add", nil, "add value to array field (field=value)")
-	bootConfigPatchCmd.Flags().StringArrayVar(&removeList, "remove", nil, "remove value from array field (field=value)")
+	bootConfigPatchCmd.Flags().StringArrayVar(&removeList, "remove", nil, "remove value from array field by index (field=index)")
 	bootConfigPatchCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
 	bootConfigPatchCmd.Flags().VarP(&cli.FormatInput, "format-input", "f", "format of input payload data for JSON patch formats (json,json-pretty,yaml)")
 	bootConfigPatchCmd.Flags().VarP(&formatPatch, "patch-method", "p", "type of patch to use (rfc6902,rfc7386,keyval)")

--- a/cmd/boot/node/patch.go
+++ b/cmd/boot/node/patch.go
@@ -78,17 +78,19 @@ See ochami-boot(1) for more details.`,
 			// Handle token for this command
 			cli.HandleToken(cmd)
 
-			var patchData map[string]interface{}
+			var patchData interface{}
+			patchMethod := formatPatch
 			if cmd.Flag("set").Changed || cmd.Flag("unset").Changed || cmd.Flag("add").Changed || cmd.Flag("remove").Changed {
-				if cmd.Flag("patch-method").Changed && formatPatch != client.PatchMethodKeyVal {
-					log.Logger.Warn().Msg("overriding --patch-method since --set/--unset/--add/--remove was passed")
-				}
-
-				pd, err := client.NewKeyValPatch(setList, unsetList, addList, removeList)
+				oldFormatPatch := patchMethod
+				newPatchMethod, pd, err := client.NewKeyValPatchData(setList, unsetList, addList, removeList)
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("error creating key-value patch data")
 					cli.LogHelpError(cmd)
 					os.Exit(1)
+				}
+				patchMethod = newPatchMethod
+				if cmd.Flag("patch-method").Changed && oldFormatPatch != patchMethod {
+					log.Logger.Warn().Msg("overriding --patch-method since --set/--unset/--add/--remove was passed")
 				}
 				patchData = pd
 			} else {
@@ -99,7 +101,7 @@ See ochami-boot(1) for more details.`,
 				}
 			}
 
-			nodePatched, err := bootServiceClient.PatchNode(cli.Token, formatPatch, args[0], patchData)
+			nodePatched, err := bootServiceClient.PatchNode(cli.Token, patchMethod, args[0], patchData)
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to patch node")
 				cli.LogHelpError(cmd)
@@ -114,7 +116,7 @@ See ochami-boot(1) for more details.`,
 	bootNodePatchCmd.Flags().StringArrayVar(&setList, "set", nil, "set field value using dot notation (field=value)")
 	bootNodePatchCmd.Flags().StringArrayVar(&unsetList, "unset", nil, "unset field using dot notation")
 	bootNodePatchCmd.Flags().StringArrayVar(&addList, "add", nil, "add value to array field (field=value)")
-	bootNodePatchCmd.Flags().StringArrayVar(&removeList, "remove", nil, "remove value from array field (field=value)")
+	bootNodePatchCmd.Flags().StringArrayVar(&removeList, "remove", nil, "remove value from array field by index (field=index)")
 	bootNodePatchCmd.Flags().StringP("data", "d", "", "payload data or (if starting with @) file containing payload data (can be - to read from stdin)")
 	bootNodePatchCmd.Flags().VarP(&cli.FormatInput, "format-input", "f", "format of input payload data for JSON patch formats (json,json-pretty,yaml)")
 	bootNodePatchCmd.Flags().VarP(&formatPatch, "patch-method", "p", "type of patch to use (rfc6902,rfc7386,keyval)")

--- a/man/ochami-boot.1.sc
+++ b/man/ochami-boot.1.sc
@@ -13,7 +13,7 @@ ochami-boot - Communicate with the Boot Service
 *ochami boot* (*bmc* | *config* | *node*) *get* [-F _format_] _uid_++
 *ochami boot* (*bmc* | *config* | *node*) *list* [-F _format_]++
 *ochami boot* (*bmc* | *config* | *node*) *patch* [-f _format_] [-p _patch_method_] [-d (_data_ | @_path_ | @-)] _uid_++
-*ochami boot* (*bmc* | *config* | *node*) *patch* (--add _key_=_val_ | --remove _key_=_val_ | --set _key_=_val_ | --unset _key_)... _uid_++
+*ochami boot* (*bmc* | *config* | *node*) *patch* (--add _key_=_val_ | --remove _key_=_index_ | --set _key_=_val_ | --unset _key_)... _uid_++
 *ochami boot* (*bmc* | *config* | *node*) *set* [-f _format_] [-d (_data_ | @_path_ | @-)] _uid_++
 *ochami boot service status* [-F _format_]
 
@@ -222,10 +222,11 @@ Subcommands for this command are as follows:
 		- _json-pretty_
 		- _yaml_
 
-*patch* ([--add _key_=_val_]... | [--remove _key_=_val_]... | [--set _key_=_val_]... | [--unset _key_]...) _uid_++
-*patch* [ -f _format_] [ -p _patch_method_] -d @_file_ _uid_++
-*patch* [ -f _format_] [ -p _patch_method_] -d @- _uid_ < _file_++
-*patch* [ -f _format_] [ -p _patch_method_] _uid_ < _file_
+*patch* ([--add _key_=_val_]... | [--remove _key_=_index_]... | [--set _key_=_val_]... | [--unset _key_]...) _uid_++
+*patch* [-f _format_] [-p _patch_method_] -d _data_ _uid_++
+*patch* [-f _format_] [-p _patch_method_] -d @_file_ _uid_++
+*patch* [-f _format_] [-p _patch_method_] -d @- _uid_ < _file_++
+*patch* [-f _format_] [-p _patch_method_] _uid_ < _file_
 	Using various patch methods, patch the specification for an existing BMC
 	identified by _uid_.
 
@@ -239,7 +240,7 @@ Subcommands for this command are as follows:
 	uses add/remove/set/unset flags to perform the patch. For _key_, dot
 	notation is used for subkeys (e.g. _key.subkey_).
 
-	In the second through fourth forms of the command, patch data is supplied
+	In the second through fifth forms of the command, patch data is supplied
 	along with an optional *--patch-method* flag to specify the patch method.
 
 	This command sends a PATCH request to boot-service's BMC endpoint.
@@ -247,8 +248,8 @@ Subcommands for this command are as follows:
 	This command accepts the following options:
 
 	*--add* _key_[[._subkey_]...]=_val_
-		Add value to array field, creating the field if necessary. Only can be
-		used with _keyval_ patch method (automatic if any of
+		Append value to an existing array field using an RFC 6902 add operation.
+		Only can be used with key/value patch flags (automatic if any of
 		*--add*/*--remove*/*--set*/*--unset* are specified).
 
 	*-d, --data* (_data_ | @_path_ | @-)
@@ -271,18 +272,18 @@ Subcommands for this command are as follows:
 		- _rfc6902_: RFC 6902 JSON Patch
 		- _keyval_: key=value format using dot notation for subkeys
 
-	*--remove* _key_[[._subkey_]...]=_val_
-		Remove value from array field. Only can be used with _keyval_ patch
-		method (automatic if any of
+	*--remove* _key_[[._subkey_]...]=_index_
+		Remove value at _index_ from array field using an RFC 6902 remove
+		operation. Only can be used with key/value patch flags (automatic if any of
 		*--add*/*--remove*/*--set*/*--unset* are specified).
 
 	*--set* _key_[[._subkey_]...]=_val_
 		Set key with its value, overwriting any previous value and creating if the
-		key doesn't exist. Only can be used with _keyval_ patch method (automatic
+		key doesn't exist. Only can be used with key/value patch flags (automatic
 		if any of *--add*/*--remove*/*--set*/*--unset* are specified).
 
 	*--unset* _key_[[._subkey_]...]
-		Unset key (and its value). Only can be used with _keyval_ patch method
+		Unset key (and its value). Only can be used with key/value patch flags
 		(automatic if any of
 		*--add*/*--remove*/*--set*/*--unset* are specified).
 
@@ -401,10 +402,11 @@ Subcommands for this command are as follows:
 		- _json-pretty_
 		- _yaml_
 
-*patch* ([--add _key_=_val_]... | [--remove _key_=_val_]... | [--set _key_=_val_]... | [--unset _key_]...) _uid_++
-*patch* [ -f _format_] [ -p _patch_method_] -d @_file_ _uid_++
-*patch* [ -f _format_] [ -p _patch_method_] -d @- _uid_ < _file_++
-*patch* [ -f _format_] [ -p _patch_method_] _uid_ < _file_
+*patch* ([--add _key_=_val_]... | [--remove _key_=_index_]... | [--set _key_=_val_]... | [--unset _key_]...) _uid_++
+*patch* [-f _format_] [-p _patch_method_] -d _data_ _uid_++
+*patch* [-f _format_] [-p _patch_method_] -d @_file_ _uid_++
+*patch* [-f _format_] [-p _patch_method_] -d @- _uid_ < _file_++
+*patch* [-f _format_] [-p _patch_method_] _uid_ < _file_
 	Using various patch methods, patch specification for an existing boot
 	configuration identified by _uid_.
 
@@ -418,7 +420,7 @@ Subcommands for this command are as follows:
 	uses add/remove/set/unset flags to perform the patch. For _key_, dot
 	notation is used for subkeys (e.g. _key.subkey_).
 
-	In the second through fourth forms of the command, patch data is supplied
+	In the second through fifth forms of the command, patch data is supplied
 	along with an optional *--patch-method* flag to specify the patch method.
 
 	This command sends a PATCH request to boot-service's
@@ -427,8 +429,8 @@ Subcommands for this command are as follows:
 	This command accepts the following options:
 
 	*--add* _key_[[._subkey_]...]=_val_
-		Add value to array field, creating the field if necessary. Only can be
-		used with _keyval_ patch method (automatic if any of
+		Append value to an existing array field using an RFC 6902 add operation.
+		Only can be used with key/value patch flags (automatic if any of
 		*--add*/*--remove*/*--set*/*--unset* are specified).
 
 	*-d, --data* (_data_ | @_path_ | @-)
@@ -451,18 +453,18 @@ Subcommands for this command are as follows:
 		- _rfc6902_: RFC 6902 JSON Patch
 		- _keyval_: key=value format using dot notation for subkeys
 
-	*--remove* _key_[[._subkey_]...]=_val_
-		Remove value from array field. Only can be used with _keyval_ patch
-		method (automatic if any of
+	*--remove* _key_[[._subkey_]...]=_index_
+		Remove value at _index_ from array field using an RFC 6902 remove
+		operation. Only can be used with key/value patch flags (automatic if any of
 		*--add*/*--remove*/*--set*/*--unset* are specified).
 
 	*--set* _key_[[._subkey_]...]=_val_
 		Set key with its value, overwriting any previous value and creating if the
-		key doesn't exist. Only can be used with _keyval_ patch method (automatic
+		key doesn't exist. Only can be used with key/value patch flags (automatic
 		if any of *--add*/*--remove*/*--set*/*--unset* are specified).
 
 	*--unset* _key_[[._subkey_]...]
-		Unset key (and its value). Only can be used with _keyval_ patch method
+		Unset key (and its value). Only can be used with key/value patch flags
 		(automatic if any of
 		*--add*/*--remove*/*--set*/*--unset* are specified).
 
@@ -579,10 +581,11 @@ Subcommands for this command are as follows:
 		- _json-pretty_
 		- _yaml_
 
-*patch* ([--add _key_=_val_]... | [--remove _key_=_val_]... | [--set _key_=_val_]... | [--unset _key_]...) _uid_++
-*patch* [ -f _format_] [ -p _patch_method_] -d @_file_ _uid_++
-*patch* [ -f _format_] [ -p _patch_method_] -d @- _uid_ < _file_++
-*patch* [ -f _format_] [ -p _patch_method_] _uid_ < _file_
+*patch* ([--add _key_=_val_]... | [--remove _key_=_index_]... | [--set _key_=_val_]... | [--unset _key_]...) _uid_++
+*patch* [-f _format_] [-p _patch_method_] -d _data_ _uid_++
+*patch* [-f _format_] [-p _patch_method_] -d @_file_ _uid_++
+*patch* [-f _format_] [-p _patch_method_] -d @- _uid_ < _file_++
+*patch* [-f _format_] [-p _patch_method_] _uid_ < _file_
 	Using various patch methods, patch the specification for an existing node
 	identified by _uid_.
 
@@ -596,7 +599,7 @@ Subcommands for this command are as follows:
 	uses add/remove/set/unset flags to perform the patch. For _key_, dot
 	notation is used for subkeys (e.g. _key.subkey_).
 
-	In the second through fourth forms of the command, patch data is supplied
+	In the second through fifth forms of the command, patch data is supplied
 	along with an optional *--patch-method* flag to specify the patch method.
 
 	This command sends a PATCH request to boot-service's node endpoint.
@@ -604,8 +607,8 @@ Subcommands for this command are as follows:
 	This command accepts the following options:
 
 	*--add* _key_[[._subkey_]...]=_val_
-		Add value to array field, creating the field if necessary. Only can be
-		used with _keyval_ patch method (automatic if any of
+		Append value to an existing array field using an RFC 6902 add operation.
+		Only can be used with key/value patch flags (automatic if any of
 		*--add*/*--remove*/*--set*/*--unset* are specified).
 
 	*-d, --data* (_data_ | @_path_ | @-)
@@ -628,18 +631,18 @@ Subcommands for this command are as follows:
 		- _rfc6902_: RFC 6902 JSON Patch
 		- _keyval_: key=value format using dot notation for subkeys
 
-	*--remove* _key_[[._subkey_]...]=_val_
-		Remove value from array field. Only can be used with _keyval_ patch
-		method (automatic if any of
+	*--remove* _key_[[._subkey_]...]=_index_
+		Remove value at _index_ from array field using an RFC 6902 remove
+		operation. Only can be used with key/value patch flags (automatic if any of
 		*--add*/*--remove*/*--set*/*--unset* are specified).
 
 	*--set* _key_[[._subkey_]...]=_val_
 		Set key with its value, overwriting any previous value and creating if the
-		key doesn't exist. Only can be used with _keyval_ patch method (automatic
+		key doesn't exist. Only can be used with key/value patch flags (automatic
 		if any of *--add*/*--remove*/*--set*/*--unset* are specified).
 
 	*--unset* _key_[[._subkey_]...]
-		Unset key (and its value). Only can be used with _keyval_ patch method
+		Unset key (and its value). Only can be used with key/value patch flags
 		(automatic if any of
 		*--add*/*--remove*/*--set*/*--unset* are specified).
 

--- a/pkg/client/boot_service/bmc.go
+++ b/pkg/client/boot_service/bmc.go
@@ -115,7 +115,7 @@ func (bsc *BootServiceClient) ListBMCs(token string, outFormat format.DataFormat
 // function. It accepts data that represents a patch formatted as patchFormat
 // and sends it as JSON to the boot-service via a PATCH request for the BMC
 // identified by uid.
-func (bsc *BootServiceClient) PatchBMC(token string, patchFormat client.PatchMethod, uid string, data map[string]interface{}) (*api.BMC, error) {
+func (bsc *BootServiceClient) PatchBMC(token string, patchFormat client.PatchMethod, uid string, data interface{}) (*api.BMC, error) {
 	// TODO: boot-service client functions don't support tokens yet.
 	_ = token
 

--- a/pkg/client/boot_service/bootconfig.go
+++ b/pkg/client/boot_service/bootconfig.go
@@ -116,7 +116,7 @@ func (bsc *BootServiceClient) ListBootConfigs(token string, outFormat format.Dat
 // PatchBootConfiguration() function. It accepts data that represents a patch
 // formatted as patchFormat and sends it as JSON to the boot-service via a PATCH
 // request for the boot configuration identified by uid.
-func (bsc *BootServiceClient) PatchBootConfig(token string, patchFormat client.PatchMethod, uid string, data map[string]interface{}) (*api.BootConfiguration, error) {
+func (bsc *BootServiceClient) PatchBootConfig(token string, patchFormat client.PatchMethod, uid string, data interface{}) (*api.BootConfiguration, error) {
 	// TODO: boot-service client functions don't support tokens yet.
 	_ = token
 

--- a/pkg/client/boot_service/node.go
+++ b/pkg/client/boot_service/node.go
@@ -115,7 +115,7 @@ func (bsc *BootServiceClient) ListNodes(token string, outFormat format.DataForma
 // function. It accepts data that represents a patch formatted as patchFormat
 // and sends it as JSON to the boot-service via a PATCH request for the node
 // identified by uid.
-func (bsc *BootServiceClient) PatchNode(token string, patchFormat client.PatchMethod, uid string, data map[string]interface{}) (*api.Node, error) {
+func (bsc *BootServiceClient) PatchNode(token string, patchFormat client.PatchMethod, uid string, data interface{}) (*api.Node, error) {
 	// TODO: boot-service client functions don't support tokens yet.
 	_ = token
 

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -419,3 +419,22 @@ func TestReadPayloadSlice(t *testing.T) {
 		})
 	}
 }
+
+func TestReadPayloadInterfaceRFC6902Array(t *testing.T) {
+	var got interface{}
+	err := ReadPayload(`[{"op":"replace","path":"/hostname","value":"ex01"}]`, format.DataFormatJson, &got)
+	if err != nil {
+		t.Fatalf("ReadPayload returned error: %v", err)
+	}
+
+	want := []interface{}{
+		map[string]interface{}{
+			"op":    "replace",
+			"path":  "/hostname",
+			"value": "ex01",
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %#v, want %#v", got, want)
+	}
+}

--- a/pkg/client/patch.go
+++ b/pkg/client/patch.go
@@ -5,11 +5,19 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/OpenCHAMI/ochami/pkg/format"
 )
+
+// JSONPatchOperation is a single operation in an RFC 6902 JSON Patch document.
+type JSONPatchOperation struct {
+	Op    string      `json:"op" yaml:"op"`
+	Path  string      `json:"path" yaml:"path"`
+	Value interface{} `json:"value,omitempty" yaml:"value,omitempty"`
+}
 
 // PatchMethod represents the supported patch type
 type PatchMethod string
@@ -52,8 +60,10 @@ func (pm PatchMethod) Type() string {
 	return "PatchMethod"
 }
 
-// NewKeyValPatch takes slices of items to set/unset/add/remove and returns a
-// map that can be marshaled and used as PatchMethodKeyVal data.
+// NewKeyValPatch takes slices of items to set/unset and returns a map that can
+// be marshaled and used as PatchMethodKeyVal/PatchMethodRFC7386 data. addList
+// and removeList are accepted for backward compatibility but are ignored here;
+// use NewKeyValPatchData to produce RFC 6902 add/remove operations.
 func NewKeyValPatch(setList, unsetList, addList, removeList []string) (map[string]interface{}, error) {
 	patch := make(map[string]interface{})
 
@@ -71,27 +81,80 @@ func NewKeyValPatch(setList, unsetList, addList, removeList []string) (map[strin
 		format.SetNestedField(patch, unsetKey, nil)
 	}
 
-	// Populate keys to add with their values
+	_ = addList
+	_ = removeList
+
+	return patch, nil
+}
+
+// NewKeyValPatchData takes set/unset/add/remove arguments and returns patch
+// data plus the patch method to use. If add/remove operations are present, it
+// returns an RFC 6902 JSON Patch document. Otherwise it returns an RFC 7386 JSON
+// Merge Patch document using keyval dot notation.
+func NewKeyValPatchData(setList, unsetList, addList, removeList []string) (PatchMethod, interface{}, error) {
+	if len(addList) == 0 && len(removeList) == 0 {
+		patch, err := NewKeyValPatch(setList, unsetList, nil, nil)
+		return PatchMethodKeyVal, patch, err
+	}
+
+	patch := []JSONPatchOperation{}
+	for _, setPair := range setList {
+		parts := strings.SplitN(setPair, "=", 2)
+		if len(parts) != 2 {
+			return "", nil, fmt.Errorf("invalid format %q for set list (expected key=value or key.subkey=value)", setPair)
+		}
+		patch = append(patch, JSONPatchOperation{Op: "add", Path: DotPathToJSONPointer(parts[0]), Value: parsePatchValue(parts[1])})
+	}
+	for _, unsetKey := range unsetList {
+		patch = append(patch, JSONPatchOperation{Op: "remove", Path: DotPathToJSONPointer(unsetKey)})
+	}
 	for _, addPair := range addList {
 		parts := strings.SplitN(addPair, "=", 2)
 		if len(parts) != 2 {
-			return nil, fmt.Errorf("invalid format %q for add list (expected key=value or key.subkey=value)", addPair)
+			return "", nil, fmt.Errorf("invalid format %q for add list (expected key=value or key.subkey=value)", addPair)
 		}
-		// For arrays, use JSON Merge Patch append syntax, if possible,
-		// otherwise, convert to JSON Patch
-		format.SetNestedField(patch, parts[0], parts[1])
+		patch = append(patch, JSONPatchOperation{Op: "add", Path: DotPathToJSONPointer(parts[0]) + "/-", Value: parsePatchValue(parts[1])})
 	}
-
-	// Populate keys to remove with their values
 	for _, removePair := range removeList {
 		parts := strings.SplitN(removePair, "=", 2)
 		if len(parts) != 2 {
-			return nil, fmt.Errorf("invalid format %q for remove list (expected key=value or key.subkey=value)", removePair)
+			return "", nil, fmt.Errorf("invalid format %q for remove list (expected key=index or key.subkey=index)", removePair)
 		}
-		// Remove operations are complex and might need JSON Patch; for now,
-		// handle simple cases
-		format.SetNestedField(patch, parts[0], parts[1])
+		if parts[1] == "-" || strings.TrimSpace(parts[1]) == "" {
+			return "", nil, fmt.Errorf("invalid index %q for remove list item %q", parts[1], removePair)
+		}
+		patch = append(patch, JSONPatchOperation{Op: "remove", Path: DotPathToJSONPointer(parts[0]) + "/" + escapeJSONPointerSegment(parts[1])})
 	}
 
-	return patch, nil
+	return PatchMethodRFC6902, patch, nil
+}
+
+// DotPathToJSONPointer converts dot notation (e.g. a.b) to an RFC 6901 JSON
+// Pointer (e.g. /a/b).
+func DotPathToJSONPointer(path string) string {
+	raw := strings.Split(path, ".")
+	parts := make([]string, 0, len(raw))
+	for _, p := range raw {
+		if p != "" {
+			parts = append(parts, escapeJSONPointerSegment(p))
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return "/" + strings.Join(parts, "/")
+}
+
+func escapeJSONPointerSegment(s string) string {
+	s = strings.ReplaceAll(s, "~", "~0")
+	s = strings.ReplaceAll(s, "/", "~1")
+	return s
+}
+
+func parsePatchValue(value string) interface{} {
+	var jsonValue interface{}
+	if err := json.Unmarshal([]byte(value), &jsonValue); err == nil {
+		return jsonValue
+	}
+	return value
 }

--- a/pkg/client/patch_test.go
+++ b/pkg/client/patch_test.go
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package client
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDotPathToJSONPointer(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "simple", path: "hostname", want: "/hostname"},
+		{name: "nested", path: "interface.ip", want: "/interface/ip"},
+		{name: "empty segments ignored", path: ".a..b.", want: "/a/b"},
+		{name: "escape", path: "a~/b.c", want: "/a~0~1b/c"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DotPathToJSONPointer(tt.path); got != tt.want {
+				t.Fatalf("DotPathToJSONPointer(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewKeyValPatchDataMergePatch(t *testing.T) {
+	method, data, err := NewKeyValPatchData([]string{"hostname=ex01", "nid=42"}, []string{"role"}, nil, nil)
+	if err != nil {
+		t.Fatalf("NewKeyValPatchData returned error: %v", err)
+	}
+	if method != PatchMethodKeyVal {
+		t.Fatalf("method = %s, want %s", method, PatchMethodKeyVal)
+	}
+	want := map[string]interface{}{"hostname": "ex01", "nid": float64(42), "role": nil}
+	if !reflect.DeepEqual(data, want) {
+		t.Fatalf("data = %#v, want %#v", data, want)
+	}
+}
+
+func TestNewKeyValPatchDataRFC6902(t *testing.T) {
+	method, data, err := NewKeyValPatchData(
+		[]string{"hostname=ex01"},
+		[]string{"role"},
+		[]string{"groups=compute"},
+		[]string{"groups=0"},
+	)
+	if err != nil {
+		t.Fatalf("NewKeyValPatchData returned error: %v", err)
+	}
+	if method != PatchMethodRFC6902 {
+		t.Fatalf("method = %s, want %s", method, PatchMethodRFC6902)
+	}
+	want := []JSONPatchOperation{
+		{Op: "add", Path: "/hostname", Value: "ex01"},
+		{Op: "remove", Path: "/role"},
+		{Op: "add", Path: "/groups/-", Value: "compute"},
+		{Op: "remove", Path: "/groups/0"},
+	}
+	if !reflect.DeepEqual(data, want) {
+		t.Fatalf("data = %#v, want %#v", data, want)
+	}
+}
+
+func TestNewKeyValPatchDataRejectsInvalidRemoveIndex(t *testing.T) {
+	_, _, err := NewKeyValPatchData(nil, nil, nil, []string{"groups=-"})
+	if err == nil {
+		t.Fatalf("NewKeyValPatchData accepted invalid remove index")
+	}
+}


### PR DESCRIPTION
### Description

Generate RFC 6902 JSON Patch payloads when `boot <resource> patch` commands use `--add` or `--remove` so array updates can be represented correctly. Use key-value/merge-patch method for `--set`-/`--unset` updates, but switch the selected patch method automatically when array operations are present.

Allow patch payload data to be an object or array by widening boot-service patch client arguments from `map[string]interface{}` to `interface{}`. This lets RFC 6902 patch documents pass through as top-level arrays.

Update `--remove` semantics to remove by array index instead of by value, and document that `--add` appends to an existing array. Refresh the manual page patch forms to include inline `-d` data and align BMC, config, and node command documentation.

Add tests for:

- RFC 6902 array payload parsing
- dot-path to JSON Pointer conversion and escaping
- keyval patch data generation
- RFC 6902 patch data generation for add/remove
- invalid remove index rejection

This will likely affect #98.

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [x] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass  
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
