### PR TITLE
fix(metadata): man page sections and stdin reading

### DIFF
--- a/cmd/metadata/defaults/set.go
+++ b/cmd/metadata/defaults/set.go
@@ -57,7 +57,11 @@ See ochami-metadata(1) for more details.`,
 
 			// Read cluster defaults data
 			defaults := metadata_service_client.UpdateClusterDefaultsRequest{}
-			cli.HandlePayload(cmd, &defaults)
+			if cmd.Flag("data").Changed {
+				cli.HandlePayload(cmd, &defaults)
+			} else {
+				cli.HandlePayloadStdin(cmd, &defaults)
+			}
 
 			// Send off requests
 			defaultsSet, err := metadataServiceClient.SetDefaults(cli.Token, args[0], defaults)

--- a/cmd/metadata/group/set.go
+++ b/cmd/metadata/group/set.go
@@ -55,7 +55,11 @@ See ochami-metadata(1) for more details.`,
 
 			// Read group data
 			group := metadata_service_client.UpdateGroupRequest{}
-			cli.HandlePayload(cmd, &group)
+			if cmd.Flag("data").Changed {
+				cli.HandlePayload(cmd, &group)
+			} else {
+				cli.HandlePayloadStdin(cmd, &group)
+			}
 
 			// Send off requests
 			groupSet, err := metadataServiceClient.SetGroup(cli.Token, args[0], group)

--- a/cmd/metadata/instance/set.go
+++ b/cmd/metadata/instance/set.go
@@ -55,7 +55,11 @@ See ochami-metadata(1) for more details.`,
 
 			// Read instance data
 			instance := metadata_service_client.UpdateInstanceInfoRequest{}
-			cli.HandlePayload(cmd, &instance)
+			if cmd.Flag("data").Changed {
+				cli.HandlePayload(cmd, &instance)
+			} else {
+				cli.HandlePayloadStdin(cmd, &instance)
+			}
 
 			// Send off requests
 			instanceSet, err := metadataServiceClient.SetInstanceInfo(cli.Token, args[0], instance)

--- a/cmd/metadata/peer/set.go
+++ b/cmd/metadata/peer/set.go
@@ -65,7 +65,11 @@ See ochami-metadata(1) for more details.`,
 
 			// Read peer data
 			peer := metadata_service_client.UpdateWireGuardPeerRequest{}
-			cli.HandlePayload(cmd, &peer)
+			if cmd.Flag("data").Changed {
+				cli.HandlePayload(cmd, &peer)
+			} else {
+				cli.HandlePayloadStdin(cmd, &peer)
+			}
 
 			// Send off requests
 			peerSet, err := metadataServiceClient.SetWireGuardPeer(cli.Token, args[0], peer)

--- a/man/ochami-metadata.1.sc
+++ b/man/ochami-metadata.1.sc
@@ -408,6 +408,71 @@ Subcommands for this command are as follows:
 		- _json-pretty_
 		- _yaml_
 
+*patch* ([--add _key_=_val_]... | [--remove _key_=_val_]... | [--set _key_=_val_]... | [--unset _key_]...) _uid_++
+*patch* [-f _format_] [-p _patch_method_] -d @_file_ _uid_++
+*patch* [-f _format_] [-p _patch_method_] -d @- _uid_ < _file_++
+*patch* [-f _format_] [-p _patch_method_] _uid_ < _file_
+	Using various patch methods, patch the specification for an existing cluster
+	defaults identified by _uid_.
+
+	*IMPORTANT:* Only the spec portion of the resource can be patched.  Metadata
+	(name, labels, annotations) and status are managed by the API.  Attempts to
+	patch metadata or status fields will be ignored.
+
+	In the first form of the command, at least one of *--add*, *--remove*,
+	*--set*, or *--unset* is passed. Each of these flags can be specified more
+	than once, but at least one of them must be passed in this form. This method
+	uses add/remove/set/unset flags to perform the patch. For _key_, dot
+	notation is used for subkeys (e.g. _key.subkey_).
+
+	In the second through fourth forms of the command, patch data is supplied
+	along with an optional *--patch-method* flag to specify the patch method.
+
+	This command sends a PATCH request to metadata-service's cluster defaults
+	endpoint.
+
+	This command accepts the following options:
+
+	*--add* _key_[[._subkey_]...]=_val_
+		Add value to array field, creating the field if necessary. Only can be
+		used with _keyval_ patch method (automatic if any of
+		*--add*/*--remove*/*--set*/*--unset* are specified).
+
+	*-d, --data* (_data_ | @_path_ | @-)
+		Specify raw _data_ to send, the _path_ to a file to read payload data
+		from, or to read the data from standard input (@-). The format of data
+		read in any of these forms is JSON by default unless *-f* is specified
+		to change it.
+
+	*-f, --format-input* _format_
+		Format of raw data being used by stdin/*-d* as the payload. Supported
+		formats are:
+
+		- _json_ (default)
+		- _yaml_
+
+	*-p, --patch-method* _patch_method_
+		Specify patch method for patch data. Supported methods are:
+
+		- _rfc7386_ (default): RFC 7386 JSON Merge Patch
+		- _rfc6902_: RFC 6902 JSON Patch
+		- _keyval_: key=value format using dot notation for subkeys
+
+	*--remove* _key_[[._subkey_]...]=_val_
+		Remove value from array field. Only can be used with _keyval_ patch
+		method (automatic if any of
+		*--add*/*--remove*/*--set*/*--unset* are specified).
+
+	*--set* _key_[[._subkey_]...]=_val_
+		Set key with its value, overwriting any previous value and creating if the
+		key doesn't exist. Only can be used with _keyval_ patch method (automatic
+		if any of *--add*/*--remove*/*--set*/*--unset* are specified).
+
+	*--unset* _key_[[._subkey_]...]
+		Unset key (and its value). Only can be used with _keyval_ patch method
+		(automatic if any of
+		*--add*/*--remove*/*--set*/*--unset* are specified).
+
 *set* [-f _format_] _uid_ < _file_++
 *set* [-f _format_] -d @_file_ _uid_++
 *set* [-f _format_] -d @- _uid_ < _file_++
@@ -1394,106 +1459,6 @@ Subcommands for this command are as follows:
 
 	*-F, --format-output* _format_
 		Output response data in specified _format_. Supported values are:
-
-		- _json_ (default)
-		- _json-pretty_
-		- _yaml_
-
-*patch* ([--add _key_=_val_]... | [--remove _key_=_val_]... | [--set _key_=_val_]... | [--unset _key_]...) _uid_++
-*patch* [ -f _format_] [ -p _patch_method_] -d @_file_ _uid_++
-*patch* [ -f _format_] [ -p _patch_method_] -d @- _uid_ < _file_++
-*patch* [ -f _format_] [ -p _patch_method_] _uid_ < _file_
-	Using various patch methods, patch the specification for an existing cluster
-	defaults identified by _uid_.
-
-	*IMPORTANT:* Only the spec portion of the resource can be patched.  Metadata
-	(name, labels, annotations) and status are managed by the API.  Attempts to
-	patch metadata or status fields will be ignored.
-
-	In the first form of the command, at least one of *--add*, *--remove*,
-	*--set*, or *--unset* is passed. Each of these flags can be specified more
-	than once, but at least one of them must be passed in this form. This method
-	uses add/remove/set/unset flags to perform the patch. For _key_, dot
-	notation is used for subkeys (e.g. _key.subkey_).
-
-	In the second through fourth forms of the command, patch data is supplied
-	along with an optional *--patch-method* flag to specify the patch method.
-
-	This command sends a PATCH request to metadata-service's cluster defaults
-	endpoint.
-
-	This command accepts the following options:
-
-	*--add* _key_[[._subkey_]...]=_val_
-		Add value to array field, creating the field if necessary. Only can be
-		used with _keyval_ patch method (automatic if any of
-		*--add*/*--remove*/*--set*/*--unset* are specified).
-
-	*-d, --data* (_data_ | @_path_ | @-)
-		Specify raw _data_ to send, the _path_ to a file to read payload data
-		from, or to read the data from standard input (@-). The format of data
-		read in any of these forms is JSON by default unless *-f* is specified
-		to change it.
-
-	*-f, --format-input* _format_
-		Format of raw data being used by stdin/*-d* as the payload. Supported
-		formats are:
-
-		- _json_ (default)
-		- _yaml_
-
-	*-p, --patch-method* _patch_method_
-		Specify patch method for patch data. Supported methods are:
-
-		- _rfc7386_ (default): RFC 7386 JSON Merge Patch
-		- _rfc6902_: RFC 6902 JSON Patch
-		- _keyval_: key=value format using dot notation for subkeys
-
-	*--remove* _key_[[._subkey_]...]=_val_
-		Remove value from array field. Only can be used with _keyval_ patch
-		method (automatic if any of
-		*--add*/*--remove*/*--set*/*--unset* are specified).
-
-	*--set* _key_[[._subkey_]...]=_val_
-		Set key with its value, overwriting any previous value and creating if the
-		key doesn't exist. Only can be used with _keyval_ patch method (automatic
-		if any of *--add*/*--remove*/*--set*/*--unset* are specified).
-
-	*--unset* _key_[[._subkey_]...]
-		Unset key (and its value). Only can be used with _keyval_ patch method
-		(automatic if any of
-		*--add*/*--remove*/*--set*/*--unset* are specified).
-
-*set* [-f _format_] _uid_ < _file_++
-*set* [-f _format_] -d @_file_ _uid_++
-*set* [-f _format_] -d @- < _file_ _uid_++
-*set* [-f _format_] -d _data_ _uid_
-	Set the spec for an existing cluster defaults in metadata-service, specified
-	by UID.
-
-	In the first and third forms of the command, data is read from standard
-	input.
-
-	In the second form of the command, a file containing the payload data is
-	passed.
-
-	In the fourth form of the command, the payload is passed raw on the command
-	line.
-
-	This command sends a POST request to metadata-service's cluster defaults
-	endpoint.
-
-	This command accepts the following flags:
-
-	*-d, --data* (_data_ | @_path_ | @-)
-		Specify raw _data_ to send, the _path_ to a file to read payload data
-		from, or to read the data from standard input (@-). The format of data
-		read in any of these forms is JSON by default unless *-f* is specified
-		to change it.
-
-	*-f, --format-input* _format_
-		Format of raw data being used by stdin/*-d* as the payload. Supported
-		formats are:
 
 		- _json_ (default)
 		- _json-pretty_


### PR DESCRIPTION
### Description

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [ ] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass
- [x] I have updated the relevant documentation (CLI examples, man pages, README, other docs, etc.)
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Description

Certain `metadata` commands would only read from stdin if `-d`/`--data -` was passed despite the docs saying otherwise. This PR removes the `-d` requirement and reads stdin if no data is specified.

Also, some of the `metadata` command descriptions in **ochami-metadata**(1) were in the wrong place (under the "service" section). This has been corrected.

### Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [x] Documentation update  
- [ ] Dependency update

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
