### PR TITLE
feat(smd): add list alias to rfe and component get commands

### DIFF
--- a/cmd/bss/boot/params/get.go
+++ b/cmd/bss/boot/params/get.go
@@ -23,9 +23,10 @@ import (
 func newCmdBootParamsGet() *cobra.Command {
 	// bootParamsGetCmd represents the "bss boot params get" command
 	var bootParamsGetCmd = &cobra.Command{
-		Use:   "get",
-		Args:  cobra.NoArgs,
-		Short: "Get boot parameters for one or all nodes",
+		Use:     "get",
+		Aliases: []string{"list"},
+		Args:    cobra.NoArgs,
+		Short:   "Get boot parameters for one or all nodes",
 		Long: `Get boot parameters for one or all nodes. If no options are passed, all boot
 parameters are returned. Optionally, --mac, --xname, and/or --nid can be passed at least once
 to get boot parameters for specific components.

--- a/cmd/bss/boot/script/get.go
+++ b/cmd/bss/boot/script/get.go
@@ -23,9 +23,10 @@ import (
 func newCmdBootScriptGet() *cobra.Command {
 	// bootScriptGetCmd represents the "bss boot script get" command
 	var bootScriptGetCmd = &cobra.Command{
-		Use:   "get",
-		Args:  cobra.NoArgs,
-		Short: "Get iPXE boot script for a component",
+		Use:     "get",
+		Aliases: []string{"list"},
+		Args:    cobra.NoArgs,
+		Short:   "Get iPXE boot script for a component",
 		Long: `Get iPXE boot script for a component. Specifying one of --mac, --xname,
 or --nid is required to specify which component to fetch the boot script for.
 

--- a/cmd/bss/hosts/get.go
+++ b/cmd/bss/hosts/get.go
@@ -23,9 +23,10 @@ import (
 func newCmdHostsGet() *cobra.Command {
 	// hostsGetCmd represents the "bss hosts get" command
 	var hostsGetCmd = &cobra.Command{
-		Use:   "get",
-		Args:  cobra.NoArgs,
-		Short: "Get information on hosts known to BSS",
+		Use:     "get",
+		Aliases: []string{"list"},
+		Args:    cobra.NoArgs,
+		Short:   "Get information on hosts known to BSS",
 		Long: `Get information on hosts known to BSS.
 
 See ochami-bss(1) for more details.`,

--- a/cmd/cloud_init/defaults/get.go
+++ b/cmd/cloud_init/defaults/get.go
@@ -22,9 +22,10 @@ import (
 func newCmdDefaultsGet() *cobra.Command {
 	// defaultsGetCmd represents the "cloud-init defaults get" command
 	var defaultsGetCmd = &cobra.Command{
-		Use:   "get",
-		Args:  cobra.NoArgs,
-		Short: "Get cloud-init default meta-data for a cluster",
+		Use:     "get",
+		Aliases: []string{"list"},
+		Args:    cobra.NoArgs,
+		Short:   "Get cloud-init default meta-data for a cluster",
 		Long: `Get cloud-init default meta-data for a cluster.
 
 See ochami-cloud-init(1) for more details.`,

--- a/cmd/cloud_init/group/get.go
+++ b/cmd/cloud_init/group/get.go
@@ -114,9 +114,10 @@ func getGroupData(cmd *cobra.Command, args []string) (groupSlice []cistore.Group
 func newCmdGroupGet() *cobra.Command {
 	// groupGetCmd represents the "cloud-init group get" command
 	var groupGetCmd = &cobra.Command{
-		Use:   "get",
-		Args:  cobra.NoArgs,
-		Short: "Get group data for all or a subset of cloud-init groups",
+		Use:     "get",
+		Aliases: []string{"list"},
+		Args:    cobra.NoArgs,
+		Short:   "Get group data for all or a subset of cloud-init groups",
 		Long: `Get group data for all or a subset of cloud-init groups.
 
 See ochami-cloud-init(1) for more details.`,

--- a/cmd/cloud_init/node/get.go
+++ b/cmd/cloud_init/node/get.go
@@ -26,9 +26,10 @@ import (
 func newCmdNodeGet() *cobra.Command {
 	// nodeGetCmd represents the "cloud-init group get" command
 	var nodeGetCmd = &cobra.Command{
-		Use:   "get",
-		Args:  cobra.NoArgs,
-		Short: "Get data for specific node(s)",
+		Use:     "get",
+		Aliases: []string{"list"},
+		Args:    cobra.NoArgs,
+		Short:   "Get data for specific node(s)",
 		Long: `Get data for specific node(s).
 
 See ochami-cloud-init(1) for more details.`,

--- a/cmd/smd/compep/get.go
+++ b/cmd/smd/compep/get.go
@@ -23,8 +23,9 @@ import (
 func newCmdCompepGet() *cobra.Command {
 	// compepGetCmd represents the "smd compep get" command
 	var compepGetCmd = &cobra.Command{
-		Use:   "get [<xname>...]",
-		Short: "Get all component endpoints or a subset, identified by xname",
+		Use:     "get [<xname>...]",
+		Aliases: []string{"list"},
+		Short:   "Get all component endpoints or a subset, identified by xname",
 		Long: `Get all component endpoints or a subset, identified by xname.
 
 See ochami-smd(1) for more details.`,

--- a/cmd/smd/component/get.go
+++ b/cmd/smd/component/get.go
@@ -22,9 +22,10 @@ import (
 func newCmdComponentGet() *cobra.Command {
 	// componentGetCmd represents the "smd component get" command
 	var componentGetCmd = &cobra.Command{
-		Use:   "get",
-		Args:  cobra.NoArgs,
-		Short: "Get all components or component identified by an xname or node ID",
+		Use:     "get",
+		Aliases: []string{"list"},
+		Args:    cobra.NoArgs,
+		Short:   "Get all components or component identified by an xname or node ID",
 		Long: `Get all components or component by an xname or node ID.
 
 See ochami-smd(1) for more details.`,

--- a/cmd/smd/group/get.go
+++ b/cmd/smd/group/get.go
@@ -23,9 +23,10 @@ import (
 func newCmdGroupGet() *cobra.Command {
 	// groupGetCmd represents the "smd group get" command
 	var groupGetCmd = &cobra.Command{
-		Use:   "get",
-		Args:  cobra.NoArgs,
-		Short: "Get all groups or group(s) identified by name and/or tag",
+		Use:     "get",
+		Aliases: []string{"list"},
+		Args:    cobra.NoArgs,
+		Short:   "Get all groups or group(s) identified by name and/or tag",
 		Long: `Get all groups or group(s) identified by name and/or tag.
 
 See ochami-smd(1) for more details.`,

--- a/cmd/smd/group/member/get.go
+++ b/cmd/smd/group/member/get.go
@@ -22,9 +22,10 @@ import (
 func newCmdGroupMemberGet() *cobra.Command {
 	// groupMemberGetCmd represents the "smd group member get" command
 	var groupMemberGetCmd = &cobra.Command{
-		Use:   "get <group_label>",
-		Args:  cobra.ExactArgs(1),
-		Short: "Get members of a group",
+		Use:     "get <group_label>",
+		Aliases: []string{"list"},
+		Args:    cobra.ExactArgs(1),
+		Short:   "Get members of a group",
 		Long: `Get members of a group.
 
 See ochami-smd(1) for more details.`,

--- a/cmd/smd/iface/get.go
+++ b/cmd/smd/iface/get.go
@@ -23,9 +23,10 @@ import (
 func newCmdIfaceGet() *cobra.Command {
 	// ifaceGetCmd represents the "smd iface get" command
 	var ifaceGetCmd = &cobra.Command{
-		Use:   "get",
-		Args:  cobra.NoArgs,
-		Short: "Get some or all ethernet interfaces",
+		Use:     "get",
+		Aliases: []string{"list"},
+		Args:    cobra.NoArgs,
+		Short:   "Get some or all ethernet interfaces",
 		Long: `Get some or all ethernet interfaces optionally based on filter(s). If no options are
 passed, all ethernet interfaces are returned. Optionally, options can be passed to limit the
 ethernet interfaces returned.

--- a/cmd/smd/rfe/get.go
+++ b/cmd/smd/rfe/get.go
@@ -23,9 +23,10 @@ import (
 func newCmdRfeGet() *cobra.Command {
 	// rfeGetCmd represents the "smd rfe get" command
 	var rfeGetCmd = &cobra.Command{
-		Use:   "get",
-		Args:  cobra.NoArgs,
-		Short: "Get all redfish endpoints or some based on filter(s)",
+		Use:     "get",
+		Aliases: []string{"list"},
+		Args:    cobra.NoArgs,
+		Short:   "Get all redfish endpoints or some based on filter(s)",
 		Long: `Get all redfish endpoints or some based on filter(s). If no options are passed,
 all redfish endpoints are returned. Optionally, options can be passed to limit the redfish
 endpoints returned.

--- a/man/ochami-bss.1.sc
+++ b/man/ochami-bss.1.sc
@@ -221,6 +221,8 @@ Subcommands for this command are as follows:
 		Command line arguments to pass to kernel for components.
 
 *get* [-F _format_] [--mac _mac_,...] [--nid _nid_,...] [--xname _xname_,...]
+	Aliases: *list*
+
 	Get boot parameters for all components or a subset of components, filtered
 	by MAC address, node ID, and/or xname.
 
@@ -390,6 +392,8 @@ Manage boot scripts for components.
 Subcommands for this command are as follows:
 
 *get* ([--mac _mac_] [--nid _nid_] [--xname _xname_])
+	Aliases: *list*
+
 	Get the iPXE boot script for a component. Exactly one of *--mac*, *--nid*,
 	or *--xname* is required to specify the component whose boot script to get.
 	Note that only *one* component's boot script is fetched.
@@ -466,6 +470,8 @@ Work with hosts in BSS.
 Subcommands for this command are as follows:
 
 *get* [-F _format_ ] [--mac _mac_,...] [--nid _nid_,...] [--xname _xname_,...]
+	Aliases: *list*
+
 	Get a list of hosts that BSS knows about that are in SMD. These results can
 	be optionally filtered by MAC address, node ID, or xname. If no filters are
 	specified, all results are returned.

--- a/man/ochami-cloud-init.1.sc
+++ b/man/ochami-cloud-init.1.sc
@@ -192,6 +192,8 @@ on the data structure used with this command.
 Subcommands for this command are as follows:
 
 *get* [-F _format_]
+	Aliases: *list*
+
 	Get cluster-wide default meta-data.
 
 	This command accepts the following options:
@@ -322,6 +324,8 @@ Subcommands for this command are as follows:
 		- _yaml_
 
 *get*
+	Aliases: *list*
+
 	Get cloud-init group data.
 
 	Commands under this one send one or more GET requests to the
@@ -546,6 +550,8 @@ Get and manage cloud-init node data.
 Subcommands for this command are as follows:
 
 *get*
+	Aliases: *list*
+
 	Get cloud-init node data. This command has the following subcommands:
 
 	*group* [--header _when_] _node_id_ _group_name_...

--- a/man/ochami-smd.1.sc
+++ b/man/ochami-smd.1.sc
@@ -285,6 +285,8 @@ Subcommands for this command are as follows:
 		- _yaml_
 
 *get* [-F _format_] [_xname_]...
+	Aliases: *list*
+
 	Get all or a subset of component endpoints.
 
 	If no arguments are passed, all component endpoints are returned. Otherwise,
@@ -411,6 +413,8 @@ Subcommands for this command are as follows:
 		- _yaml_
 
 *get* [-F _format_] [--nid _nid_] [--xname _xname_]
+	Aliases: *list*
+
 	Get all components or one identified by xname or node ID.
 
 	If no filter flags are passed, all components are returned. Otherwise, the
@@ -433,8 +437,57 @@ Subcommands for this command are as follows:
 
 	*-x, --xname* _xname_,...
 		One or more xnames to filter results by. For multiple xnames, either
-		this flag can be specified multiple times or this flag can be specified
 		once and multiple xnames, separated by commas.
+
+## iface
+
+Manage Ethernet interfaces.
+
+*get* [-F _format_] [--by-ip] [--comp-id _xname_,...] [-i _id_] [--ip _ip_,...] [-m _mac_,...] [--net _network_,...] [--newer-than _timestamp_] [--older-than _timestamp_] [--type _type_,...]
+	Aliases: *list*
+
+	Get all Ethernet interfaces or a subset based on filter options.
+
+	This command sends a GET request to SMD's /Inventory/EthernetInterfaces
+	endpoint.
+
+	This command accepts the following options:
+
+	*--by-ip*
+		Get all IP addresses for the Ethernet interface specified by *--id*.
+
+	*--comp-id* _xname_,...
+		Filter Ethernet interfaces by one or more component IDs.
+
+	*-F, --format-output* _format_
+		Output response data in specified _format_. Supported values are:
+
+		- _json_ (default)
+		- _json-pretty_
+		- _yaml_
+
+	*-i, --id* _id_
+		Get an Ethernet interface by its ID.
+
+	*--ip* _ip_,...
+		Filter Ethernet interfaces by one or more IP addresses.
+
+	*-m, --mac* _mac_,...
+		Filter Ethernet interfaces by one or more MAC addresses.
+
+	*--net* _network_,...
+		Filter Ethernet interfaces by IP address on one or more networks.
+
+	*--newer-than* _timestamp_
+		Filter Ethernet interfaces by update time newer than the specified
+		RFC3339-formatted timestamp.
+
+	*--older-than* _timestamp_
+		Filter Ethernet interfaces by update time older than the specified
+		RFC3339-formatted timestamp.
+
+	*--type* _type_,...
+		Filter Ethernet interfaces by one or more types.
 
 ## rfe
 
@@ -534,6 +587,8 @@ Subcommands for this command are as follows:
 		Do not ask the user to confirm deletion.
 
 *get* [-F _format_] [--fqdn _fqdn_,...] [-i _ip_,...] [-m _mac_,...] [--type _type_,...] [--uuid _uuid_,...] [-x _xname_,...]
+	Aliases: *list*
+
 	Get all Redfish endpoints or filter by various attributes.
 
 	If no filter flags are passed, all Redfish endpoints are returned.
@@ -677,6 +732,8 @@ Subcommands for this command are as follows:
 		- _yaml_
 
 *get* [-F _format_] [--name _name_,...] [--tag _tag_,...]
+	Aliases: *list*
+
 	Get group information for all groups in SMD or for a subset, specified by
 	filters.
 
@@ -864,6 +921,8 @@ Subcommands for this command are as follows:
 	under SMD's /groups endpoint.
 
 *get* [-F _format_] _group_name_
+	Aliases: *list*
+
 	Get members of an SMD group.
 
 	This command sends a GET request to the members subendpoint under SMD's


### PR DESCRIPTION
### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [ ] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass  
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [ ] Any non-commentable files include a `<filename>.license` sidecar  
  - [ ] All referenced licenses are present in the `LICENSES/` directory  

### Description

**Summary:**
This PR introduces `list` as an alias for the `ochami smd rfe get` and `ochami smd component get` commands. 

**Motivation and Context:**
Older CSM-based commands lacked a `list` alias, causing inconsistencies in user experience when compared to newer commands in the OpenCHAMI CLI. This simple quality-of-life update allows users to type `list` intuitively while mapping directly to the underlying `get` logic. The respective `man` pages (`ochami-smd.1.sc`) have also been updated to reflect the availability of the alias.

Fixes #(issue)
https://github.com/OpenCHAMI/ochami/issues/116

### Type of Change

- [ ] Bug fix  
- [x] New feature  
- [ ] Breaking change  
- [x] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).