### PR TITLE
fix: remove duplicate reads in the static discovery subcommand to avoid reading past EOF when using stdin

### DIFF
--- a/cmd/discover/static/static.go
+++ b/cmd/discover/static/static.go
@@ -6,6 +6,7 @@
 package static
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -117,17 +118,32 @@ See ochami-discover(1) for more details.`,
 
 			// Read data from file or stdin into map to determine which
 			// discovery method to use.
-			useDeprecatedFormat := discoverStaticDeprecatedFormat(cmd)
+			discoveryData := make(map[string]([]map[string]any))
+			if cmd.Flag("data").Changed {
+				cli.HandlePayload(cmd, &discoveryData)
+			} else {
+				cli.HandlePayloadStdin(cmd, &discoveryData)
+			}
+			useDeprecatedFormat := discoverStaticDeprecatedFormat(cmd, discoveryData)
+			var rawData []byte
 			if useDeprecatedFormat {
 				log.Logger.Warn().Msg("using deprecated discovery format which will be removed in a future version")
 
-				// Read data from file or stdin
-				nodes := discover.NodeListDeprecated{}
-				if cmd.Flag("data").Changed {
-					cli.HandlePayload(cmd, &nodes)
-				} else {
-					cli.HandlePayloadStdin(cmd, &nodes)
+				// Convert discovery data to struct
+				rawData, err := json.Marshal(discoveryData)
+				if err != nil {
+					log.Logger.Error().Err(err).Msg("unable to marshal discovery data to json")
+					// cli.LogHelpError(cmd)
+					os.Exit(1)
 				}
+				nodes := discover.NodeListDeprecated{}
+				err = json.Unmarshal(rawData, &nodes)
+				if err != nil {
+					log.Logger.Error().Err(err).Msg("unable to unmarshal discovery data from json")
+					// cli.LogHelpError(cmd)
+					os.Exit(1)
+				}
+
 				log.Logger.Debug().Msgf("read %d nodes", len(nodes.Nodes))
 				log.Logger.Debug().Msgf("nodes: %s", nodes)
 
@@ -144,7 +160,6 @@ See ochami-discover(1) for more details.`,
 
 				// Put together payload for different endpoints
 				log.Logger.Debug().Msg("generating redfish structures to send to SMD")
-				var err error
 				comps, rfes, ifaces, err = discover.DiscoveryInfoV2Deprecated(smdBaseURI, nodes)
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("failed to construct structures to send to SMD")
@@ -153,13 +168,21 @@ See ochami-discover(1) for more details.`,
 				}
 				log.Logger.Debug().Msgf("generated redfish structures: %v", rfes.RedfishEndpoints)
 			} else {
-				// Read data from file or stdin
-				items := discover.DiscoveryItems{}
-				if cmd.Flag("data").Changed {
-					cli.HandlePayload(cmd, &items)
-				} else {
-					cli.HandlePayloadStdin(cmd, &items)
+				// Convert discovery data to struct
+				rawData, err = json.Marshal(discoveryData)
+				if err != nil {
+					log.Logger.Error().Err(err).Msg("unable to marshal discovery items to json")
+					// cli.LogHelpError(cmd)
+					os.Exit(1)
 				}
+				items := discover.DiscoveryItems{}
+				err = json.Unmarshal(rawData, &items)
+				if err != nil {
+					log.Logger.Error().Err(err).Msg("unable to unmarshal discovery items from json")
+					// cli.LogHelpError(cmd)
+					os.Exit(1)
+				}
+
 				log.Logger.Debug().Msgf("read %d bmcs", len(items.BMCs))
 				log.Logger.Debug().Msgf("bmcs: %s", items.BMCs)
 				log.Logger.Debug().Msgf("read %d nodes", len(items.Nodes))
@@ -582,13 +605,7 @@ See ochami-discover(1) for more details.`,
 	return staticCmd
 }
 
-func discoverStaticDeprecatedFormat(cmd *cobra.Command) bool {
-	discoveryData := make(map[string]([]map[string]any))
-	if cmd.Flag("data").Changed {
-		cli.HandlePayload(cmd, &discoveryData)
-	} else {
-		cli.HandlePayloadStdin(cmd, &discoveryData)
-	}
+func discoverStaticDeprecatedFormat(cmd *cobra.Command, discoveryData map[string]([]map[string]any)) bool {
 	deprecatedFormat := false
 	for _, node := range discoveryData["nodes"] {
 		if _, bmcIpFound := node["bmc_ip"]; bmcIpFound {

--- a/cmd/discover/static/static.go
+++ b/cmd/discover/static/static.go
@@ -133,14 +133,12 @@ See ochami-discover(1) for more details.`,
 				rawData, err := json.Marshal(discoveryData)
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("unable to marshal discovery data to json")
-					// cli.LogHelpError(cmd)
 					os.Exit(1)
 				}
 				nodes := discover.NodeListDeprecated{}
 				err = json.Unmarshal(rawData, &nodes)
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("unable to unmarshal discovery data from json")
-					// cli.LogHelpError(cmd)
 					os.Exit(1)
 				}
 
@@ -172,14 +170,12 @@ See ochami-discover(1) for more details.`,
 				rawData, err = json.Marshal(discoveryData)
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("unable to marshal discovery items to json")
-					// cli.LogHelpError(cmd)
 					os.Exit(1)
 				}
 				items := discover.DiscoveryItems{}
 				err = json.Unmarshal(rawData, &items)
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("unable to unmarshal discovery items from json")
-					// cli.LogHelpError(cmd)
 					os.Exit(1)
 				}
 

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -12,11 +12,25 @@ import (
 	"os"
 )
 
+// Buffer for ReadStdin()
+var stdin_buffer []byte = nil
+
 // ReadStdin reads all of standard input and returns the bytes. If an error
 // occurs during scanning, it is returned.
+// It also stores the read data so subsequent calls will return the same bytes
+// instead of attempting to reread stdin after EOF
 func ReadStdin() ([]byte, error) {
+	if stdin_buffer != nil {
+		// Returning this slice raw may be unforeseen consequences if a caller
+		// tries to modify it
+		return stdin_buffer, nil
+	}
 	ior := newIOReader(os.Stdin)
-	return ior.readIn()
+	ret, err := ior.readIn()
+	if err == nil {
+		stdin_buffer = ret
+	}
+	return ret, err
 }
 
 // ioReader stores an io.Reader to be read from using readIn. It's purpose is to

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -12,25 +12,13 @@ import (
 	"os"
 )
 
-// Buffer for ReadStdin()
-var stdin_buffer []byte = nil
-
 // ReadStdin reads all of standard input and returns the bytes. If an error
 // occurs during scanning, it is returned.
 // It also stores the read data so subsequent calls will return the same bytes
 // instead of attempting to reread stdin after EOF
 func ReadStdin() ([]byte, error) {
-	if stdin_buffer != nil {
-		// Returning this slice raw may be unforeseen consequences if a caller
-		// tries to modify it
-		return stdin_buffer, nil
-	}
 	ior := newIOReader(os.Stdin)
-	ret, err := ior.readIn()
-	if err == nil {
-		stdin_buffer = ret
-	}
-	return ret, err
+	return ior.readIn()
 }
 
 // ioReader stores an io.Reader to be read from using readIn. It's purpose is to


### PR DESCRIPTION
## Pull Request Template

Thank you for your contribution! Please ensure the following before submitting:

### Checklist

- [X] My code follows the style guidelines of this project  
- [X] I have added/updated comments where needed  
- [X] I have added tests that prove my fix is effective or my feature works  
- [X] I have run `make test` (or equivalent) locally and all tests pass  
- [X] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [X] **REUSE Compliance**:  
  - [X] Each new/modified source file has SPDX copyright and license headers  
  - [X] Any non-commentable files include a `<filename>.license` sidecar  
  - [X] All referenced licenses are present in the `LICENSES/` directory  

### Description

Fixes an issue where some subcommands (tested with `ochami discover static`) would attempt to read a data file multiple times. If the data file was stdin, this would result in the file being read successfully once and subsequent reads would be empty. This commit patches the internal `io.ReadStdin()` to buffer its first successful read from stdin (Full read until EOF, not just a single `Read()` call) and return the buffered data on subsequent calls. This may break anything that expects this behavior from `io.ReadStdin()`, but I didn't see anything that relied on it and all the tests came back fine.

### Type of Change

- [X] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
