### PR TITLE
Add --param flag to bss boot image set to set the name of the kernel parameter the image is passed with

### DIFF
--- a/cmd/bss/boot/image/set.go
+++ b/cmd/bss/boot/image/set.go
@@ -194,7 +194,7 @@ See ochami-bss(1) for more details.`,
 	// Create flags
 	bootImageSetCmd.Flags().StringSliceP("xname", "x", []string{}, "one or more xnames whose boot parameters to set")
 	bootImageSetCmd.Flags().StringSliceP("mac", "m", []string{}, "one or more MAC addresses whose boot parameters to set")
-	bootImageSetCmd.Flags().StringP("param", "p", "root", "set the image parameter name")
+	bootImageSetCmd.Flags().StringP("param", "p", "root", "set the kernel parameter name that the image is passed with")
 	bootImageSetCmd.Flags().Int32SliceP("nid", "n", []int32{}, "one or more node IDs whose boot parameters to set")
 
 	bootImageSetCmd.MarkFlagsOneRequired("xname", "mac", "nid")

--- a/cmd/bss/boot/image/set.go
+++ b/cmd/bss/boot/image/set.go
@@ -158,11 +158,18 @@ See ochami-bss(1) for more details.`,
 				}
 			}
 
+			image_param_name, err := cmd.Flags().GetString("param")
+			if err != nil {
+				log.Logger.Error().Err(err).Msg("unable to get image param name")
+				cli.LogHelpError(cmd)
+				os.Exit(1)
+			}
+
 			errorsOccurred := false
 			for bpIdx, bp := range bps {
 				// Edit parameters for nodes
 				k := kargs.NewKargs([]byte(bp.Params))
-				k.SetKarg("root", args[0])
+				k.SetKarg(image_param_name, args[0])
 				bps[bpIdx].Params = k.String()
 
 				// Send modified params back to BSS
@@ -187,6 +194,7 @@ See ochami-bss(1) for more details.`,
 	// Create flags
 	bootImageSetCmd.Flags().StringSliceP("xname", "x", []string{}, "one or more xnames whose boot parameters to set")
 	bootImageSetCmd.Flags().StringSliceP("mac", "m", []string{}, "one or more MAC addresses whose boot parameters to set")
+	bootImageSetCmd.Flags().StringP("param", "p", "root", "set the image parameter name")
 	bootImageSetCmd.Flags().Int32SliceP("nid", "n", []int32{}, "one or more node IDs whose boot parameters to set")
 
 	bootImageSetCmd.MarkFlagsOneRequired("xname", "mac", "nid")


### PR DESCRIPTION
## Pull Request Template

Thank you for your contribution! Please ensure the following before submitting:

### Checklist

- [X] My code follows the style guidelines of this project  
- [X] I have added/updated comments where needed  
- [X] I have added tests that prove my fix is effective or my feature works  
- [X] I have run `make test` (or equivalent) locally and all tests pass  
- [X] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [X] **REUSE Compliance**:  
  - [X] Each new/modified source file has SPDX copyright and license headers  
  - [X] Any non-commentable files include a `<filename>.license` sidecar  
  - [X] All referenced licenses are present in the `LICENSES/` directory  

### Description

Adds a --param/-p flag to the `bss boot image set` command to allow for using a different kernel parameter name when setting the boot image. The flag defaults to "root" so previous behavior is retained. I'll get documentation added once the behavior is confirmed to address #102 properly.

Example:
```
ochami bss boot image set -p rd.live.image <image>
ochami bss boot image set --param rd.live.image <image>
```

Implements #102

### Type of Change

- [ ] Bug fix  
- [X] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
