### PR TITLE
feat: make the verbose option print loaded config values before merging

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -561,7 +561,7 @@ func LoadGlobalConfigMerged() error {
 			if err != nil {
 				return fmt.Errorf("failed to serialize config: %w", err)
 			}
-			log.EarlyLogger.BasicLogf("Config data: %s", serializedConfig)
+			log.EarlyLogger.BasicLogf("Config data: \n%s", serializedConfig)
 
 			if err := MergeConfigIntoParser(ko, cfgLoaded.Cfg); err != nil {
 				return fmt.Errorf("failed to merge config: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -561,7 +561,7 @@ func LoadGlobalConfigMerged() error {
 			if err != nil {
 				return fmt.Errorf("failed to serialize config: %w", err)
 			}
-			log.EarlyLogger.BasicLogf("Config data: \n%s", serializedConfig)
+			log.EarlyLogger.BasicLogf("config data:\n%s", serializedConfig)
 
 			if err := MergeConfigIntoParser(ko, cfgLoaded.Cfg); err != nil {
 				return fmt.Errorf("failed to merge config: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -584,6 +584,12 @@ func LoadGlobalConfigMerged() error {
 
 	log.EarlyLogger.BasicLog("config files, if any, have been merged")
 
+	if finalConfig, err := GetConfigString(GlobalConfig, "", "yaml"); err != nil {
+		log.EarlyLogger.BasicLogf("warning: failed to marshal config as YAML: %v", err)
+	} else {
+		log.EarlyLogger.BasicLogf("final merged config:\n%s", finalConfig)
+	}
+
 	return nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -556,6 +556,13 @@ func LoadGlobalConfigMerged() error {
 			}
 		} else {
 			log.EarlyLogger.BasicLogf("merging in config from %s", cfgLoaded.File)
+
+			serializedConfig, err := GetConfigString(cfgLoaded.Cfg, "", "yaml")
+			if err != nil {
+				return fmt.Errorf("failed to serialize config: %w", err)
+			}
+			log.EarlyLogger.BasicLogf("Config data: %s", serializedConfig)
+
 			if err := MergeConfigIntoParser(ko, cfgLoaded.Cfg); err != nil {
 				return fmt.Errorf("failed to merge config: %w", err)
 			}


### PR DESCRIPTION
### Checklist

- [X] My code follows the style guidelines of this project  
- [X] I have added/updated comments where needed  
- [X] I have added tests that prove my fix is effective or my feature works  
- [X] I have run `make test` (or equivalent) locally and all tests pass  
- [X] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [X] **REUSE Compliance**:  
  - [X] Each new/modified source file has SPDX copyright and license headers  
  - [X] Any non-commentable files include a `<filename>.license` sidecar  
  - [X] All referenced licenses are present in the `LICENSES/` directory  

### Description

This PR makes the verbose option print the values it loaded from each config file before merging them, for debugging purposes.

Fixes #104

### Type of Change

- [ ] Bug fix  
- [X] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
