### PR TITLE
feat: differentiate simple/advanced API for fabrica payloads

### DIFF
--- a/cmd/boot/bmc/add.go
+++ b/cmd/boot/bmc/add.go
@@ -10,6 +10,8 @@ import (
 	boot_service_client "github.com/openchami/boot-service/pkg/client"
 	"github.com/spf13/cobra"
 
+	api "github.com/openchami/boot-service/apis/boot.openchami.io/v1"
+
 	"github.com/OpenCHAMI/ochami/internal/cli"
 	boot_service_lib "github.com/OpenCHAMI/ochami/internal/cli/boot_service"
 	"github.com/OpenCHAMI/ochami/internal/log"
@@ -27,12 +29,17 @@ See ochami-boot(1) for more details.`,
 		Example: `  # Add BMC using payload data
   ochami boot bmc add -d \
     '{
-       "xname": "x1000c0s0b0",
-       "description": "This node's BMC",
-       "interface": {
-         "type": "management",
-         "mac": "de:ca:fc:0f:fe:e1",
-         "ip": "172.16.0.254"
+       "metadata": {
+         "name": "x1000c0s0b0"
+       },
+       "spec": {
+         "xname": "x1000c0s0b0",
+         "description": "This node's BMC",
+         "interface": {
+           "type": "management",
+           "mac": "de:ca:fc:0f:fe:e1",
+           "ip": "172.16.0.254"
+         }
        }
      }'
 
@@ -40,24 +47,48 @@ See ochami-boot(1) for more details.`,
   ochami boot bmc add -d \
     '[
        {
-         "xname": "x1000c0s0b0",
-         "description": "Node 1's BMC",
-         "interface": {
-           "type": "management",
-           "mac": "de:ca:fc:0f:fe:e1",
-           "ip": "172.16.0.1"
+         "metadata": {
+           "name": "x1000c0s0b0"
+         },
+         "spec": {
+           "xname": "x1000c0s0b0",
+           "description": "Node 1's BMC",
+           "interface": {
+             "type": "management",
+             "mac": "de:ca:fc:0f:fe:e1",
+             "ip": "172.16.0.1"
+           }
          }
        },
        {
-         "xname": "x1000c0s0b1",
-         "description": "Node 2's BMC",
-         "interface": {
-           "type": "management",
-           "mac": "de:ca:fc:0f:fe:e2",
-           "ip": "172.16.0.2"
+         "metadata": {
+           "name": "x1000c0s0b1"
+         },
+         "spec": {
+           "xname": "x1000c0s0b1",
+           "description": "Node 2's BMC",
+           "interface": {
+             "type": "management",
+             "mac": "de:ca:fc:0f:fe:e2",
+             "ip": "172.16.0.2"
+           }
          }
        }
      ]'
+
+  # Add BMC preserving labels/annotations (envelope API)
+  ochami boot bmc add -e -d \
+    '{
+       "metadata": {
+         "name": "x1000c0s0b0",
+         "labels": {
+           "env": "prod"
+         }
+       },
+       "spec": {
+         "xname": "x1000c0s0b0"
+       }
+     }'
 
   # Add BMCs using input payload file
   ochami boot bmc add -d @payload.json
@@ -84,7 +115,15 @@ See ochami-boot(1) for more details.`,
 			}
 
 			// Send off requests
-			bmcsCreated, errs, err := bootServiceClient.AddBMCs(cli.Token, bmcs)
+			envelope, _ := cmd.Flags().GetBool("envelope")
+			var bmcsCreated []*api.BMC
+			var errs []error
+			var err error
+			if envelope {
+				bmcsCreated, errs, err = bootServiceClient.AddBMCs(cli.Token, bmcs)
+			} else {
+				bmcsCreated, errs, err = bootServiceClient.AddBMCsSimple(cli.Token, bmcs)
+			}
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to add BMCs")
 				cli.LogHelpError(cmd)

--- a/cmd/boot/bmc/add.go
+++ b/cmd/boot/bmc/add.go
@@ -15,6 +15,7 @@ import (
 	"github.com/OpenCHAMI/ochami/internal/cli"
 	boot_service_lib "github.com/OpenCHAMI/ochami/internal/cli/boot_service"
 	"github.com/OpenCHAMI/ochami/internal/log"
+	"github.com/OpenCHAMI/ochami/pkg/client/boot_service"
 )
 
 func newCmdBootBmcAdd() *cobra.Command {
@@ -29,17 +30,13 @@ See ochami-boot(1) for more details.`,
 		Example: `  # Add BMC using payload data
   ochami boot bmc add -d \
     '{
-       "metadata": {
-         "name": "x1000c0s0b0"
-       },
-       "spec": {
-         "xname": "x1000c0s0b0",
-         "description": "This node's BMC",
-         "interface": {
-           "type": "management",
-           "mac": "de:ca:fc:0f:fe:e1",
-           "ip": "172.16.0.254"
-         }
+       "name": "bmc01",
+       "xname": "x1000c0s0b0",
+       "description": "This node's BMC",
+       "interface": {
+         "type": "management",
+         "mac": "de:ca:fc:0f:fe:e1",
+         "ip": "172.16.0.254"
        }
      }'
 
@@ -47,31 +44,23 @@ See ochami-boot(1) for more details.`,
   ochami boot bmc add -d \
     '[
        {
-         "metadata": {
-           "name": "x1000c0s0b0"
-         },
-         "spec": {
-           "xname": "x1000c0s0b0",
-           "description": "Node 1's BMC",
-           "interface": {
-             "type": "management",
-             "mac": "de:ca:fc:0f:fe:e1",
-             "ip": "172.16.0.1"
-           }
+         "name": "bmc01",
+         "xname": "x1000c0s0b0",
+         "description": "Node 1's BMC",
+         "interface": {
+           "type": "management",
+           "mac": "de:ca:fc:0f:fe:e1",
+           "ip": "172.16.0.1"
          }
        },
        {
-         "metadata": {
-           "name": "x1000c0s0b1"
-         },
-         "spec": {
-           "xname": "x1000c0s0b1",
-           "description": "Node 2's BMC",
-           "interface": {
-             "type": "management",
-             "mac": "de:ca:fc:0f:fe:e2",
-             "ip": "172.16.0.2"
-           }
+         "name": "bmc02",
+         "xname": "x1000c0s0b1",
+         "description": "Node 2's BMC",
+         "interface": {
+           "type": "management",
+           "mac": "de:ca:fc:0f:fe:e2",
+           "ip": "172.16.0.2"
          }
        }
      ]'
@@ -106,40 +95,60 @@ See ochami-boot(1) for more details.`,
 			// Handle token for this command
 			cli.HandleToken(cmd)
 
-			// Read node data
-			bmcs := []boot_service_client.CreateBMCRequest{}
-			if cmd.Flag("data").Changed {
-				cli.HandlePayloadSlice[boot_service_client.CreateBMCRequest](cmd, &bmcs)
-			} else {
-				cli.HandlePayloadStdinSlice[boot_service_client.CreateBMCRequest](cmd, &bmcs)
+			// Determine how to read payload (simple versus advanced API)
+			envelope, flagErr := cmd.Flags().GetBool("envelope")
+			if flagErr != nil {
+				log.Logger.Warn().Err(flagErr).Msg("failed to read --envelope, falling back to simple API")
 			}
 
-			// Send off requests
-			envelope, _ := cmd.Flags().GetBool("envelope")
 			var bmcsCreated []*api.BMC
-			var errs []error
-			var err error
+			var reqErrs []error
+			var reqErr error
 			if envelope {
-				bmcsCreated, errs, err = bootServiceClient.AddBMCs(cli.Token, bmcs)
+				// Use advanced API (spec, metadata, annotations)
+
+				// Read node data
+				bmcs := []boot_service_client.CreateBMCRequest{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayloadSlice[boot_service_client.CreateBMCRequest](cmd, &bmcs)
+				} else {
+					cli.HandlePayloadStdinSlice[boot_service_client.CreateBMCRequest](cmd, &bmcs)
+				}
+
+				// Send off requests
+				bmcsCreated, reqErrs, reqErr = bootServiceClient.AddBMCs(cli.Token, bmcs)
 			} else {
-				bmcsCreated, errs, err = bootServiceClient.AddBMCsSimple(cli.Token, bmcs)
+				// Use simple API (spec)
+
+				// Read node data
+				bmcs := []boot_service.BMCSpec{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayloadSlice[boot_service.BMCSpec](cmd, &bmcs)
+				} else {
+					cli.HandlePayloadStdinSlice[boot_service.BMCSpec](cmd, &bmcs)
+				}
+
+				// Send off requests
+				bmcsCreated, reqErrs, reqErr = bootServiceClient.AddBMCSpecs(cli.Token, bmcs)
 			}
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to add BMCs")
+
+			// Handle any non-request error
+			if reqErr != nil {
+				log.Logger.Error().Err(reqErr).Msg("failed to add BMCs")
 				cli.LogHelpError(cmd)
 				os.Exit(1)
 			}
 
 			// Deal with per-request errors
-			var errorsOccurred = false
-			for _, err := range errs {
+			var reqErrorsOccurred = false
+			for _, err := range reqErrs {
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("failed to add BMC")
-					errorsOccurred = true
+					reqErrorsOccurred = true
 				}
 			}
 			log.Logger.Debug().Msgf("BMCs created: %+v", bmcsCreated)
-			if errorsOccurred {
+			if reqErrorsOccurred {
 				cli.LogHelpError(cmd)
 				log.Logger.Warn().Msg("BMC addition completed with errors")
 				os.Exit(1)

--- a/cmd/boot/bmc/bmc.go
+++ b/cmd/boot/bmc/bmc.go
@@ -29,6 +29,9 @@ See ochami-boot(1) for more details.`,
 		},
 	}
 
+	// Create flags
+	bootBmcCmd.PersistentFlags().BoolP("envelope", "e", false, "use the envelope (advanced) API, preserving metadata/labels/annotations, instead of the simple API")
+
 	// Add subcommands
 	bootBmcCmd.AddCommand(
 		newCmdBootBmcAdd(),

--- a/cmd/boot/bmc/set.go
+++ b/cmd/boot/bmc/set.go
@@ -29,14 +29,12 @@ See ochami-boot(1) for more details.`,
 		Example: `  # Set BMC details using payload data
   ochami boot bmc set bmc-773d99bf -d \
     '{
-       "spec": {
-         "xname": "x1000c0s0b0",
-         "description": "This node's BMC",
-         "interface": {
-           "type": "management",
-           "mac": "de:ca:fc:0f:fe:e1",
-           "ip": "172.16.0.254"
-         }
+       "xname": "x1000c0s0b0",
+       "description": "This node's BMC",
+       "interface": {
+         "type": "management",
+         "mac": "de:ca:fc:0f:fe:e1",
+         "ip": "172.16.0.254"
        }
      }'
 
@@ -69,25 +67,43 @@ See ochami-boot(1) for more details.`,
 			// Handle token for this command
 			cli.HandleToken(cmd)
 
-			// Read BMC data
-			bmc := boot_service_client.UpdateBMCRequest{}
-			if cmd.Flag("data").Changed {
-				cli.HandlePayload(cmd, &bmc)
-			} else {
-				cli.HandlePayloadStdin(cmd, &bmc)
+			// Determine how to read payload (simple versus advanced API)
+			envelope, flagErr := cmd.Flags().GetBool("envelope")
+			if flagErr != nil {
+				log.Logger.Warn().Err(flagErr).Msg("failed to read --envelope, falling back to simple API")
 			}
 
-			// Send off requests
-			envelope, _ := cmd.Flags().GetBool("envelope")
 			var bmcSet *api.BMC
-			var err error
+			var reqErr error
 			if envelope {
-				bmcSet, err = bootServiceClient.SetBMC(cli.Token, args[0], bmc)
+				// Use advanced API (spec, metadata, annotations)
+
+				// Read BMC data
+				bmc := boot_service_client.UpdateBMCRequest{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayload(cmd, &bmc)
+				} else {
+					cli.HandlePayloadStdin(cmd, &bmc)
+				}
+
+				// Send off request
+				bmcSet, reqErr = bootServiceClient.SetBMC(cli.Token, args[0], bmc)
 			} else {
-				bmcSet, err = bootServiceClient.SetBMCSimple(cli.Token, args[0], bmc)
+				// Use simple API (spec)
+
+				// Read BMC data
+				spec := api.BMCSpec{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayload(cmd, &spec)
+				} else {
+					cli.HandlePayloadStdin(cmd, &spec)
+				}
+
+				// Send off request
+				bmcSet, reqErr = bootServiceClient.SetBMCSpec(cli.Token, args[0], spec)
 			}
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to set bmc")
+			if reqErr != nil {
+				log.Logger.Error().Err(reqErr).Msg("failed to set bmc")
 				cli.LogHelpError(cmd)
 				os.Exit(1)
 			}

--- a/cmd/boot/bmc/set.go
+++ b/cmd/boot/bmc/set.go
@@ -10,6 +10,8 @@ import (
 	boot_service_client "github.com/openchami/boot-service/pkg/client"
 	"github.com/spf13/cobra"
 
+	api "github.com/openchami/boot-service/apis/boot.openchami.io/v1"
+
 	"github.com/OpenCHAMI/ochami/internal/cli"
 	boot_service_lib "github.com/OpenCHAMI/ochami/internal/cli/boot_service"
 	"github.com/OpenCHAMI/ochami/internal/log"
@@ -27,12 +29,27 @@ See ochami-boot(1) for more details.`,
 		Example: `  # Set BMC details using payload data
   ochami boot bmc set bmc-773d99bf -d \
     '{
-       "xname": "x1000c0s0b0",
-       "description": "This node's BMC",
-       "interface": {
-         "type": "management",
-         "mac": "de:ca:fc:0f:fe:e1",
-         "ip": "172.16.0.254"
+       "spec": {
+         "xname": "x1000c0s0b0",
+         "description": "This node's BMC",
+         "interface": {
+           "type": "management",
+           "mac": "de:ca:fc:0f:fe:e1",
+           "ip": "172.16.0.254"
+         }
+       }
+     }'
+
+  # Set BMC details preserving labels/annotations (envelope API)
+  ochami boot bmc set bmc-773d99bf -e -d \
+    '{
+       "metadata": {
+         "labels": {
+           "env": "prod"
+         }
+       },
+       "spec": {
+         "xname": "x1000c0s0b0"
        }
      }'
 
@@ -61,7 +78,14 @@ See ochami-boot(1) for more details.`,
 			}
 
 			// Send off requests
-			bmcSet, err := bootServiceClient.SetBMC(cli.Token, args[0], bmc)
+			envelope, _ := cmd.Flags().GetBool("envelope")
+			var bmcSet *api.BMC
+			var err error
+			if envelope {
+				bmcSet, err = bootServiceClient.SetBMC(cli.Token, args[0], bmc)
+			} else {
+				bmcSet, err = bootServiceClient.SetBMCSimple(cli.Token, args[0], bmc)
+			}
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to set bmc")
 				cli.LogHelpError(cmd)

--- a/cmd/boot/config/add.go
+++ b/cmd/boot/config/add.go
@@ -15,6 +15,7 @@ import (
 	"github.com/OpenCHAMI/ochami/internal/cli"
 	boot_service_lib "github.com/OpenCHAMI/ochami/internal/cli/boot_service"
 	"github.com/OpenCHAMI/ochami/internal/log"
+	"github.com/OpenCHAMI/ochami/pkg/client/boot_service"
 )
 
 func newCmdBootConfigAdd() *cobra.Command {
@@ -29,59 +30,47 @@ See ochami-boot(1) for more details.`,
 		Example: `  # Add boot configuration using payload data
   ochami boot config add -d \
     '{
-       "metadata": {
-         "name": "compute-boot"
-       },
-       "spec": {
-         "hosts": [
-           "item1",
-           "item2"
-         ],
-         "macs": [
-           "de:ca:fc:0f:fe:e1",
-           "de:ca:fc:0f:fe:e2"
-         ],
-         "nids": [
-           1,
-           2
-         ],
-         "groups": [
-           "group1",
-           "group2"
-         ],
-         "kernel": "http://s3.openchami.cluster/kernels/vmlinuz1",
-         "initrd": "http://s3.openchami.cluster/initrds/initramfs1.img",
-         "params": "console=tty0,115200n8 console=ttyS0,115200n8",
-         "priority": 42
-       }
+       "name": "compute-boot",
+       "hosts": [
+         "item1",
+         "item2"
+       ],
+       "macs": [
+         "de:ca:fc:0f:fe:e1",
+         "de:ca:fc:0f:fe:e2"
+       ],
+       "nids": [
+         1,
+         2
+       ],
+       "groups": [
+         "group1",
+         "group2"
+       ],
+       "kernel": "http://s3.openchami.cluster/kernels/vmlinuz1",
+       "initrd": "http://s3.openchami.cluster/initrds/initramfs1.img",
+       "params": "console=tty0,115200n8 console=ttyS0,115200n8",
+       "priority": 42
      }'
 
   # Add multiple boot configurations using payload data
   ochami boot config add -d \
     '[
        {
-         "metadata": {
-           "name": "boot-by-host"
-         },
-         "spec": {
-           "hosts": ["host1"],
-           "kernel": "http://s3.openchami.cluster/kernels/vmlinuz1",
-           "initrd": "http://s3.openchami.cluster/initrds/initramfs1.img",
-           "params": "console=tty0,115200n8 console=ttyS0,115200n8",
-           "priority": 42
-         }
+         "name": "boot-by-host",
+         "hosts": ["host1"],
+         "kernel": "http://s3.openchami.cluster/kernels/vmlinuz1",
+         "initrd": "http://s3.openchami.cluster/initrds/initramfs1.img",
+         "params": "console=tty0,115200n8 console=ttyS0,115200n8",
+         "priority": 42
        },
        {
-         "metadata": {
-           "name": "boot-by-mac"
-         },
-         "spec": {
-           "macs": ["de:ca:fc:0f:fe:ee"],
-           "kernel": "http://s3.openchami.cluster/kernels/vmlinuz2",
-           "initrd": "http://s3.openchami.cluster/initrds/initramfs2.img",
-           "params": "ip=dhcp",
-           "priority": 43
-         }
+         "name": "boot-by-mac",
+         "macs": ["de:ca:fc:0f:fe:ee"],
+         "kernel": "http://s3.openchami.cluster/kernels/vmlinuz2",
+         "initrd": "http://s3.openchami.cluster/initrds/initramfs2.img",
+         "params": "ip=dhcp",
+         "priority": 43
        }
      ]'
 
@@ -116,40 +105,60 @@ See ochami-boot(1) for more details.`,
 			// Handle token for this command
 			cli.HandleToken(cmd)
 
-			// Read boot configuration data
-			bcs := []boot_service_client.CreateBootConfigurationRequest{}
-			if cmd.Flag("data").Changed {
-				cli.HandlePayloadSlice[boot_service_client.CreateBootConfigurationRequest](cmd, &bcs)
-			} else {
-				cli.HandlePayloadStdinSlice[boot_service_client.CreateBootConfigurationRequest](cmd, &bcs)
+			// Determine how to read payload (simple versus advanced API)
+			envelope, flagErr := cmd.Flags().GetBool("envelope")
+			if flagErr != nil {
+				log.Logger.Warn().Err(flagErr).Msg("failed to read --envelope, falling back to simple API")
 			}
 
-			// Send off requests
-			envelope, _ := cmd.Flags().GetBool("envelope")
 			var cfgsCreated []*api.BootConfiguration
-			var errs []error
-			var err error
+			var reqErrs []error
+			var reqErr error
 			if envelope {
-				cfgsCreated, errs, err = bootServiceClient.AddBootConfigs(cli.Token, bcs)
+				// Use advanced API (spec, metadata, annotations)
+
+				// Read boot configuration data
+				bcs := []boot_service_client.CreateBootConfigurationRequest{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayloadSlice[boot_service_client.CreateBootConfigurationRequest](cmd, &bcs)
+				} else {
+					cli.HandlePayloadStdinSlice[boot_service_client.CreateBootConfigurationRequest](cmd, &bcs)
+				}
+
+				// Send off requests
+				cfgsCreated, reqErrs, reqErr = bootServiceClient.AddBootConfigs(cli.Token, bcs)
 			} else {
-				cfgsCreated, errs, err = bootServiceClient.AddBootConfigsSimple(cli.Token, bcs)
+				// Use simple API (spec)
+
+				// Read boot configuration data
+				bcs := []boot_service.BootConfigSpec{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayloadSlice[boot_service.BootConfigSpec](cmd, &bcs)
+				} else {
+					cli.HandlePayloadStdinSlice[boot_service.BootConfigSpec](cmd, &bcs)
+				}
+
+				// Send off requests
+				cfgsCreated, reqErrs, reqErr = bootServiceClient.AddBootConfigSpecs(cli.Token, bcs)
 			}
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to add boot configurations")
+
+			// Handle any non-request error
+			if reqErr != nil {
+				log.Logger.Error().Err(reqErr).Msg("failed to add boot configurations")
 				cli.LogHelpError(cmd)
 				os.Exit(1)
 			}
 
 			// Deal with per-request errors
-			var errorsOccurred = false
-			for _, err := range errs {
+			var reqErrorsOccurred = false
+			for _, err := range reqErrs {
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("failed to add boot configuration")
-					errorsOccurred = true
+					reqErrorsOccurred = true
 				}
 			}
 			log.Logger.Debug().Msgf("boot configs created: %+v", cfgsCreated)
-			if errorsOccurred {
+			if reqErrorsOccurred {
 				cli.LogHelpError(cmd)
 				log.Logger.Warn().Msg("boot configuration addition completed with errors")
 				os.Exit(1)

--- a/cmd/boot/config/add.go
+++ b/cmd/boot/config/add.go
@@ -10,6 +10,8 @@ import (
 	boot_service_client "github.com/openchami/boot-service/pkg/client"
 	"github.com/spf13/cobra"
 
+	api "github.com/openchami/boot-service/apis/boot.openchami.io/v1"
+
 	"github.com/OpenCHAMI/ochami/internal/cli"
 	boot_service_lib "github.com/OpenCHAMI/ochami/internal/cli/boot_service"
 	"github.com/OpenCHAMI/ochami/internal/log"
@@ -27,46 +29,76 @@ See ochami-boot(1) for more details.`,
 		Example: `  # Add boot configuration using payload data
   ochami boot config add -d \
     '{
-       "hosts": [
-         "item1",
-         "item2"
-       ],
-       "macs": [
-         "de:ca:fc:0f:fe:e1",
-         "de:ca:fc:0f:fe:e2"
-       ],
-       "nids": [
-         1,
-         2
-       ],
-       "groups": [
-         "group1",
-         "group2"
-       ],
-       "kernel": "http://s3.openchami.cluster/kernels/vmlinuz1",
-       "initrd": "http://s3.openchami.cluster/initrds/initramfs1.img",
-       "params": "console=tty0,115200n8 console=ttyS0,115200n8",
-       "priority": 42
+       "metadata": {
+         "name": "compute-boot"
+       },
+       "spec": {
+         "hosts": [
+           "item1",
+           "item2"
+         ],
+         "macs": [
+           "de:ca:fc:0f:fe:e1",
+           "de:ca:fc:0f:fe:e2"
+         ],
+         "nids": [
+           1,
+           2
+         ],
+         "groups": [
+           "group1",
+           "group2"
+         ],
+         "kernel": "http://s3.openchami.cluster/kernels/vmlinuz1",
+         "initrd": "http://s3.openchami.cluster/initrds/initramfs1.img",
+         "params": "console=tty0,115200n8 console=ttyS0,115200n8",
+         "priority": 42
+       }
      }'
 
   # Add multiple boot configurations using payload data
   ochami boot config add -d \
     '[
        {
-         "hosts": ["host1"],
-         "kernel": "http://s3.openchami.cluster/kernels/vmlinuz1",
-         "initrd": "http://s3.openchami.cluster/initrds/initramfs1.img",
-         "params": "console=tty0,115200n8 console=ttyS0,115200n8",
-         "priority": 42
+         "metadata": {
+           "name": "boot-by-host"
+         },
+         "spec": {
+           "hosts": ["host1"],
+           "kernel": "http://s3.openchami.cluster/kernels/vmlinuz1",
+           "initrd": "http://s3.openchami.cluster/initrds/initramfs1.img",
+           "params": "console=tty0,115200n8 console=ttyS0,115200n8",
+           "priority": 42
+         }
        },
        {
-         "macs": ["de:ca:fc:0f:fe:ee"],
-         "kernel": "http://s3.openchami.cluster/kernels/vmlinuz2",
-         "initrd": "http://s3.openchami.cluster/initrds/initramfs2.img",
-         "params": "ip=dhcp",
-         "priority": 43
+         "metadata": {
+           "name": "boot-by-mac"
+         },
+         "spec": {
+           "macs": ["de:ca:fc:0f:fe:ee"],
+           "kernel": "http://s3.openchami.cluster/kernels/vmlinuz2",
+           "initrd": "http://s3.openchami.cluster/initrds/initramfs2.img",
+           "params": "ip=dhcp",
+           "priority": 43
+         }
        }
      ]'
+
+  # Add boot configuration preserving labels/annotations (envelope API)
+  ochami boot config add -e -d \
+    '{
+       "metadata": {
+         "name": "compute-boot",
+         "labels": {
+           "env": "prod"
+         }
+       },
+       "spec": {
+         "hosts": ["item1"],
+         "kernel": "http://s3.openchami.cluster/kernels/vmlinuz1"
+       }
+     }'
 
   # Add boot configuration using input payload file
   ochami boot config add -d @payload.json
@@ -93,7 +125,15 @@ See ochami-boot(1) for more details.`,
 			}
 
 			// Send off requests
-			cfgsCreated, errs, err := bootServiceClient.AddBootConfigs(cli.Token, bcs)
+			envelope, _ := cmd.Flags().GetBool("envelope")
+			var cfgsCreated []*api.BootConfiguration
+			var errs []error
+			var err error
+			if envelope {
+				cfgsCreated, errs, err = bootServiceClient.AddBootConfigs(cli.Token, bcs)
+			} else {
+				cfgsCreated, errs, err = bootServiceClient.AddBootConfigsSimple(cli.Token, bcs)
+			}
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to add boot configurations")
 				cli.LogHelpError(cmd)

--- a/cmd/boot/config/config.go
+++ b/cmd/boot/config/config.go
@@ -30,6 +30,9 @@ See ochami-boot(1) for more details.`,
 		},
 	}
 
+	// Create flags
+	bootConfigCmd.PersistentFlags().BoolP("envelope", "e", false, "use the envelope (advanced) API, preserving metadata/labels/annotations, instead of the simple API")
+
 	// Add subcommands
 	bootConfigCmd.AddCommand(
 		newCmdBootConfigAdd(),

--- a/cmd/boot/config/set.go
+++ b/cmd/boot/config/set.go
@@ -29,28 +29,26 @@ See ochami-boot(1) for more details.`,
 		Example: `  # Set boot configuration using payload data
   ochami boot config set boo-914afad2 -d \
     '{
-       "spec": {
-         "hosts": [
-           "item1",
-           "item2"
-         ],
-         "macs": [
-           "de:ca:fc:0f:fe:e1",
-           "de:ca:fc:0f:fe:e2"
-         ],
-         "nids": [
-           1,
-           2
-         ],
-         "groups": [
-           "group1",
-           "group2"
-         ],
-         "kernel": "http://s3.openchami.cluster/kernels/vmlinuz1",
-         "initrd": "http://s3.openchami.cluster/initrds/initramfs1.img",
-         "params": "console=tty0,115200n8 console=ttyS0,115200n8",
-         "priority": 42
-       }
+       "hosts": [
+         "item1",
+         "item2"
+       ],
+       "macs": [
+         "de:ca:fc:0f:fe:e1",
+         "de:ca:fc:0f:fe:e2"
+       ],
+       "nids": [
+         1,
+         2
+       ],
+       "groups": [
+         "group1",
+         "group2"
+       ],
+       "kernel": "http://s3.openchami.cluster/kernels/vmlinuz1",
+       "initrd": "http://s3.openchami.cluster/initrds/initramfs1.img",
+       "params": "console=tty0,115200n8 console=ttyS0,115200n8",
+       "priority": 42
      }'
 
   # Set boot configuration preserving labels/annotations (envelope API)
@@ -83,25 +81,43 @@ See ochami-boot(1) for more details.`,
 			// Handle token for this command
 			cli.HandleToken(cmd)
 
-			// Read boot configuration data
-			bcs := boot_service_client.UpdateBootConfigurationRequest{}
-			if cmd.Flag("data").Changed {
-				cli.HandlePayload(cmd, &bcs)
-			} else {
-				cli.HandlePayloadStdin(cmd, &bcs)
+			// Determine how to read payload (simple versus advanced API)
+			envelope, flagErr := cmd.Flags().GetBool("envelope")
+			if flagErr != nil {
+				log.Logger.Warn().Err(flagErr).Msg("failed to read --envelope, falling back to simple API")
 			}
 
-			// Send off requests
-			envelope, _ := cmd.Flags().GetBool("envelope")
 			var cfgSet *api.BootConfiguration
-			var err error
+			var reqErr error
 			if envelope {
-				cfgSet, err = bootServiceClient.SetBootConfig(cli.Token, args[0], bcs)
+				// Use advanced API (spec, metadata, annotations)
+
+				// Read boot configuration data
+				bcs := boot_service_client.UpdateBootConfigurationRequest{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayload(cmd, &bcs)
+				} else {
+					cli.HandlePayloadStdin(cmd, &bcs)
+				}
+
+				// Send off request
+				cfgSet, reqErr = bootServiceClient.SetBootConfig(cli.Token, args[0], bcs)
 			} else {
-				cfgSet, err = bootServiceClient.SetBootConfigSimple(cli.Token, args[0], bcs)
+				// Use simple API (spec)
+
+				// Read boot configuration data
+				spec := api.BootConfigurationSpec{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayload(cmd, &spec)
+				} else {
+					cli.HandlePayloadStdin(cmd, &spec)
+				}
+
+				// Send off request
+				cfgSet, reqErr = bootServiceClient.SetBootConfigSpec(cli.Token, args[0], spec)
 			}
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to set boot configuration")
+			if reqErr != nil {
+				log.Logger.Error().Err(reqErr).Msg("failed to set boot configuration")
 				cli.LogHelpError(cmd)
 				os.Exit(1)
 			}

--- a/cmd/boot/config/set.go
+++ b/cmd/boot/config/set.go
@@ -10,6 +10,8 @@ import (
 	boot_service_client "github.com/openchami/boot-service/pkg/client"
 	"github.com/spf13/cobra"
 
+	api "github.com/openchami/boot-service/apis/boot.openchami.io/v1"
+
 	"github.com/OpenCHAMI/ochami/internal/cli"
 	boot_service_lib "github.com/OpenCHAMI/ochami/internal/cli/boot_service"
 	"github.com/OpenCHAMI/ochami/internal/log"
@@ -27,26 +29,42 @@ See ochami-boot(1) for more details.`,
 		Example: `  # Set boot configuration using payload data
   ochami boot config set boo-914afad2 -d \
     '{
-       "hosts": [
-         "item1",
-         "item2"
-       ],
-       "macs": [
-         "de:ca:fc:0f:fe:e1",
-         "de:ca:fc:0f:fe:e2"
-       ],
-       "nids": [
-         1,
-         2
-       ],
-       "groups": [
-         "group1",
-         "group2"
-       ],
-       "kernel": "http://s3.openchami.cluster/kernels/vmlinuz1",
-       "initrd": "http://s3.openchami.cluster/initrds/initramfs1.img",
-       "params": "console=tty0,115200n8 console=ttyS0,115200n8",
-       "priority": 42
+       "spec": {
+         "hosts": [
+           "item1",
+           "item2"
+         ],
+         "macs": [
+           "de:ca:fc:0f:fe:e1",
+           "de:ca:fc:0f:fe:e2"
+         ],
+         "nids": [
+           1,
+           2
+         ],
+         "groups": [
+           "group1",
+           "group2"
+         ],
+         "kernel": "http://s3.openchami.cluster/kernels/vmlinuz1",
+         "initrd": "http://s3.openchami.cluster/initrds/initramfs1.img",
+         "params": "console=tty0,115200n8 console=ttyS0,115200n8",
+         "priority": 42
+       }
+     }'
+
+  # Set boot configuration preserving labels/annotations (envelope API)
+  ochami boot config set boo-914afad2 -e -d \
+    '{
+       "metadata": {
+         "labels": {
+           "env": "prod"
+         }
+       },
+       "spec": {
+         "hosts": ["item1"],
+         "kernel": "http://s3.openchami.cluster/kernels/vmlinuz1"
+       }
      }'
 
   # Set boot configuration using input payload file
@@ -74,7 +92,14 @@ See ochami-boot(1) for more details.`,
 			}
 
 			// Send off requests
-			cfgSet, err := bootServiceClient.SetBootConfig(cli.Token, args[0], bcs)
+			envelope, _ := cmd.Flags().GetBool("envelope")
+			var cfgSet *api.BootConfiguration
+			var err error
+			if envelope {
+				cfgSet, err = bootServiceClient.SetBootConfig(cli.Token, args[0], bcs)
+			} else {
+				cfgSet, err = bootServiceClient.SetBootConfigSimple(cli.Token, args[0], bcs)
+			}
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to set boot configuration")
 				cli.LogHelpError(cmd)

--- a/cmd/boot/node/add.go
+++ b/cmd/boot/node/add.go
@@ -10,6 +10,8 @@ import (
 	boot_service_client "github.com/openchami/boot-service/pkg/client"
 	"github.com/spf13/cobra"
 
+	api "github.com/openchami/boot-service/apis/boot.openchami.io/v1"
+
 	"github.com/OpenCHAMI/ochami/internal/cli"
 	boot_service_lib "github.com/OpenCHAMI/ochami/internal/cli/boot_service"
 	"github.com/OpenCHAMI/ochami/internal/log"
@@ -27,32 +29,15 @@ See ochami-boot(1) for more details.`,
 		Example: `  # Add node using payload data
   ochami boot node add -d \
     '{
-       "xname": "x1000c0s0b0n0",
-       "nid": 42,
-       "bootMac": "de:ca:fc:0f:fe:e1",
-       "role": "example-role",
-       "subRole": "example-subrole",
-       "hostname": "ex01.example.org",
-       "interfaces": [
-         {
-           "type": "management",
-           "mac": "de:ca:fc:0f:fe:e1",
-           "ip": "172.16.0.1"
-         }
-       ],
-       "groups": [
-         "group1",
-         "group2"
-       ]
-     }'
-
-  # Add multiple nodes using payload data
-  ochami boot node add -d \
-    '[
-       {
+       "metadata": {
+         "name": "x1000c0s0b0n0"
+       },
+       "spec": {
          "xname": "x1000c0s0b0n0",
          "nid": 42,
          "bootMac": "de:ca:fc:0f:fe:e1",
+         "role": "example-role",
+         "subRole": "example-subrole",
          "hostname": "ex01.example.org",
          "interfaces": [
            {
@@ -60,22 +45,69 @@ See ochami-boot(1) for more details.`,
              "mac": "de:ca:fc:0f:fe:e1",
              "ip": "172.16.0.1"
            }
-         ]
-       },
-       {
-         "xname": "x1000c0s0b0n1",
-         "nid": 43,
-         "bootMac": "de:ca:fc:0f:fe:e2",
-         "hostname": "ex02.example.org",
-         "interfaces": [
-           {
-             "type": "management",
-             "mac": "de:ca:fc:0f:fe:e2",
-             "ip": "172.16.0.2"
-           }
+         ],
+         "groups": [
+           "group1",
+           "group2"
          ]
        }
+     }'
+
+  # Add multiple nodes using payload data
+  ochami boot node add -d \
+    '[
+       {
+         "metadata": {
+           "name": "x1000c0s0b0n0"
+         },
+         "spec": {
+           "xname": "x1000c0s0b0n0",
+           "nid": 42,
+           "bootMac": "de:ca:fc:0f:fe:e1",
+           "hostname": "ex01.example.org",
+           "interfaces": [
+             {
+               "type": "management",
+               "mac": "de:ca:fc:0f:fe:e1",
+               "ip": "172.16.0.1"
+             }
+           ]
+         }
+       },
+       {
+         "metadata": {
+           "name": "x1000c0s0b0n1"
+         },
+         "spec": {
+           "xname": "x1000c0s0b0n1",
+           "nid": 43,
+           "bootMac": "de:ca:fc:0f:fe:e2",
+           "hostname": "ex02.example.org",
+           "interfaces": [
+             {
+               "type": "management",
+               "mac": "de:ca:fc:0f:fe:e2",
+               "ip": "172.16.0.2"
+             }
+           ]
+         }
+       }
      ]'
+
+  # Add node preserving labels/annotations (envelope API)
+  ochami boot node add -e -d \
+    '{
+       "metadata": {
+         "name": "x1000c0s0b0n0",
+         "labels": {
+           "env": "prod"
+         }
+       },
+       "spec": {
+         "xname": "x1000c0s0b0n0",
+         "nid": 42
+       }
+     }'
 
   # Add nodes using input payload file
   ochami boot node add -d @payload.json
@@ -102,7 +134,15 @@ See ochami-boot(1) for more details.`,
 			}
 
 			// Send off requests
-			nodesCreated, errs, err := bootServiceClient.AddNodes(cli.Token, nodes)
+			envelope, _ := cmd.Flags().GetBool("envelope")
+			var nodesCreated []*api.Node
+			var errs []error
+			var err error
+			if envelope {
+				nodesCreated, errs, err = bootServiceClient.AddNodes(cli.Token, nodes)
+			} else {
+				nodesCreated, errs, err = bootServiceClient.AddNodesSimple(cli.Token, nodes)
+			}
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to add nodes")
 				cli.LogHelpError(cmd)

--- a/cmd/boot/node/add.go
+++ b/cmd/boot/node/add.go
@@ -15,6 +15,7 @@ import (
 	"github.com/OpenCHAMI/ochami/internal/cli"
 	boot_service_lib "github.com/OpenCHAMI/ochami/internal/cli/boot_service"
 	"github.com/OpenCHAMI/ochami/internal/log"
+	"github.com/OpenCHAMI/ochami/pkg/client/boot_service"
 )
 
 func newCmdBootNodeAdd() *cobra.Command {
@@ -29,15 +30,34 @@ See ochami-boot(1) for more details.`,
 		Example: `  # Add node using payload data
   ochami boot node add -d \
     '{
-       "metadata": {
-         "name": "x1000c0s0b0n0"
-       },
-       "spec": {
+       "name": "node01",
+       "xname": "x1000c0s0b0n0",
+       "nid": 42,
+       "bootMac": "de:ca:fc:0f:fe:e1",
+       "role": "example-role",
+       "subRole": "example-subrole",
+       "hostname": "ex01.example.org",
+       "interfaces": [
+         {
+           "type": "management",
+           "mac": "de:ca:fc:0f:fe:e1",
+           "ip": "172.16.0.1"
+         }
+       ],
+       "groups": [
+         "group1",
+         "group2"
+       ]
+     }'
+
+  # Add multiple nodes using payload data
+  ochami boot node add -d \
+    '[
+       {
+         "name": "node01",
          "xname": "x1000c0s0b0n0",
          "nid": 42,
          "bootMac": "de:ca:fc:0f:fe:e1",
-         "role": "example-role",
-         "subRole": "example-subrole",
          "hostname": "ex01.example.org",
          "interfaces": [
            {
@@ -45,52 +65,21 @@ See ochami-boot(1) for more details.`,
              "mac": "de:ca:fc:0f:fe:e1",
              "ip": "172.16.0.1"
            }
-         ],
-         "groups": [
-           "group1",
-           "group2"
          ]
-       }
-     }'
-
-  # Add multiple nodes using payload data
-  ochami boot node add -d \
-    '[
-       {
-         "metadata": {
-           "name": "x1000c0s0b0n0"
-         },
-         "spec": {
-           "xname": "x1000c0s0b0n0",
-           "nid": 42,
-           "bootMac": "de:ca:fc:0f:fe:e1",
-           "hostname": "ex01.example.org",
-           "interfaces": [
-             {
-               "type": "management",
-               "mac": "de:ca:fc:0f:fe:e1",
-               "ip": "172.16.0.1"
-             }
-           ]
-         }
        },
        {
-         "metadata": {
-           "name": "x1000c0s0b0n1"
-         },
-         "spec": {
-           "xname": "x1000c0s0b0n1",
-           "nid": 43,
-           "bootMac": "de:ca:fc:0f:fe:e2",
-           "hostname": "ex02.example.org",
-           "interfaces": [
-             {
-               "type": "management",
-               "mac": "de:ca:fc:0f:fe:e2",
-               "ip": "172.16.0.2"
-             }
-           ]
-         }
+         "name": "node02",
+         "xname": "x1000c0s0b0n1",
+         "nid": 43,
+         "bootMac": "de:ca:fc:0f:fe:e2",
+         "hostname": "ex02.example.org",
+         "interfaces": [
+           {
+             "type": "management",
+             "mac": "de:ca:fc:0f:fe:e2",
+             "ip": "172.16.0.2"
+           }
+         ]
        }
      ]'
 
@@ -125,40 +114,60 @@ See ochami-boot(1) for more details.`,
 			// Handle token for this command
 			cli.HandleToken(cmd)
 
-			// Read node data
-			nodes := []boot_service_client.CreateNodeRequest{}
-			if cmd.Flag("data").Changed {
-				cli.HandlePayloadSlice[boot_service_client.CreateNodeRequest](cmd, &nodes)
-			} else {
-				cli.HandlePayloadStdinSlice[boot_service_client.CreateNodeRequest](cmd, &nodes)
+			// Determine how to read payload (simple versus advanced API)
+			envelope, flagErr := cmd.Flags().GetBool("envelope")
+			if flagErr != nil {
+				log.Logger.Warn().Err(flagErr).Msg("failed to read --envelope, falling back to simple API")
 			}
 
-			// Send off requests
-			envelope, _ := cmd.Flags().GetBool("envelope")
 			var nodesCreated []*api.Node
-			var errs []error
-			var err error
+			var reqErrs []error
+			var reqErr error
 			if envelope {
-				nodesCreated, errs, err = bootServiceClient.AddNodes(cli.Token, nodes)
+				// Use advanced API (spec, metadata, annotations)
+
+				// Read node data
+				nodes := []boot_service_client.CreateNodeRequest{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayloadSlice[boot_service_client.CreateNodeRequest](cmd, &nodes)
+				} else {
+					cli.HandlePayloadStdinSlice[boot_service_client.CreateNodeRequest](cmd, &nodes)
+				}
+
+				// Send off requests
+				nodesCreated, reqErrs, reqErr = bootServiceClient.AddNodes(cli.Token, nodes)
 			} else {
-				nodesCreated, errs, err = bootServiceClient.AddNodesSimple(cli.Token, nodes)
+				// Use simple API (spec)
+
+				// Read node data
+				nodes := []boot_service.NodeSpec{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayloadSlice[boot_service.NodeSpec](cmd, &nodes)
+				} else {
+					cli.HandlePayloadStdinSlice[boot_service.NodeSpec](cmd, &nodes)
+				}
+
+				// Send off requests
+				nodesCreated, reqErrs, reqErr = bootServiceClient.AddNodeSpecs(cli.Token, nodes)
 			}
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to add nodes")
+
+			// Handle any non-request error
+			if reqErr != nil {
+				log.Logger.Error().Err(reqErr).Msg("failed to add nodes")
 				cli.LogHelpError(cmd)
 				os.Exit(1)
 			}
 
 			// Deal with per-request errors
-			var errorsOccurred = false
-			for _, err := range errs {
+			var reqErrorsOccurred = false
+			for _, err := range reqErrs {
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("failed to add node")
-					errorsOccurred = true
+					reqErrorsOccurred = true
 				}
 			}
 			log.Logger.Debug().Msgf("nodes created: %+v", nodesCreated)
-			if errorsOccurred {
+			if reqErrorsOccurred {
 				cli.LogHelpError(cmd)
 				log.Logger.Warn().Msg("node addition completed with errors")
 				os.Exit(1)

--- a/cmd/boot/node/node.go
+++ b/cmd/boot/node/node.go
@@ -29,6 +29,9 @@ See ochami-boot(1) for more details.`,
 		},
 	}
 
+	// Create flags
+	bootNodeCmd.PersistentFlags().BoolP("envelope", "e", false, "use the envelope (advanced) API, preserving metadata/labels/annotations, instead of the simple API")
+
 	// Add subcommands
 	bootNodeCmd.AddCommand(
 		newCmdBootNodeAdd(),

--- a/cmd/boot/node/set.go
+++ b/cmd/boot/node/set.go
@@ -29,25 +29,23 @@ See ochami-boot(1) for more details.`,
 		Example: `  # Set node details using payload data
   ochami boot node set nod-bc76f7f2 -d \
     '{
-       "spec": {
-         "xname": "x1000c0s0b0n0",
-         "nid": 42,
-         "bootMac": "de:ca:fc:0f:fe:e1",
-         "role": "example-role",
-         "subRole": "example-subrole",
-         "hostname": "ex01.example.org",
-         "interfaces": [
-           {
-             "type": "management",
-             "mac": "de:ca:fc:0f:fe:e1",
-             "ip": "172.16.0.1"
-           }
-         ],
-         "groups": [
-           "group1",
-           "group2"
-         ]
-       }
+       "xname": "x1000c0s0b0n0",
+       "nid": 42,
+       "bootMac": "de:ca:fc:0f:fe:e1",
+       "role": "example-role",
+       "subRole": "example-subrole",
+       "hostname": "ex01.example.org",
+       "interfaces": [
+         {
+           "type": "management",
+           "mac": "de:ca:fc:0f:fe:e1",
+           "ip": "172.16.0.1"
+         }
+       ],
+       "groups": [
+         "group1",
+         "group2"
+       ]
      }'
 
   # Set node details preserving labels/annotations (envelope API)
@@ -64,11 +62,11 @@ See ochami-boot(1) for more details.`,
        }
      }'
 
-  # Set boot configuration using input payload file
+  # Set node details using input payload file
   ochami boot node set -d @payload.json nod-bc76f7f2
   ochami boot node set -d @payload.yaml -f yaml nod-bc76f7f2
 
-  # Set boot configuration using data from stdin
+  # Set node details using data from stdin
   echo '<json_data>' | ochami boot node set -d @- nod-bc76f7f2
   echo '<json_data>' | ochami boot node set nod-bc76f7f2
   echo '<yaml_data>' | ochami boot node set -d @- -f yaml nod-bc76f7f2
@@ -80,25 +78,43 @@ See ochami-boot(1) for more details.`,
 			// Handle token for this command
 			cli.HandleToken(cmd)
 
-			// Read node data
-			node := boot_service_client.UpdateNodeRequest{}
-			if cmd.Flag("data").Changed {
-				cli.HandlePayload(cmd, &node)
-			} else {
-				cli.HandlePayloadStdin(cmd, &node)
+			// Determine how to read payload (simple versus advanced API)
+			envelope, flagErr := cmd.Flags().GetBool("envelope")
+			if flagErr != nil {
+				log.Logger.Warn().Err(flagErr).Msg("failed to read --envelope, falling back to simple API")
 			}
 
-			// Send off requests
-			envelope, _ := cmd.Flags().GetBool("envelope")
 			var nodeSet *api.Node
-			var err error
+			var reqErr error
 			if envelope {
-				nodeSet, err = bootServiceClient.SetNode(cli.Token, args[0], node)
+				// Use advanced API (spec, metadata, annotations)
+
+				// Read node data
+				node := boot_service_client.UpdateNodeRequest{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayload(cmd, &node)
+				} else {
+					cli.HandlePayloadStdin(cmd, &node)
+				}
+
+				// Send off request
+				nodeSet, reqErr = bootServiceClient.SetNode(cli.Token, args[0], node)
 			} else {
-				nodeSet, err = bootServiceClient.SetNodeSimple(cli.Token, args[0], node)
+				// Use simple API (spec)
+
+				// Read node data
+				spec := api.NodeSpec{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayload(cmd, &spec)
+				} else {
+					cli.HandlePayloadStdin(cmd, &spec)
+				}
+
+				// Send off request
+				nodeSet, reqErr = bootServiceClient.SetNodeSpec(cli.Token, args[0], spec)
 			}
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to set node")
+			if reqErr != nil {
+				log.Logger.Error().Err(reqErr).Msg("failed to set node")
 				cli.LogHelpError(cmd)
 				os.Exit(1)
 			}

--- a/cmd/boot/node/set.go
+++ b/cmd/boot/node/set.go
@@ -10,6 +10,8 @@ import (
 	boot_service_client "github.com/openchami/boot-service/pkg/client"
 	"github.com/spf13/cobra"
 
+	api "github.com/openchami/boot-service/apis/boot.openchami.io/v1"
+
 	"github.com/OpenCHAMI/ochami/internal/cli"
 	boot_service_lib "github.com/OpenCHAMI/ochami/internal/cli/boot_service"
 	"github.com/OpenCHAMI/ochami/internal/log"
@@ -27,23 +29,39 @@ See ochami-boot(1) for more details.`,
 		Example: `  # Set node details using payload data
   ochami boot node set nod-bc76f7f2 -d \
     '{
-       "xname": "x1000c0s0b0n0",
-       "nid": 42,
-       "bootMac": "de:ca:fc:0f:fe:e1",
-       "role": "example-role",
-       "subRole": "example-subrole",
-       "hostname": "ex01.example.org",
-       "interfaces": [
-         {
-           "type": "management",
-           "mac": "de:ca:fc:0f:fe:e1",
-           "ip": "172.16.0.1"
+       "spec": {
+         "xname": "x1000c0s0b0n0",
+         "nid": 42,
+         "bootMac": "de:ca:fc:0f:fe:e1",
+         "role": "example-role",
+         "subRole": "example-subrole",
+         "hostname": "ex01.example.org",
+         "interfaces": [
+           {
+             "type": "management",
+             "mac": "de:ca:fc:0f:fe:e1",
+             "ip": "172.16.0.1"
+           }
+         ],
+         "groups": [
+           "group1",
+           "group2"
+         ]
+       }
+     }'
+
+  # Set node details preserving labels/annotations (envelope API)
+  ochami boot node set nod-bc76f7f2 -e -d \
+    '{
+       "metadata": {
+         "labels": {
+           "env": "prod"
          }
-       ],
-       "groups": [
-         "group1",
-         "group2"
-       ]
+       },
+       "spec": {
+         "xname": "x1000c0s0b0n0",
+         "nid": 42
+       }
      }'
 
   # Set boot configuration using input payload file
@@ -71,7 +89,14 @@ See ochami-boot(1) for more details.`,
 			}
 
 			// Send off requests
-			nodeSet, err := bootServiceClient.SetNode(cli.Token, args[0], node)
+			envelope, _ := cmd.Flags().GetBool("envelope")
+			var nodeSet *api.Node
+			var err error
+			if envelope {
+				nodeSet, err = bootServiceClient.SetNode(cli.Token, args[0], node)
+			} else {
+				nodeSet, err = bootServiceClient.SetNodeSimple(cli.Token, args[0], node)
+			}
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to set node")
 				cli.LogHelpError(cmd)

--- a/cmd/metadata/defaults/add.go
+++ b/cmd/metadata/defaults/add.go
@@ -15,6 +15,7 @@ import (
 	"github.com/OpenCHAMI/ochami/internal/cli"
 	metadata_service_lib "github.com/OpenCHAMI/ochami/internal/cli/metadata_service"
 	"github.com/OpenCHAMI/ochami/internal/log"
+	"github.com/OpenCHAMI/ochami/pkg/client/metadata_service"
 )
 
 func newCmdMetadataDefaultsAdd() *cobra.Command {
@@ -29,74 +30,58 @@ See ochami-metadata(1) for more details.`,
 		Example: `  # Add cluster defaults using payload data
   ochami metadata defaults add -d \
     '{
-      "metadata": {
-        "name": "demo-cluster-defaults"
-      },
-      "spec": {
-        "base_url": "https://demo.openchami.cluster:8443/cloud-init",
-        "cluster_name": "demo",
-        "description": "Demo cluster defaults",
-        "short_name": "nid",
-        "nid_length": 4
-      }
+       "name": "demo-cluster-defaults",
+       "base_url": "https://demo.openchami.cluster:8443/cloud-init",
+       "cluster_name": "demo",
+       "description": "Demo cluster defaults",
+       "short_name": "nid",
+       "nid_length": 4
      }'
 
-  # Add multiple cluster defaults using resource envelope payload data
+  # Add multiple cluster defaults using payload data
   ochami metadata defaults add -d \
     '[
        {
-         "metadata": {
-           "name": "demo1-cluster-defaults"
-         },
-         "spec": {
-           "base_url": "https://demo1.openchami.cluster:8443/cloud-init",
-           "cluster_name": "demo1",
-           "description": "Demo 1 cluster defaults",
-           "short_name": "nid",
-           "nid_length": 4
-         }
+         "name": "demo1-cluster-defaults",
+         "base_url": "https://demo1.openchami.cluster:8443/cloud-init",
+         "cluster_name": "demo1",
+         "description": "Demo 1 cluster defaults",
+         "short_name": "nid",
+         "nid_length": 4
        },
        {
-         "metadata": {
-           "name": "demo2-cluster-defaults"
-         },
-         "spec": {
-           "base_url": "https://demo2.openchami.cluster:8443/cloud-init",
-           "cluster_name": "demo2",
-           "description": "Demo 2 cluster defaults",
-           "short_name": "de",
-           "nid_length": 3
-         }
+         "name": "demo2-cluster-defaults",
+         "base_url": "https://demo2.openchami.cluster:8443/cloud-init",
+         "cluster_name": "demo2",
+         "description": "Demo 2 cluster defaults",
+         "short_name": "de",
+         "nid_length": 3
        }
      ]'
 
-  # Add multiple cluster defaults using YAML array of resource envelopes
+  # Add multiple cluster defaults using YAML array of specs
   ochami metadata defaults add -f yaml <<'EOF'
-  - metadata:
-      name: demo1-cluster-defaults
-    spec:
-      base_url: "https://demo1.openchami.cluster:8443/cloud-init"
-      cluster_name: "demo1"
-  - metadata:
-      name: demo2-cluster-defaults
-    spec:
-      base_url: "https://demo2.openchami.cluster:8443/cloud-init"
-      cluster_name: "demo2"
-  EOF
+   - name: demo1-cluster-defaults
+     base_url: "https://demo1.openchami.cluster:8443/cloud-init"
+     cluster_name: "demo1"
+   - name: demo2-cluster-defaults
+     base_url: "https://demo2.openchami.cluster:8443/cloud-init"
+     cluster_name: "demo2"
+   EOF
 
   # Add cluster defaults preserving labels/annotations (envelope API)
   ochami metadata defaults add -e -d \
     '{
-      "metadata": {
-        "name": "demo-cluster-defaults",
-        "labels": {
-          "env": "prod"
-        }
-      },
-      "spec": {
-        "base_url": "https://demo.openchami.cluster:8443/cloud-init",
-        "cluster_name": "demo"
-      }
+       "metadata": {
+         "name": "demo-cluster-defaults",
+         "labels": {
+           "env": "prod"
+         }
+       },
+       "spec": {
+         "base_url": "https://demo.openchami.cluster:8443/cloud-init",
+         "cluster_name": "demo"
+       }
      }'
 
   # Add cluster defaults using input payload file
@@ -115,36 +100,56 @@ See ochami-metadata(1) for more details.`,
 			// Handle token for this command
 			cli.HandleToken(cmd)
 
-			// Read node data
-			defaults := []metadata_service_client.CreateClusterDefaultsRequest{}
-			if cmd.Flag("data").Changed {
-				cli.HandlePayloadSlice[metadata_service_client.CreateClusterDefaultsRequest](cmd, &defaults)
-			} else {
-				cli.HandlePayloadStdinSlice[metadata_service_client.CreateClusterDefaultsRequest](cmd, &defaults)
+			// Determine how to read payload (simple versus advanced API)
+			envelope, flagErr := cmd.Flags().GetBool("envelope")
+			if flagErr != nil {
+				log.Logger.Warn().Err(flagErr).Msg("failed to read --envelope, falling back to simple API")
 			}
 
-			// Send off requests
-			envelope, _ := cmd.Flags().GetBool("envelope")
 			var defaultsCreated []api.ClusterDefaults
-			var errs []error
-			var err error
+			var reqErrs []error
+			var reqErr error
 			if envelope {
-				defaultsCreated, errs, err = metadataServiceClient.AddDefaults(cli.Token, defaults)
+				// Use advanced API (spec, metadata, annotations)
+
+				// Read cluster defaults data
+				defaults := []metadata_service_client.CreateClusterDefaultsRequest{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayloadSlice[metadata_service_client.CreateClusterDefaultsRequest](cmd, &defaults)
+				} else {
+					cli.HandlePayloadStdinSlice[metadata_service_client.CreateClusterDefaultsRequest](cmd, &defaults)
+				}
+
+				// Send off requests
+				defaultsCreated, reqErrs, reqErr = metadataServiceClient.AddDefaults(cli.Token, defaults)
 			} else {
-				defaultsCreated, errs, err = metadataServiceClient.AddDefaultsSimple(cli.Token, defaults)
+				// Use simple API (spec)
+
+				// Read cluster defaults data
+				defaults := []metadata_service.ClusterDefaultsSpec{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayloadSlice[metadata_service.ClusterDefaultsSpec](cmd, &defaults)
+				} else {
+					cli.HandlePayloadStdinSlice[metadata_service.ClusterDefaultsSpec](cmd, &defaults)
+				}
+
+				// Send off requests
+				defaultsCreated, reqErrs, reqErr = metadataServiceClient.AddDefaultsSpecs(cli.Token, defaults)
 			}
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to add cluster defaults")
+
+			// Handle any non-request error
+			if reqErr != nil {
+				log.Logger.Error().Err(reqErr).Msg("failed to add cluster defaults")
 				cli.LogHelpError(cmd)
 				os.Exit(1)
 			}
 
 			// Deal with per-request errors
-			var errorsOccurred = false
-			for _, err := range errs {
+			var reqErrorsOccurred = false
+			for _, err := range reqErrs {
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("failed to add cluster defaults")
-					errorsOccurred = true
+					reqErrorsOccurred = true
 				}
 			}
 
@@ -156,7 +161,7 @@ See ochami-metadata(1) for more details.`,
 			log.Logger.Info().Msgf("Cluster defaults created: %+v", uids)
 
 			// Warn if any request errors occurred
-			if errorsOccurred {
+			if reqErrorsOccurred {
 				cli.LogHelpError(cmd)
 				log.Logger.Warn().Msg("Cluster defaults addition completed with errors")
 				os.Exit(1)

--- a/cmd/metadata/defaults/add.go
+++ b/cmd/metadata/defaults/add.go
@@ -10,6 +10,8 @@ import (
 	metadata_service_client "github.com/OpenCHAMI/metadata-service/pkg/client"
 	"github.com/spf13/cobra"
 
+	api "github.com/OpenCHAMI/metadata-service/apis/cloud-init.openchami.io/v1"
+
 	"github.com/OpenCHAMI/ochami/internal/cli"
 	metadata_service_lib "github.com/OpenCHAMI/ochami/internal/cli/metadata_service"
 	"github.com/OpenCHAMI/ochami/internal/log"
@@ -82,6 +84,21 @@ See ochami-metadata(1) for more details.`,
       cluster_name: "demo2"
   EOF
 
+  # Add cluster defaults preserving labels/annotations (envelope API)
+  ochami metadata defaults add -e -d \
+    '{
+      "metadata": {
+        "name": "demo-cluster-defaults",
+        "labels": {
+          "env": "prod"
+        }
+      },
+      "spec": {
+        "base_url": "https://demo.openchami.cluster:8443/cloud-init",
+        "cluster_name": "demo"
+      }
+     }'
+
   # Add cluster defaults using input payload file
   ochami metadata defaults add -d @payload.json
   ochami metadata defaults add -d @payload.yaml -f yaml
@@ -107,7 +124,15 @@ See ochami-metadata(1) for more details.`,
 			}
 
 			// Send off requests
-			defaultsCreated, errs, err := metadataServiceClient.AddDefaults(cli.Token, defaults)
+			envelope, _ := cmd.Flags().GetBool("envelope")
+			var defaultsCreated []api.ClusterDefaults
+			var errs []error
+			var err error
+			if envelope {
+				defaultsCreated, errs, err = metadataServiceClient.AddDefaults(cli.Token, defaults)
+			} else {
+				defaultsCreated, errs, err = metadataServiceClient.AddDefaultsSimple(cli.Token, defaults)
+			}
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to add cluster defaults")
 				cli.LogHelpError(cmd)

--- a/cmd/metadata/defaults/defaults.go
+++ b/cmd/metadata/defaults/defaults.go
@@ -31,6 +31,9 @@ See ochami-metadata(1) for more details.`,
 		},
 	}
 
+	// Create flags
+	metadataDefaultsCmd.PersistentFlags().BoolP("envelope", "e", false, "use the envelope (advanced) API, preserving metadata/labels/annotations, instead of the simple API")
+
 	// Add subcommands
 	metadataDefaultsCmd.AddCommand(
 		newCmdMetadataDefaultsAdd(),

--- a/cmd/metadata/defaults/set.go
+++ b/cmd/metadata/defaults/set.go
@@ -10,6 +10,8 @@ import (
 	metadata_service_client "github.com/OpenCHAMI/metadata-service/pkg/client"
 	"github.com/spf13/cobra"
 
+	api "github.com/OpenCHAMI/metadata-service/apis/cloud-init.openchami.io/v1"
+
 	"github.com/OpenCHAMI/ochami/internal/cli"
 	metadata_service_lib "github.com/OpenCHAMI/ochami/internal/cli/metadata_service"
 	"github.com/OpenCHAMI/ochami/internal/log"
@@ -64,7 +66,14 @@ See ochami-metadata(1) for more details.`,
 			}
 
 			// Send off requests
-			defaultsSet, err := metadataServiceClient.SetDefaults(cli.Token, args[0], defaults)
+			envelope, _ := cmd.Flags().GetBool("envelope")
+			var defaultsSet *api.ClusterDefaults
+			var err error
+			if envelope {
+				defaultsSet, err = metadataServiceClient.SetDefaults(cli.Token, args[0], defaults)
+			} else {
+				defaultsSet, err = metadataServiceClient.SetDefaultsSimple(cli.Token, args[0], defaults)
+			}
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to set cluster defaults")
 				cli.LogHelpError(cmd)

--- a/cmd/metadata/defaults/set.go
+++ b/cmd/metadata/defaults/set.go
@@ -29,15 +29,24 @@ See ochami-metadata(1) for more details.`,
 		Example: `  # Set cluster defaults details using payload data
   ochami metadata defaults set clusterdefaults-d614b918 -d \
     '{
+       "base_url": "https://demo.openchami.cluster:8443/cloud-init",
+       "cluster_name": "demo",
+       "description": "Demo cluster defaults",
+       "short_name": "nid",
+       "nid_length": 4
+     }'
+
+  # Set cluster defaults details preserving labels/annotations (envelope API)
+  ochami metadata defaults set clusterdefaults-d614b918 -e -d \
+    '{
        "metadata": {
-         "name": "demo-cluster-defaults"
+         "labels": {
+           "env": "prod"
+         }
        },
        "spec": {
          "base_url": "https://demo.openchami.cluster:8443/cloud-init",
-         "cluster_name": "demo",
-         "description": "Demo cluster defaults",
-         "short_name": "nid",
-         "nid_length": 4
+         "cluster_name": "demo"
        }
      }'
 
@@ -57,25 +66,43 @@ See ochami-metadata(1) for more details.`,
 			// Handle token for this command
 			cli.HandleToken(cmd)
 
-			// Read cluster defaults data
-			defaults := metadata_service_client.UpdateClusterDefaultsRequest{}
-			if cmd.Flag("data").Changed {
-				cli.HandlePayload(cmd, &defaults)
-			} else {
-				cli.HandlePayloadStdin(cmd, &defaults)
+			// Determine how to read payload (simple versus advanced API)
+			envelope, flagErr := cmd.Flags().GetBool("envelope")
+			if flagErr != nil {
+				log.Logger.Warn().Err(flagErr).Msg("failed to read --envelope, falling back to simple API")
 			}
 
-			// Send off requests
-			envelope, _ := cmd.Flags().GetBool("envelope")
 			var defaultsSet *api.ClusterDefaults
-			var err error
+			var reqErr error
 			if envelope {
-				defaultsSet, err = metadataServiceClient.SetDefaults(cli.Token, args[0], defaults)
+				// Use advanced API (spec, metadata, annotations)
+
+				// Read cluster defaults data
+				defaults := metadata_service_client.UpdateClusterDefaultsRequest{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayload(cmd, &defaults)
+				} else {
+					cli.HandlePayloadStdin(cmd, &defaults)
+				}
+
+				// Send off request
+				defaultsSet, reqErr = metadataServiceClient.SetDefaults(cli.Token, args[0], defaults)
 			} else {
-				defaultsSet, err = metadataServiceClient.SetDefaultsSimple(cli.Token, args[0], defaults)
+				// Use simple API (spec)
+
+				// Read cluster defaults data
+				spec := api.ClusterDefaultsSpec{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayload(cmd, &spec)
+				} else {
+					cli.HandlePayloadStdin(cmd, &spec)
+				}
+
+				// Send off request
+				defaultsSet, reqErr = metadataServiceClient.SetDefaultsSpec(cli.Token, args[0], spec)
 			}
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to set cluster defaults")
+			if reqErr != nil {
+				log.Logger.Error().Err(reqErr).Msg("failed to set cluster defaults")
 				cli.LogHelpError(cmd)
 				os.Exit(1)
 			}

--- a/cmd/metadata/group/add.go
+++ b/cmd/metadata/group/add.go
@@ -10,6 +10,8 @@ import (
 	metadata_service_client "github.com/OpenCHAMI/metadata-service/pkg/client"
 	"github.com/spf13/cobra"
 
+	api "github.com/OpenCHAMI/metadata-service/apis/cloud-init.openchami.io/v1"
+
 	"github.com/OpenCHAMI/ochami/internal/cli"
 	metadata_service_lib "github.com/OpenCHAMI/ochami/internal/cli/metadata_service"
 	"github.com/OpenCHAMI/ochami/internal/log"
@@ -90,6 +92,20 @@ See ochami-metadata(1) for more details.`,
           - nfs-server
   EOF
 
+  # Add group preserving labels/annotations (envelope API)
+  ochami metadata group add -e -d \
+    '{
+       "metadata": {
+         "name": "storage-group",
+         "labels": {
+           "role": "storage"
+         }
+       },
+       "spec": {
+         "template":"#cloud-config\npackages:\n  - vim\n"
+       }
+     }'
+
   # Add multiple groups from file
   ochami metadata group add -d @groups.json
   ochami metadata group add -d @groups.yaml -f yaml
@@ -115,7 +131,15 @@ See ochami-metadata(1) for more details.`,
 			}
 
 			// Send off requests
-			groupsCreated, errs, err := metadataServiceClient.AddGroups(cli.Token, groups)
+			envelope, _ := cmd.Flags().GetBool("envelope")
+			var groupsCreated []api.Group
+			var errs []error
+			var err error
+			if envelope {
+				groupsCreated, errs, err = metadataServiceClient.AddGroups(cli.Token, groups)
+			} else {
+				groupsCreated, errs, err = metadataServiceClient.AddGroupsSimple(cli.Token, groups)
+			}
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to add groups")
 				cli.LogHelpError(cmd)

--- a/cmd/metadata/group/add.go
+++ b/cmd/metadata/group/add.go
@@ -15,6 +15,7 @@ import (
 	"github.com/OpenCHAMI/ochami/internal/cli"
 	metadata_service_lib "github.com/OpenCHAMI/ochami/internal/cli/metadata_service"
 	"github.com/OpenCHAMI/ochami/internal/log"
+	"github.com/OpenCHAMI/ochami/pkg/client/metadata_service"
 )
 
 func newCmdMetadataGroupAdd() *cobra.Command {
@@ -28,69 +29,51 @@ func newCmdMetadataGroupAdd() *cobra.Command {
 See ochami-metadata(1) for more details.`,
 		Example: `  # Add group with inline multi-line template (YAML via stdin)
   ochami metadata group add -f yaml <<'EOF'
-  metadata:
-    name: compute-group
-  spec:
-    template: |
-      #cloud-config
-      package_update: true
-      packages:
-        - nfs-common
-        - chrony
-    metaData:
-      role: compute
-  EOF
+   name: compute-group
+   template: |
+     #cloud-config
+     package_update: true
+     packages:
+       - nfs-common
+       - chrony
+   metaData:
+     role: compute
+   EOF
 
   # Add group using JSON (single line template)
   ochami metadata group add -d \
     '{
-       "metadata": {
-         "name": "storage-group"
-       },
-       "spec": {
-         "template":"#cloud-config\npackages:\n  - vim\n",
-         "metaData":{"role":"storage"}
-       }
+       "name": "storage-group",
+       "template":"#cloud-config\npackages:\n  - vim\n",
+       "metaData":{"role":"storage"}
      }'
 
-  # Add multiple groups using JSON array of resource envelopes
+  # Add multiple groups using JSON array of specs
   ochami metadata group add -d \
     '[
        {
-         "metadata": {
-           "name": "nfs-client-group"
-         },
-         "spec": {
-           "template":"#cloud-config\npackages:\n  - nfs-common\n"
-         }
+         "name": "nfs-client-group",
+         "template":"#cloud-config\npackages:\n  - nfs-common\n"
        },
        {
-         "metadata": {
-           "name": "nfs-server-group"
-         },
-         "spec": {
-           "template":"#cloud-config\npackages:\n  - nfs-server\n"
-         }
+         "name": "nfs-server-group",
+         "template":"#cloud-config\npackages:\n  - nfs-server\n"
        }
      ]'
 
-  # Add multiple groups using YAML array of resource envelopes
+  # Add multiple groups using YAML array of specs
   ochami metadata group add -f yaml <<'EOF'
-  - metadata:
-      name: nfs-client-group
-    spec:
-      template: |
-        #cloud-config
-        packages:
-          - nfs-common
-  - metadata:
-      name: nfs-server-group
-    spec:
-      template: |
-        #cloud-config
-        packages:
-          - nfs-server
-  EOF
+   - name: nfs-client-group
+     template: |
+       #cloud-config
+       packages:
+         - nfs-common
+   - name: nfs-server-group
+     template: |
+       #cloud-config
+       packages:
+         - nfs-server
+   EOF
 
   # Add group preserving labels/annotations (envelope API)
   ochami metadata group add -e -d \
@@ -122,36 +105,56 @@ See ochami-metadata(1) for more details.`,
 			// Handle token for this command
 			cli.HandleToken(cmd)
 
-			// Read group data
-			groups := []metadata_service_client.CreateGroupRequest{}
-			if cmd.Flag("data").Changed {
-				cli.HandlePayloadSlice[metadata_service_client.CreateGroupRequest](cmd, &groups)
-			} else {
-				cli.HandlePayloadStdinSlice[metadata_service_client.CreateGroupRequest](cmd, &groups)
+			// Determine how to read payload (simple versus advanced API)
+			envelope, flagErr := cmd.Flags().GetBool("envelope")
+			if flagErr != nil {
+				log.Logger.Warn().Err(flagErr).Msg("failed to read --envelope, falling back to simple API")
 			}
 
-			// Send off requests
-			envelope, _ := cmd.Flags().GetBool("envelope")
 			var groupsCreated []api.Group
-			var errs []error
-			var err error
+			var reqErrs []error
+			var reqErr error
 			if envelope {
-				groupsCreated, errs, err = metadataServiceClient.AddGroups(cli.Token, groups)
+				// Use advanced API (spec, metadata, annotations)
+
+				// Read group data
+				groups := []metadata_service_client.CreateGroupRequest{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayloadSlice[metadata_service_client.CreateGroupRequest](cmd, &groups)
+				} else {
+					cli.HandlePayloadStdinSlice[metadata_service_client.CreateGroupRequest](cmd, &groups)
+				}
+
+				// Send off requests
+				groupsCreated, reqErrs, reqErr = metadataServiceClient.AddGroups(cli.Token, groups)
 			} else {
-				groupsCreated, errs, err = metadataServiceClient.AddGroupsSimple(cli.Token, groups)
+				// Use simple API (spec)
+
+				// Read group data
+				groups := []metadata_service.GroupSpec{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayloadSlice[metadata_service.GroupSpec](cmd, &groups)
+				} else {
+					cli.HandlePayloadStdinSlice[metadata_service.GroupSpec](cmd, &groups)
+				}
+
+				// Send off requests
+				groupsCreated, reqErrs, reqErr = metadataServiceClient.AddGroupSpecs(cli.Token, groups)
 			}
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to add groups")
+
+			// Handle any non-request error
+			if reqErr != nil {
+				log.Logger.Error().Err(reqErr).Msg("failed to add groups")
 				cli.LogHelpError(cmd)
 				os.Exit(1)
 			}
 
 			// Deal with per-request errors
-			var errorsOccurred = false
-			for _, err := range errs {
+			var reqErrorsOccurred = false
+			for _, err := range reqErrs {
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("failed to add group")
-					errorsOccurred = true
+					reqErrorsOccurred = true
 				}
 			}
 
@@ -163,7 +166,7 @@ See ochami-metadata(1) for more details.`,
 			log.Logger.Info().Msgf("Groups created: %+v", uids)
 
 			// Warn if any request errors occurred
-			if errorsOccurred {
+			if reqErrorsOccurred {
 				cli.LogHelpError(cmd)
 				log.Logger.Warn().Msg("Group addition completed with errors")
 				os.Exit(1)

--- a/cmd/metadata/group/group.go
+++ b/cmd/metadata/group/group.go
@@ -31,6 +31,9 @@ See ochami-metadata(1) for more details.`,
 		},
 	}
 
+	// Create flags
+	metadataGroupCmd.PersistentFlags().BoolP("envelope", "e", false, "use the envelope (advanced) API, preserving metadata/labels/annotations, instead of the simple API")
+
 	// Add subcommands
 	metadataGroupCmd.AddCommand(
 		newCmdMetadataGroupAdd(),

--- a/cmd/metadata/group/set.go
+++ b/cmd/metadata/group/set.go
@@ -10,6 +10,8 @@ import (
 	metadata_service_client "github.com/OpenCHAMI/metadata-service/pkg/client"
 	"github.com/spf13/cobra"
 
+	api "github.com/OpenCHAMI/metadata-service/apis/cloud-init.openchami.io/v1"
+
 	"github.com/OpenCHAMI/ochami/internal/cli"
 	metadata_service_lib "github.com/OpenCHAMI/ochami/internal/cli/metadata_service"
 	"github.com/OpenCHAMI/ochami/internal/log"
@@ -62,7 +64,14 @@ See ochami-metadata(1) for more details.`,
 			}
 
 			// Send off requests
-			groupSet, err := metadataServiceClient.SetGroup(cli.Token, args[0], group)
+			envelope, _ := cmd.Flags().GetBool("envelope")
+			var groupSet *api.Group
+			var err error
+			if envelope {
+				groupSet, err = metadataServiceClient.SetGroup(cli.Token, args[0], group)
+			} else {
+				groupSet, err = metadataServiceClient.SetGroupSimple(cli.Token, args[0], group)
+			}
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to set group")
 				cli.LogHelpError(cmd)

--- a/cmd/metadata/group/set.go
+++ b/cmd/metadata/group/set.go
@@ -29,13 +29,21 @@ See ochami-metadata(1) for more details.`,
 		Example: `  # Set group details using payload data
   ochami metadata group set group-d614b918 -d \
     '{
+       "template":"#cloud-config\npackages:\n  - vim\n",
+       "metaData":{"role":"compute"},
+       "osVersion":"ubuntu-22.04"
+     }'
+
+  # Set group details preserving labels/annotations (envelope API)
+  ochami metadata group set group-d614b918 -e -d \
+    '{
        "metadata": {
-         "name": "compute-group"
+         "labels": {
+           "role": "compute"
+         }
        },
        "spec": {
-         "template":"#cloud-config\npackages:\n  - vim\n",
-         "metaData":{"role":"compute"},
-         "osVersion":"ubuntu-22.04"
+         "template":"#cloud-config\npackages:\n  - vim\n"
        }
      }'
 
@@ -55,25 +63,43 @@ See ochami-metadata(1) for more details.`,
 			// Handle token for this command
 			cli.HandleToken(cmd)
 
-			// Read group data
-			group := metadata_service_client.UpdateGroupRequest{}
-			if cmd.Flag("data").Changed {
-				cli.HandlePayload(cmd, &group)
-			} else {
-				cli.HandlePayloadStdin(cmd, &group)
+			// Determine how to read payload (simple versus advanced API)
+			envelope, flagErr := cmd.Flags().GetBool("envelope")
+			if flagErr != nil {
+				log.Logger.Warn().Err(flagErr).Msg("failed to read --envelope, falling back to simple API")
 			}
 
-			// Send off requests
-			envelope, _ := cmd.Flags().GetBool("envelope")
 			var groupSet *api.Group
-			var err error
+			var reqErr error
 			if envelope {
-				groupSet, err = metadataServiceClient.SetGroup(cli.Token, args[0], group)
+				// Use advanced API (spec, metadata, annotations)
+
+				// Read group data
+				group := metadata_service_client.UpdateGroupRequest{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayload(cmd, &group)
+				} else {
+					cli.HandlePayloadStdin(cmd, &group)
+				}
+
+				// Send off request
+				groupSet, reqErr = metadataServiceClient.SetGroup(cli.Token, args[0], group)
 			} else {
-				groupSet, err = metadataServiceClient.SetGroupSimple(cli.Token, args[0], group)
+				// Use simple API (spec)
+
+				// Read group data
+				spec := api.GroupSpec{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayload(cmd, &spec)
+				} else {
+					cli.HandlePayloadStdin(cmd, &spec)
+				}
+
+				// Send off request
+				groupSet, reqErr = metadataServiceClient.SetGroupSpec(cli.Token, args[0], spec)
 			}
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to set group")
+			if reqErr != nil {
+				log.Logger.Error().Err(reqErr).Msg("failed to set group")
 				cli.LogHelpError(cmd)
 				os.Exit(1)
 			}

--- a/cmd/metadata/instance/add.go
+++ b/cmd/metadata/instance/add.go
@@ -15,6 +15,7 @@ import (
 	"github.com/OpenCHAMI/ochami/internal/cli"
 	metadata_service_lib "github.com/OpenCHAMI/ochami/internal/cli/metadata_service"
 	"github.com/OpenCHAMI/ochami/internal/log"
+	"github.com/OpenCHAMI/ochami/pkg/client/metadata_service"
 )
 
 func newCmdMetadataInstanceAdd() *cobra.Command {
@@ -29,49 +30,33 @@ See ochami-metadata(1) for more details.`,
 		Example: `  # Add instance info using JSON
   ochami metadata instance add -d \
     '{
-       "metadata": {
-         "name": "x1000c0s0b0n0-instance"
-       },
-       "spec": {
-         "instance_id": "x1000c0s0b0n0",
-         "hostname": "nid001000.demo.cluster",
-         "local_hostname": "nid001000",
-         "public_keys": ["ssh-ed25519 AAAAC3Nza... admin@demo"]
-       }
+       "name": "x1000c0s0b0n0-instance",
+       "instance_id": "x1000c0s0b0n0",
+       "hostname": "nid001000.demo.cluster",
+       "local_hostname": "nid001000",
+       "public_keys": ["ssh-ed25519 AAAAC3Nza... admin@demo"]
      }'
 
-  # Add multiple instance infos using JSON array of resource envelopes
+  # Add multiple instance infos using JSON array of specs
   ochami metadata instance add -d \
     '[
        {
-         "metadata": {
-           "name": "x1000c0s0b0n0-instance"
-         },
-         "spec": {
-           "instance_id": "x1000c0s0b0n0"
-         }
+         "name": "x1000c0s0b0n0-instance",
+         "instance_id": "x1000c0s0b0n0"
        },
        {
-         "metadata": {
-           "name": "x1000c0s0b0n1-instance"
-         },
-         "spec": {
-           "instance_id": "x1000c0s0b0n1"
-         }
+         "name": "x1000c0s0b0n1-instance",
+         "instance_id": "x1000c0s0b0n1"
        }
      ]'
 
-  # Add multiple instance infos using YAML array of resource envelopes
+  # Add multiple instance infos using YAML array of specs
   ochami metadata instance add -f yaml <<'EOF'
-  - metadata:
-      name: x1000c0s0b0n0-instance
-    spec:
-      instance_id: "x1000c0s0b0n0"
-  - metadata:
-      name: x1000c0s0b0n1-instance
-    spec:
-      instance_id: "x1000c0s0b0n1"
-  EOF
+   - name: x1000c0s0b0n0-instance
+     instance_id: "x1000c0s0b0n0"
+   - name: x1000c0s0b0n1-instance
+     instance_id: "x1000c0s0b0n1"
+   EOF
 
   # Add instance info preserving labels/annotations (envelope API)
   ochami metadata instance add -e -d \
@@ -101,36 +86,56 @@ See ochami-metadata(1) for more details.`,
 			// Handle token for this command
 			cli.HandleToken(cmd)
 
-			// Read instance data
-			instances := []metadata_service_client.CreateInstanceInfoRequest{}
-			if cmd.Flag("data").Changed {
-				cli.HandlePayloadSlice[metadata_service_client.CreateInstanceInfoRequest](cmd, &instances)
-			} else {
-				cli.HandlePayloadStdinSlice[metadata_service_client.CreateInstanceInfoRequest](cmd, &instances)
+			// Determine how to read payload (simple versus advanced API)
+			envelope, flagErr := cmd.Flags().GetBool("envelope")
+			if flagErr != nil {
+				log.Logger.Warn().Err(flagErr).Msg("failed to read --envelope, falling back to simple API")
 			}
 
-			// Send off requests
-			envelope, _ := cmd.Flags().GetBool("envelope")
 			var instancesCreated []api.InstanceInfo
-			var errs []error
-			var err error
+			var reqErrs []error
+			var reqErr error
 			if envelope {
-				instancesCreated, errs, err = metadataServiceClient.AddInstanceInfos(cli.Token, instances)
+				// Use advanced API (spec, metadata, annotations)
+
+				// Read instance data
+				instances := []metadata_service_client.CreateInstanceInfoRequest{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayloadSlice[metadata_service_client.CreateInstanceInfoRequest](cmd, &instances)
+				} else {
+					cli.HandlePayloadStdinSlice[metadata_service_client.CreateInstanceInfoRequest](cmd, &instances)
+				}
+
+				// Send off requests
+				instancesCreated, reqErrs, reqErr = metadataServiceClient.AddInstanceInfos(cli.Token, instances)
 			} else {
-				instancesCreated, errs, err = metadataServiceClient.AddInstanceInfosSimple(cli.Token, instances)
+				// Use simple API (spec)
+
+				// Read instance data
+				instances := []metadata_service.InstanceInfoSpec{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayloadSlice[metadata_service.InstanceInfoSpec](cmd, &instances)
+				} else {
+					cli.HandlePayloadStdinSlice[metadata_service.InstanceInfoSpec](cmd, &instances)
+				}
+
+				// Send off requests
+				instancesCreated, reqErrs, reqErr = metadataServiceClient.AddInstanceInfoSpecs(cli.Token, instances)
 			}
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to add instance infos")
+
+			// Handle any non-request error
+			if reqErr != nil {
+				log.Logger.Error().Err(reqErr).Msg("failed to add instance infos")
 				cli.LogHelpError(cmd)
 				os.Exit(1)
 			}
 
 			// Deal with per-request errors
-			var errorsOccurred = false
-			for _, err := range errs {
+			var reqErrorsOccurred = false
+			for _, err := range reqErrs {
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("failed to add instance info")
-					errorsOccurred = true
+					reqErrorsOccurred = true
 				}
 			}
 
@@ -142,7 +147,7 @@ See ochami-metadata(1) for more details.`,
 			log.Logger.Info().Msgf("Instance infos created: %+v", uids)
 
 			// Warn if any request errors occurred
-			if errorsOccurred {
+			if reqErrorsOccurred {
 				cli.LogHelpError(cmd)
 				log.Logger.Warn().Msg("Instance info addition completed with errors")
 				os.Exit(1)

--- a/cmd/metadata/instance/add.go
+++ b/cmd/metadata/instance/add.go
@@ -10,6 +10,8 @@ import (
 	metadata_service_client "github.com/OpenCHAMI/metadata-service/pkg/client"
 	"github.com/spf13/cobra"
 
+	api "github.com/OpenCHAMI/metadata-service/apis/cloud-init.openchami.io/v1"
+
 	"github.com/OpenCHAMI/ochami/internal/cli"
 	metadata_service_lib "github.com/OpenCHAMI/ochami/internal/cli/metadata_service"
 	"github.com/OpenCHAMI/ochami/internal/log"
@@ -71,6 +73,20 @@ See ochami-metadata(1) for more details.`,
       instance_id: "x1000c0s0b0n1"
   EOF
 
+  # Add instance info preserving labels/annotations (envelope API)
+  ochami metadata instance add -e -d \
+    '{
+       "metadata": {
+         "name": "x1000c0s0b0n0-instance",
+         "labels": {
+           "env": "prod"
+         }
+       },
+       "spec": {
+         "instance_id": "x1000c0s0b0n0"
+       }
+     }'
+
   # Add multiple instances from file
   ochami metadata instance add -d @instances.json
   ochami metadata instance add -d @instance.yaml -f yaml
@@ -94,7 +110,15 @@ See ochami-metadata(1) for more details.`,
 			}
 
 			// Send off requests
-			instancesCreated, errs, err := metadataServiceClient.AddInstanceInfos(cli.Token, instances)
+			envelope, _ := cmd.Flags().GetBool("envelope")
+			var instancesCreated []api.InstanceInfo
+			var errs []error
+			var err error
+			if envelope {
+				instancesCreated, errs, err = metadataServiceClient.AddInstanceInfos(cli.Token, instances)
+			} else {
+				instancesCreated, errs, err = metadataServiceClient.AddInstanceInfosSimple(cli.Token, instances)
+			}
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to add instance infos")
 				cli.LogHelpError(cmd)

--- a/cmd/metadata/instance/instance.go
+++ b/cmd/metadata/instance/instance.go
@@ -31,6 +31,9 @@ See ochami-metadata(1) for more details.`,
 		},
 	}
 
+	// Create flags
+	metadataInstanceCmd.PersistentFlags().BoolP("envelope", "e", false, "use the envelope (advanced) API, preserving metadata/labels/annotations, instead of the simple API")
+
 	// Add subcommands
 	metadataInstanceCmd.AddCommand(
 		newCmdMetadataInstanceAdd(),

--- a/cmd/metadata/instance/set.go
+++ b/cmd/metadata/instance/set.go
@@ -10,6 +10,8 @@ import (
 	metadata_service_client "github.com/OpenCHAMI/metadata-service/pkg/client"
 	"github.com/spf13/cobra"
 
+	api "github.com/OpenCHAMI/metadata-service/apis/cloud-init.openchami.io/v1"
+
 	"github.com/OpenCHAMI/ochami/internal/cli"
 	metadata_service_lib "github.com/OpenCHAMI/ochami/internal/cli/metadata_service"
 	"github.com/OpenCHAMI/ochami/internal/log"
@@ -62,7 +64,14 @@ See ochami-metadata(1) for more details.`,
 			}
 
 			// Send off requests
-			instanceSet, err := metadataServiceClient.SetInstanceInfo(cli.Token, args[0], instance)
+			envelope, _ := cmd.Flags().GetBool("envelope")
+			var instanceSet *api.InstanceInfo
+			var err error
+			if envelope {
+				instanceSet, err = metadataServiceClient.SetInstanceInfo(cli.Token, args[0], instance)
+			} else {
+				instanceSet, err = metadataServiceClient.SetInstanceInfoSimple(cli.Token, args[0], instance)
+			}
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to set instance info")
 				cli.LogHelpError(cmd)

--- a/cmd/metadata/instance/set.go
+++ b/cmd/metadata/instance/set.go
@@ -29,13 +29,21 @@ See ochami-metadata(1) for more details.`,
 		Example: `  # Set instance info details using payload data
   ochami metadata instance set instanceinfo-d614b918 -d \
     '{
+       "instance_id": "x1000c0s0b0n0",
+       "hostname": "nid001000.demo.cluster",
+       "local_hostname": "nid001000"
+     }'
+
+  # Set instance info details preserving labels/annotations (envelope API)
+  ochami metadata instance set instanceinfo-d614b918 -e -d \
+    '{
        "metadata": {
-         "name": "x1000c0s0b0n0-instance"
+         "labels": {
+           "env": "prod"
+         }
        },
        "spec": {
-         "instance_id": "x1000c0s0b0n0",
-         "hostname": "nid001000.demo.cluster",
-         "local_hostname": "nid001000"
+         "instance_id": "x1000c0s0b0n0"
        }
      }'
 
@@ -55,25 +63,43 @@ See ochami-metadata(1) for more details.`,
 			// Handle token for this command
 			cli.HandleToken(cmd)
 
-			// Read instance data
-			instance := metadata_service_client.UpdateInstanceInfoRequest{}
-			if cmd.Flag("data").Changed {
-				cli.HandlePayload(cmd, &instance)
-			} else {
-				cli.HandlePayloadStdin(cmd, &instance)
+			// Determine how to read payload (simple versus advanced API)
+			envelope, flagErr := cmd.Flags().GetBool("envelope")
+			if flagErr != nil {
+				log.Logger.Warn().Err(flagErr).Msg("failed to read --envelope, falling back to simple API")
 			}
 
-			// Send off requests
-			envelope, _ := cmd.Flags().GetBool("envelope")
 			var instanceSet *api.InstanceInfo
-			var err error
+			var reqErr error
 			if envelope {
-				instanceSet, err = metadataServiceClient.SetInstanceInfo(cli.Token, args[0], instance)
+				// Use advanced API (spec, metadata, annotations)
+
+				// Read instance data
+				instance := metadata_service_client.UpdateInstanceInfoRequest{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayload(cmd, &instance)
+				} else {
+					cli.HandlePayloadStdin(cmd, &instance)
+				}
+
+				// Send off request
+				instanceSet, reqErr = metadataServiceClient.SetInstanceInfo(cli.Token, args[0], instance)
 			} else {
-				instanceSet, err = metadataServiceClient.SetInstanceInfoSimple(cli.Token, args[0], instance)
+				// Use simple API (spec)
+
+				// Read instance data
+				spec := api.InstanceInfoSpec{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayload(cmd, &spec)
+				} else {
+					cli.HandlePayloadStdin(cmd, &spec)
+				}
+
+				// Send off request
+				instanceSet, reqErr = metadataServiceClient.SetInstanceInfoSpec(cli.Token, args[0], spec)
 			}
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to set instance info")
+			if reqErr != nil {
+				log.Logger.Error().Err(reqErr).Msg("failed to set instance info")
 				cli.LogHelpError(cmd)
 				os.Exit(1)
 			}

--- a/cmd/metadata/peer/add.go
+++ b/cmd/metadata/peer/add.go
@@ -10,6 +10,8 @@ import (
 	metadata_service_client "github.com/OpenCHAMI/metadata-service/pkg/client"
 	"github.com/spf13/cobra"
 
+	api "github.com/OpenCHAMI/metadata-service/apis/cloud-init.openchami.io/v1"
+
 	"github.com/OpenCHAMI/ochami/internal/cli"
 	metadata_service_lib "github.com/OpenCHAMI/ochami/internal/cli/metadata_service"
 	"github.com/OpenCHAMI/ochami/internal/log"
@@ -84,6 +86,21 @@ See ochami-metadata(1) for more details.`,
       allowed_ip: "10.42.1.2/32"
   EOF
 
+  # Add WireGuard peer preserving labels/annotations (envelope API)
+  ochami metadata peer add -e -d \
+    '{
+       "metadata": {
+         "name": "peer-nid001000",
+         "labels": {
+           "env": "prod"
+         }
+       },
+       "spec": {
+         "public_key": "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=",
+         "allowed_ip": "10.42.1.1/32"
+       }
+     }'
+
   # Add multiple peers from file
   ochami metadata peer add -d @peers.json
   ochami metadata peer add -d @peers.yaml -f yaml
@@ -109,7 +126,15 @@ See ochami-metadata(1) for more details.`,
 			}
 
 			// Send off requests
-			peersCreated, errs, err := metadataServiceClient.AddWireGuardPeers(cli.Token, peers)
+			envelope, _ := cmd.Flags().GetBool("envelope")
+			var peersCreated []api.WireGuardPeer
+			var errs []error
+			var err error
+			if envelope {
+				peersCreated, errs, err = metadataServiceClient.AddWireGuardPeers(cli.Token, peers)
+			} else {
+				peersCreated, errs, err = metadataServiceClient.AddWireGuardPeersSimple(cli.Token, peers)
+			}
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to add WireGuard peers")
 				cli.LogHelpError(cmd)

--- a/cmd/metadata/peer/add.go
+++ b/cmd/metadata/peer/add.go
@@ -15,6 +15,7 @@ import (
 	"github.com/OpenCHAMI/ochami/internal/cli"
 	metadata_service_lib "github.com/OpenCHAMI/ochami/internal/cli/metadata_service"
 	"github.com/OpenCHAMI/ochami/internal/log"
+	"github.com/OpenCHAMI/ochami/pkg/client/metadata_service"
 )
 
 func newCmdMetadataPeerAdd() *cobra.Command {
@@ -29,62 +30,44 @@ See ochami-metadata(1) for more details.`,
 		Example: `  # Add WireGuard peer using JSON
   ochami metadata peer add -d \
     '{
-       "metadata": {
-         "name": "peer-nid001000"
-       },
-       "spec": {
-         "public_key": "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=",
-         "allowed_ip": "10.42.1.1/32",
-         "description": "Peer for nid001000"
-       }
+       "name": "peer-nid001000",
+       "public_key": "xTIBA5rboUvnH4htodjb6e6e97QjLERt1NAB4mZqp8Dg=",
+       "allowed_ip": "10.42.1.1/32",
+       "description": "Peer for nid001000"
      }'
 
   # Add peer from YAML
   ochami metadata peer add -f yaml <<'EOF'
-  metadata:
-    name: peer-nid001000
-  spec:
-    public_key: xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=
-    allowed_ip: 10.42.1.1/32
-    description: Compute node peer
-  EOF
+   name: peer-nid001000
+   public_key: xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=
+   allowed_ip: 10.42.1.1/32
+   description: Compute node peer
+   EOF
 
-  # Add multiple WireGuard peers using JSON array of resource envelopes
+  # Add multiple WireGuard peers using JSON array of specs
   ochami metadata peer add -d \
     '[
        {
-         "metadata": {
-           "name": "peer-nid001000"
-         },
-         "spec": {
-           "public_key": "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=",
-           "allowed_ip": "10.42.1.1/32"
-         }
+         "name": "peer-nid001000",
+         "public_key": "xTIBA5rboUvnH4htodjb6e6e97QjLERt1NAB4mZqp8Dg=",
+         "allowed_ip": "10.42.1.1/32"
        },
        {
-         "metadata": {
-           "name": "peer-nid001001"
-         },
-         "spec": {
-           "public_key": "yUJCB6sbcpVwoI5iupekc7f798RkMFSu2OBC5nArq9Eh=",
-           "allowed_ip": "10.42.1.2/32"
-         }
+         "name": "peer-nid001001",
+         "public_key": "yUJCB6sbcpVwoI5iupekc7f798RkMFSu2OBC5nArq9Eh=",
+         "allowed_ip": "10.42.1.2/32"
        }
      ]'
 
-  # Add multiple WireGuard peers using YAML array of resource envelopes
+  # Add multiple WireGuard peers using YAML array of specs
   ochami metadata peer add -f yaml <<'EOF'
-  - metadata:
-      name: peer-nid001000
-    spec:
-      public_key: "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg="
-      allowed_ip: "10.42.1.1/32"
-  - metadata:
-      name: peer-nid001001
-    spec:
-      public_key: "yUJCB6sbcpVwoI5iupekc7f798RkMFSu2OBC5nArq9Eh="
-      allowed_ip: "10.42.1.2/32"
-  EOF
+   - name: peer-nid001000
+     public_key: "xTIBA5rboUvnH4htodjb6e6e97QjLERt1NAB4mZqp8Dg="
+     allowed_ip: "10.42.1.1/32"
+   - name: peer-nid001001
+     public_key: "yUJCB6sbcpVwoI5iupekc7f798RkMFSu2OBC5nArq9Eh="
+     allowed_ip: "10.42.1.2/32"
+   EOF
 
   # Add WireGuard peer preserving labels/annotations (envelope API)
   ochami metadata peer add -e -d \
@@ -96,7 +79,7 @@ See ochami-metadata(1) for more details.`,
          }
        },
        "spec": {
-         "public_key": "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=",
+         "public_key": "xTIBA5rboUvnH4htodjb6e6e97QjLERt1NAB4mZqp8Dg=",
          "allowed_ip": "10.42.1.1/32"
        }
      }'
@@ -117,36 +100,56 @@ See ochami-metadata(1) for more details.`,
 			// Handle token for this command
 			cli.HandleToken(cmd)
 
-			// Read peer data
-			peers := []metadata_service_client.CreateWireGuardPeerRequest{}
-			if cmd.Flag("data").Changed {
-				cli.HandlePayloadSlice[metadata_service_client.CreateWireGuardPeerRequest](cmd, &peers)
-			} else {
-				cli.HandlePayloadStdinSlice[metadata_service_client.CreateWireGuardPeerRequest](cmd, &peers)
+			// Determine how to read payload (simple versus advanced API)
+			envelope, flagErr := cmd.Flags().GetBool("envelope")
+			if flagErr != nil {
+				log.Logger.Warn().Err(flagErr).Msg("failed to read --envelope, falling back to simple API")
 			}
 
-			// Send off requests
-			envelope, _ := cmd.Flags().GetBool("envelope")
 			var peersCreated []api.WireGuardPeer
-			var errs []error
-			var err error
+			var reqErrs []error
+			var reqErr error
 			if envelope {
-				peersCreated, errs, err = metadataServiceClient.AddWireGuardPeers(cli.Token, peers)
+				// Use advanced API (spec, metadata, annotations)
+
+				// Read peer data
+				peers := []metadata_service_client.CreateWireGuardPeerRequest{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayloadSlice[metadata_service_client.CreateWireGuardPeerRequest](cmd, &peers)
+				} else {
+					cli.HandlePayloadStdinSlice[metadata_service_client.CreateWireGuardPeerRequest](cmd, &peers)
+				}
+
+				// Send off requests
+				peersCreated, reqErrs, reqErr = metadataServiceClient.AddWireGuardPeers(cli.Token, peers)
 			} else {
-				peersCreated, errs, err = metadataServiceClient.AddWireGuardPeersSimple(cli.Token, peers)
+				// Use simple API (spec)
+
+				// Read peer data
+				peers := []metadata_service.WireGuardPeerSpec{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayloadSlice[metadata_service.WireGuardPeerSpec](cmd, &peers)
+				} else {
+					cli.HandlePayloadStdinSlice[metadata_service.WireGuardPeerSpec](cmd, &peers)
+				}
+
+				// Send off requests
+				peersCreated, reqErrs, reqErr = metadataServiceClient.AddWireGuardPeerSpecs(cli.Token, peers)
 			}
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to add WireGuard peers")
+
+			// Handle any non-request error
+			if reqErr != nil {
+				log.Logger.Error().Err(reqErr).Msg("failed to add WireGuard peers")
 				cli.LogHelpError(cmd)
 				os.Exit(1)
 			}
 
 			// Deal with per-request errors
-			var errorsOccurred = false
-			for _, err := range errs {
+			var reqErrorsOccurred = false
+			for _, err := range reqErrs {
 				if err != nil {
 					log.Logger.Error().Err(err).Msg("failed to add WireGuard peer")
-					errorsOccurred = true
+					reqErrorsOccurred = true
 				}
 			}
 
@@ -158,7 +161,7 @@ See ochami-metadata(1) for more details.`,
 			log.Logger.Info().Msgf("WireGuard peers created: %+v", uids)
 
 			// Warn if any request errors occurred
-			if errorsOccurred {
+			if reqErrorsOccurred {
 				cli.LogHelpError(cmd)
 				log.Logger.Warn().Msg("WireGuard peer addition completed with errors")
 				os.Exit(1)

--- a/cmd/metadata/peer/peer.go
+++ b/cmd/metadata/peer/peer.go
@@ -31,6 +31,9 @@ See ochami-metadata(1) for more details.`,
 		},
 	}
 
+	// Create flags
+	metadataPeerCmd.PersistentFlags().BoolP("envelope", "e", false, "use the envelope (advanced) API, preserving metadata/labels/annotations, instead of the simple API")
+
 	// Add subcommands
 	metadataPeerCmd.AddCommand(
 		newCmdMetadataPeerAdd(),

--- a/cmd/metadata/peer/set.go
+++ b/cmd/metadata/peer/set.go
@@ -10,6 +10,8 @@ import (
 	metadata_service_client "github.com/OpenCHAMI/metadata-service/pkg/client"
 	"github.com/spf13/cobra"
 
+	api "github.com/OpenCHAMI/metadata-service/apis/cloud-init.openchami.io/v1"
+
 	"github.com/OpenCHAMI/ochami/internal/cli"
 	metadata_service_lib "github.com/OpenCHAMI/ochami/internal/cli/metadata_service"
 	"github.com/OpenCHAMI/ochami/internal/log"
@@ -72,7 +74,14 @@ See ochami-metadata(1) for more details.`,
 			}
 
 			// Send off requests
-			peerSet, err := metadataServiceClient.SetWireGuardPeer(cli.Token, args[0], peer)
+			envelope, _ := cmd.Flags().GetBool("envelope")
+			var peerSet *api.WireGuardPeer
+			var err error
+			if envelope {
+				peerSet, err = metadataServiceClient.SetWireGuardPeer(cli.Token, args[0], peer)
+			} else {
+				peerSet, err = metadataServiceClient.SetWireGuardPeerSimple(cli.Token, args[0], peer)
+			}
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("failed to set WireGuard peer")
 				cli.LogHelpError(cmd)

--- a/cmd/metadata/peer/set.go
+++ b/cmd/metadata/peer/set.go
@@ -29,25 +29,31 @@ See ochami-metadata(1) for more details.`,
 		Example: `  # Set WireGuard peer details using payload data
   ochami metadata peer set wireguardpeer-d614b918 -d \
     '{
-       "metadata": {
-         "name": "peer-nid001000"
-       },
-       "spec": {
-         "public_key": "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=",
-         "allowed_ip": "10.42.1.1/32",
-         "description": "Updated peer"
-       }
+       "public_key": "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=",
+       "allowed_ip": "10.42.1.1/32",
+       "description": "Updated peer"
      }'
 
   # Set WireGuard peer details using YAML payload data
   ochami metadata peer set wireguardpeer-d614b918 -f yaml <<'EOF'
-  metadata:
-    name: peer-nid001000
-  spec:
-    public_key: "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg="
-    allowed_ip: "10.42.1.1/32"
-    description: "Updated peer"
-  EOF
+   public_key: "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg="
+   allowed_ip: "10.42.1.1/32"
+   description: "Updated peer"
+   EOF
+
+  # Set WireGuard peer details preserving labels/annotations (envelope API)
+  ochami metadata peer set wireguardpeer-d614b918 -e -d \
+    '{
+       "metadata": {
+         "labels": {
+           "env": "prod"
+         }
+       },
+       "spec": {
+         "public_key": "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=",
+         "allowed_ip": "10.42.1.1/32"
+       }
+     }'
 
   # Set WireGuard peer details using file
   ochami metadata peer set wireguardpeer-d614b918 -d @peer.json
@@ -65,25 +71,43 @@ See ochami-metadata(1) for more details.`,
 			// Handle token for this command
 			cli.HandleToken(cmd)
 
-			// Read peer data
-			peer := metadata_service_client.UpdateWireGuardPeerRequest{}
-			if cmd.Flag("data").Changed {
-				cli.HandlePayload(cmd, &peer)
-			} else {
-				cli.HandlePayloadStdin(cmd, &peer)
+			// Determine how to read payload (simple versus advanced API)
+			envelope, flagErr := cmd.Flags().GetBool("envelope")
+			if flagErr != nil {
+				log.Logger.Warn().Err(flagErr).Msg("failed to read --envelope, falling back to simple API")
 			}
 
-			// Send off requests
-			envelope, _ := cmd.Flags().GetBool("envelope")
 			var peerSet *api.WireGuardPeer
-			var err error
+			var reqErr error
 			if envelope {
-				peerSet, err = metadataServiceClient.SetWireGuardPeer(cli.Token, args[0], peer)
+				// Use advanced API (spec, metadata, annotations)
+
+				// Read peer data
+				peer := metadata_service_client.UpdateWireGuardPeerRequest{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayload(cmd, &peer)
+				} else {
+					cli.HandlePayloadStdin(cmd, &peer)
+				}
+
+				// Send off request
+				peerSet, reqErr = metadataServiceClient.SetWireGuardPeer(cli.Token, args[0], peer)
 			} else {
-				peerSet, err = metadataServiceClient.SetWireGuardPeerSimple(cli.Token, args[0], peer)
+				// Use simple API (spec)
+
+				// Read peer data
+				spec := api.WireGuardPeerSpec{}
+				if cmd.Flag("data").Changed {
+					cli.HandlePayload(cmd, &spec)
+				} else {
+					cli.HandlePayloadStdin(cmd, &spec)
+				}
+
+				// Send off request
+				peerSet, reqErr = metadataServiceClient.SetWireGuardPeerSpec(cli.Token, args[0], spec)
 			}
-			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to set WireGuard peer")
+			if reqErr != nil {
+				log.Logger.Error().Err(reqErr).Msg("failed to set WireGuard peer")
 				cli.LogHelpError(cmd)
 				os.Exit(1)
 			}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -659,6 +659,22 @@ func LogHelpWarn(cmd *cobra.Command) {
 	log.Logger.Warn().Msgf("see '%s --help' for long command help", cmd.CommandPath())
 }
 
+// WarnDiscardedEnvelope logs a warning when a request being sent via a simple
+// (non-envelope) API variant carries labels or annotations that will be
+// discarded. It advises the user to pass --envelope to preserve them. The name
+// is included in the message to identify the affected resource. If neither
+// labels nor annotations are set, no warning is logged.
+func WarnDiscardedEnvelope(name string, labels, annotations map[string]string) {
+	if len(labels) == 0 && len(annotations) == 0 {
+		return
+	}
+	id := name
+	if id == "" {
+		id = "<unnamed>"
+	}
+	log.Logger.Warn().Msgf("discarding labels/annotations for %q; pass --envelope to preserve them", id)
+}
+
 // CompletionFormatData is the cobra completion function for any flag that uses
 // the format.DataFormat type.
 func CompletionFormatData(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -659,22 +659,6 @@ func LogHelpWarn(cmd *cobra.Command) {
 	log.Logger.Warn().Msgf("see '%s --help' for long command help", cmd.CommandPath())
 }
 
-// WarnDiscardedEnvelope logs a warning when a request being sent via a simple
-// (non-envelope) API variant carries labels or annotations that will be
-// discarded. It advises the user to pass --envelope to preserve them. The name
-// is included in the message to identify the affected resource. If neither
-// labels nor annotations are set, no warning is logged.
-func WarnDiscardedEnvelope(name string, labels, annotations map[string]string) {
-	if len(labels) == 0 && len(annotations) == 0 {
-		return
-	}
-	id := name
-	if id == "" {
-		id = "<unnamed>"
-	}
-	log.Logger.Warn().Msgf("discarding labels/annotations for %q; pass --envelope to preserve them", id)
-}
-
 // CompletionFormatData is the cobra completion function for any flag that uses
 // the format.DataFormat type.
 func CompletionFormatData(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -20,7 +20,10 @@ import (
 
 	"github.com/lestrrat-go/jwx/v3/jwa"
 	"github.com/lestrrat-go/jwx/v3/jwt"
+	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
+
+	"github.com/OpenCHAMI/ochami/internal/log"
 )
 
 func TestIOStream_AskToCreate(t *testing.T) {
@@ -423,4 +426,58 @@ func TestSetToken_FromEnvironment(t *testing.T) {
 	// This test is skipped because SetToken calls os.Exit() on errors
 	// To properly test this, SetToken should be refactored to return errors
 	t.Skip("Skipping test that may call os.Exit() - SetToken needs refactoring for testability")
+}
+
+func TestWarnDiscardedEnvelope(t *testing.T) {
+	tests := []struct {
+		name        string
+		resource    string
+		labels      map[string]string
+		annotations map[string]string
+		wantWarn    bool
+	}{
+		{
+			name:     "no labels or annotations does not warn",
+			resource: "foo",
+			wantWarn: false,
+		},
+		{
+			name:     "labels present warns",
+			resource: "foo",
+			labels:   map[string]string{"env": "prod"},
+			wantWarn: true,
+		},
+		{
+			name:        "annotations present warns",
+			resource:    "foo",
+			annotations: map[string]string{"note": "x"},
+			wantWarn:    true,
+		},
+		{
+			name:     "unnamed resource with labels warns",
+			resource: "",
+			labels:   map[string]string{"env": "prod"},
+			wantWarn: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			orig := log.Logger
+			log.Logger = zerolog.New(&buf).Level(zerolog.WarnLevel)
+			defer func() { log.Logger = orig }()
+
+			WarnDiscardedEnvelope(tc.resource, tc.labels, tc.annotations)
+
+			got := buf.String()
+			if tc.wantWarn && !strings.Contains(got, "--envelope") {
+				t.Errorf("expected warning mentioning --envelope, got %q", got)
+			}
+			if !tc.wantWarn && got != "" {
+				t.Errorf("expected no warning, got %q", got)
+			}
+		})
+	}
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -20,10 +20,7 @@ import (
 
 	"github.com/lestrrat-go/jwx/v3/jwa"
 	"github.com/lestrrat-go/jwx/v3/jwt"
-	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
-
-	"github.com/OpenCHAMI/ochami/internal/log"
 )
 
 func TestIOStream_AskToCreate(t *testing.T) {
@@ -426,58 +423,4 @@ func TestSetToken_FromEnvironment(t *testing.T) {
 	// This test is skipped because SetToken calls os.Exit() on errors
 	// To properly test this, SetToken should be refactored to return errors
 	t.Skip("Skipping test that may call os.Exit() - SetToken needs refactoring for testability")
-}
-
-func TestWarnDiscardedEnvelope(t *testing.T) {
-	tests := []struct {
-		name        string
-		resource    string
-		labels      map[string]string
-		annotations map[string]string
-		wantWarn    bool
-	}{
-		{
-			name:     "no labels or annotations does not warn",
-			resource: "foo",
-			wantWarn: false,
-		},
-		{
-			name:     "labels present warns",
-			resource: "foo",
-			labels:   map[string]string{"env": "prod"},
-			wantWarn: true,
-		},
-		{
-			name:        "annotations present warns",
-			resource:    "foo",
-			annotations: map[string]string{"note": "x"},
-			wantWarn:    true,
-		},
-		{
-			name:     "unnamed resource with labels warns",
-			resource: "",
-			labels:   map[string]string{"env": "prod"},
-			wantWarn: true,
-		},
-	}
-
-	for _, tt := range tests {
-		tc := tt
-		t.Run(tc.name, func(t *testing.T) {
-			var buf bytes.Buffer
-			orig := log.Logger
-			log.Logger = zerolog.New(&buf).Level(zerolog.WarnLevel)
-			defer func() { log.Logger = orig }()
-
-			WarnDiscardedEnvelope(tc.resource, tc.labels, tc.annotations)
-
-			got := buf.String()
-			if tc.wantWarn && !strings.Contains(got, "--envelope") {
-				t.Errorf("expected warning mentioning --envelope, got %q", got)
-			}
-			if !tc.wantWarn && got != "" {
-				t.Errorf("expected no warning, got %q", got)
-			}
-		})
-	}
 }

--- a/man/ochami-boot.1.sc
+++ b/man/ochami-boot.1.sc
@@ -17,7 +17,74 @@ ochami-boot - Communicate with the Boot Service
 *ochami boot* (*bmc* | *config* | *node*) *set* [-e] [-f _format_] [-d (_data_ | @_path_ | @-)] _uid_++
 *ochami boot service status* [-F _format_]
 
-# DATA STRUCTURE
+# SIMPLE VERSUS ADVANCED API
+
+The user can either specify just the specification of a resource when
+creating/modifying it or specify additional annotations, labels, and metadata as
+outlined below.
+
+## SIMPLE API
+
+For commands that add or edit data (*add*, *set*), the default way to pass the
+data is via the specification ("spec") of the data itself with a mandatory
+*name* field (see *DATA SPECIFICATIONS* for data type specifications). This is the
+*simple API*.
+
+When using the simple API, the *name* field is _required_ to be specified in the
+spec. This will set the name in the metadata of the resource, which means the
+specified name will appear in *metadata.name* when listing the resource.
+
+For example, a resource spec when creating/modifying a resource would look
+something like:
+
+```
+{
+  "name": "my-resource",
+  // other spec data
+}
+```
+
+When listing that same resource, it will look like:
+
+```
+{
+  "metadata": {
+    "name": "my-resource",
+	...
+  },
+  ...
+  "spec": {
+	  // other spec data
+  }
+}
+```
+
+## ADVANCED API
+
+For finer-grain control, the *--envelope*/*-e* flag can be used to enable the
+*advanced* API, which allows specifying additional metadata, labels, and
+annotations. A JSON example of using this API would be:
+
+```
+{
+  "annotations": {...},
+  "labels": {...},
+  "metadata": {...},
+  "spec": {...}         // <- where spec goes
+}
+```
+
+This can be thought of as the "raw" data structure since the simple API
+abstracts creating this structure while the advanced API exposes it directly.
+Either way, this data structure is what is sent over the wire.
+
+# DATA SPECIFICATIONS
+
+The following are the specifications for the various boot-service resources
+accepted and returned by *ochami*.
+
+Note that the *name* field is omitted from the data specifications below since
+that is technically metadata (see *SIMPLE VERSUS ADVANCED API*).
 
 ## BOOT CONFIGURATION
 
@@ -129,11 +196,12 @@ creating, deleting, reading, listing, patching, and replacing boot-service
 resources. The *service* command provides operations for boot-service itself.
 
 By default, the *add* and *set* subcommands use the boot-service _simple_ API,
-which sends only the resource name (from _metadata.name_) and spec. Any
-_labels_ or _annotations_ present in the payload are discarded and a warning is
-logged. To use the _envelope_ (advanced) API, which preserves metadata, labels,
-and annotations, pass the *-e, --envelope* flag. This flag is available on the
-*add* and *set* subcommands of the *bmc*, *config*, and *node* commands.
+which sends only the resource spec (with a required _name_ field for *add*). Any
+_labels_ or _annotations_ must instead be supplied via the _envelope_ (advanced)
+API, which is enabled by passing the *-e*/*--envelope* flag and preserves
+metadata, labels, and annotations. See *SIMPLE VERSUS ADVANCED API* for details.
+This flag is available on the *add* and *set* subcommands of the *bmc*,
+*config*, and *node* commands.
 
 [[ *Resource*
 :< *Subcommands*
@@ -178,8 +246,9 @@ Subcommands for this command are as follows:
 
 	*-e, --envelope*
 		Use the envelope (advanced) API, preserving metadata, labels, and
-		annotations, instead of the simple API. Without this flag, labels and
-		annotations in the payload are discarded.
+		annotations, instead of the simple API. Without this
+		flag, only the spec is sent and labels/annotations cannot be
+		specified. See *SIMPLE VERSUS ADVANCED API* for details.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data
@@ -321,8 +390,9 @@ Subcommands for this command are as follows:
 
 	*-e, --envelope*
 		Use the envelope (advanced) API, preserving metadata, labels, and
-		annotations, instead of the simple API. Without this flag, labels and
-		annotations in the payload are discarded.
+		annotations, instead of the simple API. Without this
+		flag, only the spec is sent and labels/annotations cannot be
+		specified. See *SIMPLE VERSUS ADVANCED API* for details.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data
@@ -367,8 +437,9 @@ Subcommands for this command are as follows:
 
 	*-e, --envelope*
 		Use the envelope (advanced) API, preserving metadata, labels, and
-		annotations, instead of the simple API. Without this flag, labels and
-		annotations in the payload are discarded.
+		annotations, instead of the simple API. Without this
+		flag, only the spec is sent and labels/annotations cannot be
+		specified. See *SIMPLE VERSUS ADVANCED API* for details.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data
@@ -514,8 +585,9 @@ Subcommands for this command are as follows:
 
 	*-e, --envelope*
 		Use the envelope (advanced) API, preserving metadata, labels, and
-		annotations, instead of the simple API. Without this flag, labels and
-		annotations in the payload are discarded.
+		annotations, instead of the simple API. Without this
+		flag, only the spec is sent and labels/annotations cannot be
+		specified. See *SIMPLE VERSUS ADVANCED API* for details.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data
@@ -557,8 +629,9 @@ Subcommands for this command are as follows:
 
 	*-e, --envelope*
 		Use the envelope (advanced) API, preserving metadata, labels, and
-		annotations, instead of the simple API. Without this flag, labels and
-		annotations in the payload are discarded.
+		annotations, instead of the simple API. Without this
+		flag, only the spec is sent and labels/annotations cannot be
+		specified. See *SIMPLE VERSUS ADVANCED API* for details.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data
@@ -701,8 +774,9 @@ Subcommands for this command are as follows:
 
 	*-e, --envelope*
 		Use the envelope (advanced) API, preserving metadata, labels, and
-		annotations, instead of the simple API. Without this flag, labels and
-		annotations in the payload are discarded.
+		annotations, instead of the simple API. Without this
+		flag, only the spec is sent and labels/annotations cannot be
+		specified. See *SIMPLE VERSUS ADVANCED API* for details.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data

--- a/man/ochami-boot.1.sc
+++ b/man/ochami-boot.1.sc
@@ -8,13 +8,13 @@ ochami-boot - Communicate with the Boot Service
 
 *ochami boot* [_global-options_] _command_ [_command-options_] [_arguments_]
 
-*ochami boot* (*bmc* | *config* | *node*) *add* [-f _format_] [-d (_data_ | @_path_ | @-)]++
+*ochami boot* (*bmc* | *config* | *node*) *add* [-e] [-f _format_] [-d (_data_ | @_path_ | @-)]++
 *ochami boot* (*bmc* | *config* | *node*) *delete* [--no-confirm] _uid_...++
 *ochami boot* (*bmc* | *config* | *node*) *get* [-F _format_] _uid_++
 *ochami boot* (*bmc* | *config* | *node*) *list* [-F _format_]++
 *ochami boot* (*bmc* | *config* | *node*) *patch* [-f _format_] [-p _patch_method_] [-d (_data_ | @_path_ | @-)] _uid_++
 *ochami boot* (*bmc* | *config* | *node*) *patch* (--add _key_=_val_ | --remove _key_=_index_ | --set _key_=_val_ | --unset _key_)... _uid_++
-*ochami boot* (*bmc* | *config* | *node*) *set* [-f _format_] [-d (_data_ | @_path_ | @-)] _uid_++
+*ochami boot* (*bmc* | *config* | *node*) *set* [-e] [-f _format_] [-d (_data_ | @_path_ | @-)] _uid_++
 *ochami boot service status* [-F _format_]
 
 # DATA STRUCTURE
@@ -128,6 +128,13 @@ The *bmc*, *config*, and *node* commands share a common set of subcommands for
 creating, deleting, reading, listing, patching, and replacing boot-service
 resources. The *service* command provides operations for boot-service itself.
 
+By default, the *add* and *set* subcommands use the boot-service _simple_ API,
+which sends only the resource name (from _metadata.name_) and spec. Any
+_labels_ or _annotations_ present in the payload are discarded and a warning is
+logged. To use the _envelope_ (advanced) API, which preserves metadata, labels,
+and annotations, pass the *-e, --envelope* flag. This flag is available on the
+*add* and *set* subcommands of the *bmc*, *config*, and *node* commands.
+
 [[ *Resource*
 :< *Subcommands*
 :< *Description*
@@ -150,10 +157,10 @@ Manage BMCs stored in boot-service.
 
 Subcommands for this command are as follows:
 
-*add* [-f _format_] < _file_++
-*add* [-f _format_] -d @_file_++
-*add* [-f _format_] -d @- < _file_++
-*add* [-f _format_] -d _data_
+*add* [-e] [-f _format_] < _file_++
+*add* [-e] [-f _format_] -d @_file_++
+*add* [-e] [-f _format_] -d @- < _file_++
+*add* [-e] [-f _format_] -d _data_
 	Add one or more BMC specifications to boot-service.
 
 	In the first and third forms of the command, data is read from standard
@@ -168,6 +175,11 @@ Subcommands for this command are as follows:
 	This command sends a POST request to boot-service's BMC endpoint.
 
 	This command accepts the following options:
+
+	*-e, --envelope*
+		Use the envelope (advanced) API, preserving metadata, labels, and
+		annotations, instead of the simple API. Without this flag, labels and
+		annotations in the payload are discarded.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data
@@ -287,10 +299,10 @@ Subcommands for this command are as follows:
 		(automatic if any of
 		*--add*/*--remove*/*--set*/*--unset* are specified).
 
-*set* [-f _format_] _uid_ < _file_++
-*set* [-f _format_] -d @_file_ _uid_++
-*set* [-f _format_] -d @- _uid_ < _file_++
-*set* [-f _format_] -d _data_ _uid_
+*set* [-e] [-f _format_] _uid_ < _file_++
+*set* [-e] [-f _format_] -d @_file_ _uid_++
+*set* [-e] [-f _format_] -d @- _uid_ < _file_++
+*set* [-e] [-f _format_] -d _data_ _uid_
 	Set the specification of a BMC identified by _uid_. The entire
 	specification for the BMC is replaced with the specification that is passed.
 
@@ -306,6 +318,11 @@ Subcommands for this command are as follows:
 	This command sends a PUT request to boot-service's BMC endpoint.
 
 	This command accepts the following options:
+
+	*-e, --envelope*
+		Use the envelope (advanced) API, preserving metadata, labels, and
+		annotations, instead of the simple API. Without this flag, labels and
+		annotations in the payload are discarded.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data
@@ -326,10 +343,10 @@ Manage boot configurations stored in the boot service.
 
 Subcommands for this command are as follows:
 
-*add* [-f _format_] < _file_++
-*add* [-f _format_] -d @_file_++
-*add* [-f _format_] -d @- < _file_++
-*add* [-f _format_] -d _data_
+*add* [-e] [-f _format_] < _file_++
+*add* [-e] [-f _format_] -d @_file_++
+*add* [-e] [-f _format_] -d @- < _file_++
+*add* [-e] [-f _format_] -d _data_
 	Add new boot configuration to be able to be used by nodes. If boot
 	configuration already exists for the specified components, this command will
 	fail.
@@ -347,6 +364,11 @@ Subcommands for this command are as follows:
 	endpoint.
 
 	This command accepts the following options:
+
+	*-e, --envelope*
+		Use the envelope (advanced) API, preserving metadata, labels, and
+		annotations, instead of the simple API. Without this flag, labels and
+		annotations in the payload are discarded.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data
@@ -468,10 +490,10 @@ Subcommands for this command are as follows:
 		(automatic if any of
 		*--add*/*--remove*/*--set*/*--unset* are specified).
 
-*set* [-f _format_] _uid_ < _file_++
-*set* [-f _format_] -d @_file_ _uid_++
-*set* [-f _format_] -d @- _uid_ < _file_++
-*set* [-f _format_] -d _data_ _uid_
+*set* [-e] [-f _format_] _uid_ < _file_++
+*set* [-e] [-f _format_] -d @_file_ _uid_++
+*set* [-e] [-f _format_] -d @- _uid_ < _file_++
+*set* [-e] [-f _format_] -d _data_ _uid_
 	Set the specification of a boot configuration identified by _uid_. The
 	entire specification for the boot configuration gets replaced with the
 	specification that is passed.
@@ -489,6 +511,11 @@ Subcommands for this command are as follows:
 	endpoint.
 
 	This command accepts the following options:
+
+	*-e, --envelope*
+		Use the envelope (advanced) API, preserving metadata, labels, and
+		annotations, instead of the simple API. Without this flag, labels and
+		annotations in the payload are discarded.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data
@@ -509,10 +536,10 @@ Manage nodes stored in boot-service.
 
 Subcommands for this command are as follows:
 
-*add* [-f _format_] < _file_++
-*add* [-f _format_] -d @_file_++
-*add* [-f _format_] -d @- < _file_++
-*add* [-f _format_] -d _data_
+*add* [-e] [-f _format_] < _file_++
+*add* [-e] [-f _format_] -d @_file_++
+*add* [-e] [-f _format_] -d @- < _file_++
+*add* [-e] [-f _format_] -d _data_
 	Add one or more nodes to boot-service.
 
 	In the first and third forms of the command, data is read from standard
@@ -527,6 +554,11 @@ Subcommands for this command are as follows:
 	This command sends a POST request to boot-service's node endpoint.
 
 	This command accepts the following options:
+
+	*-e, --envelope*
+		Use the envelope (advanced) API, preserving metadata, labels, and
+		annotations, instead of the simple API. Without this flag, labels and
+		annotations in the payload are discarded.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data
@@ -646,10 +678,10 @@ Subcommands for this command are as follows:
 		(automatic if any of
 		*--add*/*--remove*/*--set*/*--unset* are specified).
 
-*set* [-f _format_] _uid_ < _file_++
-*set* [-f _format_] -d @_file_ _uid_++
-*set* [-f _format_] -d @- _uid_ < _file_++
-*set* [-f _format_] -d _data_ _uid_
+*set* [-e] [-f _format_] _uid_ < _file_++
+*set* [-e] [-f _format_] -d @_file_ _uid_++
+*set* [-e] [-f _format_] -d @- _uid_ < _file_++
+*set* [-e] [-f _format_] -d _data_ _uid_
 	Set the specification of a node identified by _uid_. The entire
 	specification for the node is replaced with the specification that is
 	passed.
@@ -666,6 +698,11 @@ Subcommands for this command are as follows:
 	This command sends a PUT request to boot-service's node endpoint.
 
 	This command accepts the following options:
+
+	*-e, --envelope*
+		Use the envelope (advanced) API, preserving metadata, labels, and
+		annotations, instead of the simple API. Without this flag, labels and
+		annotations in the payload are discarded.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data

--- a/man/ochami-metadata.1.sc
+++ b/man/ochami-metadata.1.sc
@@ -17,7 +17,74 @@ ochami-metadata - Communicate with the Metadata Service
 *ochami metadata* (*defaults* | *group* | *instance* | *peer*) *set* [-e] [-f _format_] [-d (_data_ | @_path_)] _uid_++
 *ochami metadata service status* [-F _format_]
 
-# DATA STRUCTURE
+# SIMPLE VERSUS ADVANCED API
+
+The user can either specify just the specification of a resource when
+creating/modifying it or specify additional annotations, labels, and metadata as
+outlined below.
+
+## SIMPLE API
+
+For commands that add or edit data (*add*, *set*), the default way to pass the
+data is via the specification ("spec") of the data itself with a mandatory
+*name* field (see *DATA SPECIFICATIONS* for data type specifications). This is the
+*simple API*.
+
+When using the simple API, the *name* field is _required_ to be specified in the
+spec. This will set the name in the metadata of the resource, which means the
+specified name will appear in *metadata.name* when listing the resource.
+
+For example, a resource spec when creating/modifying a resource would look
+something like:
+
+```
+{
+  "name": "my-resource",
+  // other spec data
+}
+```
+
+When listing that same resource, it will look like:
+
+```
+{
+  "metadata": {
+    "name": "my-resource",
+	...
+  },
+  ...
+  "spec": {
+	  // other spec data
+  }
+}
+```
+
+## ADVANCED API
+
+For finer-grain control, the *--envelope*/*-e* flag can be used to enable the
+*advanced* API, which allows specifying additional metadata, labels, and
+annotations. A JSON example of using this API would be:
+
+```
+{
+  "annotations": {...},
+  "labels": {...},
+  "metadata": {...},
+  "spec": {...}         // <- where spec goes
+}
+```
+
+This can be thought of as the "raw" data structure since the simple API
+abstracts creating this structure while the advanced API exposes it directly.
+Either way, this data structure is what is sent over the wire.
+
+# DATA SPECIFICATIONS
+
+The following are the specifications for the various metadata-service resources
+accepted and returned by *ochami*.
+
+Note that the *name* field is omitted from the data specifications below since
+that is technically metadata (see *SIMPLE VERSUS ADVANCED API*).
 
 ## CLUSTER DEFAULTS
 
@@ -27,41 +94,18 @@ that can be applied across all nodes in the cluster.
 
 ```
 {
-  "apiVersion": "cloud-init.openchami.io/v1",
-  "kind": "ClusterDefaults",
-  "metadata": {
-    "name": "demo-cluster-defaults",
-    "uid": "clusterdefaults-demo-01hzy7h9xq6b8m2p4v1n3r5t7w",
-    "labels": {
-      "cluster": "demo",
-      "environment": "production"
-    },
-    "annotations": {
-      "contact.email": "hpc-ops@example.com",
-      "deployment.notes": "Default metadata for the demo OpenCHAMI cluster"
-    },
-    "createdAt": "2026-01-15T18:30:00Z",
-    "updatedAt": "2026-01-15T19:45:00Z"
-  },
-  "spec": {
-    "description": "Cluster-wide defaults for the demo OpenCHAMI environment",
-    "base_url": "https://demo.openchami.cluster:8443/cloud-init",
-    "cloud_provider": "on-prem",
-    "region": "us-west-dc1",
-    "availability_zone": "rack-row-a",
-    "cluster_name": "demo",
-    "short_name": "nid",
-    "nid_length": 4,
-    "public_keys": [
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMLtQNuzGcMDatF+YVMMkuxbX2c5v2OxWftBhEVfFb+U hpc-admin@demo-login",
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB4vVRvkzmGE5PyWX2fuzJEgEfET4PRLHXCnD1uFZ8ZL automation@demo-login"
-    ]
-  },
-  "status": {
-    "phase": "Ready",
-    "message": "Cluster defaults are active",
-    "ready": true
-  }
+  "description": "Cluster-wide defaults for the demo OpenCHAMI environment",
+  "base_url": "https://demo.openchami.cluster:8443/cloud-init",
+  "cloud_provider": "on-prem",
+  "region": "us-west-dc1",
+  "availability_zone": "rack-row-a",
+  "cluster_name": "demo",
+  "short_name": "nid",
+  "nid_length": 4,
+  "public_keys": [
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMLtQNuzGcMDatF+YVMMkuxbX2c5v2OxWftBhEVfFb+U hpc-admin@demo-login",
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB4vVRvkzmGE5PyWX2fuzJEgEfET4PRLHXCnD1uFZ8ZL automation@demo-login"
+  ]
 }
 ```
 
@@ -95,33 +139,13 @@ multi-line strings without escaping.
 
 ```
 {
-  "apiVersion": "cloud-init.openchami.io/v1",
-  "kind": "Group",
-  "metadata": {
-    "name": "compute-group-1",
-    "uid": "group-01hzy7h9xq6b8m2p4v1n3r5t7w",
-    "labels": {
-      "role": "compute",
-      "cluster": "demo"
-    },
-    "createdAt": "2026-01-15T18:30:00Z",
-    "updatedAt": "2026-01-15T19:45:00Z"
+  "description": "Compute node group configuration",
+  "template": "#cloud-config\\n##template: jinja2\\npackage_update: true\\npackages:\\n  - nfs-common\\n  - chrony\\nruncmd:\\n  - echo \"Configured {{ cluster_name }}\"\\n",
+  "metaData": {
+    "role": "compute",
+    "ntp_server": "10.1.1.100"
   },
-  "spec": {
-    "description": "Compute node group configuration",
-    "template": "#cloud-config\\n##template: jinja2\\npackage_update: true\\npackages:\\n  - nfs-common\\n  - chrony\\nruncmd:\\n  - echo \"Configured {{ cluster_name }}\"\\n",
-    "metaData": {
-      "role": "compute",
-      "ntp_server": "10.1.1.100"
-    },
-    "osVersion": "ubuntu-22.04"
-  },
-  "status": {
-    "valid": true,
-    "lastApplied": "2026-01-15T19:45:00Z",
-    "currentTemplateVersion": "v-a1b2c3d4",
-    "requiredVariables": ["cluster_name"]
-  }
+  "osVersion": "ubuntu-22.04"
 }
 ```
 
@@ -142,30 +166,15 @@ JSON form below:
 
 ```
 {
-  "apiVersion": "cloud-init.openchami.io/v1",
-  "kind": "InstanceInfo",
-  "metadata": {
-    "name": "x1000c0s0b0n0-instance",
-    "uid": "instanceinfo-01hzy7h9xq6b8m2p4v1n3r5t7w",
-    "createdAt": "2026-01-15T18:30:00Z",
-    "updatedAt": "2026-01-15T19:45:00Z"
-  },
-  "spec": {
-    "description": "Compute node instance information",
-    "instance_id": "x1000c0s0b0n0",
-    "local_hostname": "nid001000",
-    "hostname": "nid001000.demo.cluster",
-    "cloud_init_base_url": "https://demo.openchami.cluster:8443/cloud-init",
-    "public_keys": [
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMLtQNuzGcMDatF+YVMMkuxbX2c5v2OxWftBhEVfFb+U admin@demo"
-    ],
-    "default_profile": "compute"
-  },
-  "status": {
-    "phase": "Ready",
-    "message": "Instance info is active",
-    "ready": true
-  }
+  "description": "Compute node instance information",
+  "instance_id": "x1000c0s0b0n0",
+  "local_hostname": "nid001000",
+  "hostname": "nid001000.demo.cluster",
+  "cloud_init_base_url": "https://demo.openchami.cluster:8443/cloud-init",
+  "public_keys": [
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMLtQNuzGcMDatF+YVMMkuxbX2c5v2OxWftBhEVfFb+U admin@demo"
+  ],
+  "default_profile": "compute"
 }
 ```
 
@@ -189,24 +198,9 @@ detailed in JSON form below:
 
 ```
 {
-  "apiVersion": "cloud-init.openchami.io/v1",
-  "kind": "WireGuardPeer",
-  "metadata": {
-    "name": "peer-nid001000",
-    "uid": "wireguardpeer-01hzy7h9xq6b8m2p4v1n3r5t7w",
-    "createdAt": "2026-01-15T18:30:00Z",
-    "updatedAt": "2026-01-15T19:45:00Z"
-  },
-  "spec": {
-    "description": "WireGuard peer for nid001000",
-    "public_key": "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=",
-    "allowed_ip": "10.42.1.1/32"
-  },
-  "status": {
-    "phase": "Ready",
-    "message": "Peer is configured",
-    "ready": true
-  }
+  "description": "WireGuard peer for nid001000",
+  "public_key": "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=",
+  "allowed_ip": "10.42.1.1/32"
 }
 ```
 
@@ -256,12 +250,12 @@ metadata-service resources. The *service* command provides operations for
 metadata-service itself.
 
 By default, the *add* and *set* subcommands use the metadata-service _simple_
-API, which sends only the resource name (from _metadata.name_) and spec. Any
-_labels_ or _annotations_ present in the payload are discarded and a warning is
-logged. To use the _envelope_ (advanced) API, which preserves metadata, labels,
-and annotations, pass the *-e, --envelope* flag. This flag is available on the
-*add* and *set* subcommands of the *defaults*, *group*, *instance*, and *peer*
-commands.
+API, which sends only the resource spec (with a required _name_ field for
+*add*). Any _labels_ or _annotations_ must instead be supplied via the
+_envelope_ (advanced) API, which is enabled by passing the *-e*/*--envelope*
+flag and preserves metadata, labels, and annotations. See *SIMPLE VERSUS
+ADVANCED API* for details. This flag is available on the *add* and *set*
+subcommands of the *defaults*, *group*, *instance*, and *peer* commands.
 
 [[ *Resource*
 :< *Subcommands*
@@ -310,8 +304,9 @@ Subcommands for this command are as follows:
 
 	*-e, --envelope*
 		Use the envelope (advanced) API, preserving metadata, labels, and
-		annotations, instead of the simple API. Without this flag, labels and
-		annotations in the payload are discarded.
+		annotations, instead of the simple API. Without this
+		flag, only the spec is sent and labels/annotations cannot be
+		specified. See *SIMPLE VERSUS ADVANCED API* for details.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data
@@ -510,8 +505,9 @@ Subcommands for this command are as follows:
 
 	*-e, --envelope*
 		Use the envelope (advanced) API, preserving metadata, labels, and
-		annotations, instead of the simple API. Without this flag, labels and
-		annotations in the payload are discarded.
+		annotations, instead of the simple API. Without this
+		flag, only the spec is sent and labels/annotations cannot be
+		specified. See *SIMPLE VERSUS ADVANCED API* for details.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data
@@ -554,8 +550,9 @@ Subcommands for this command are as follows:
 
 	*-e, --envelope*
 		Use the envelope (advanced) API, preserving metadata, labels, and
-		annotations, instead of the simple API. Without this flag, labels and
-		annotations in the payload are discarded.
+		annotations, instead of the simple API. Without this
+		flag, only the spec is sent and labels/annotations cannot be
+		specified. See *SIMPLE VERSUS ADVANCED API* for details.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data
@@ -823,8 +820,9 @@ Subcommands for this command are as follows:
 
 	*-e, --envelope*
 		Use the envelope (advanced) API, preserving metadata, labels, and
-		annotations, instead of the simple API. Without this flag, labels and
-		annotations in the payload are discarded.
+		annotations, instead of the simple API. Without this
+		flag, only the spec is sent and labels/annotations cannot be
+		specified. See *SIMPLE VERSUS ADVANCED API* for details.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data
@@ -885,8 +883,9 @@ Subcommands for this command are as follows:
 
 	*-e, --envelope*
 		Use the envelope (advanced) API, preserving metadata, labels, and
-		annotations, instead of the simple API. Without this flag, labels and
-		annotations in the payload are discarded.
+		annotations, instead of the simple API. Without this
+		flag, only the spec is sent and labels/annotations cannot be
+		specified. See *SIMPLE VERSUS ADVANCED API* for details.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data
@@ -1135,8 +1134,9 @@ Subcommands for this command are as follows:
 
 	*-e, --envelope*
 		Use the envelope (advanced) API, preserving metadata, labels, and
-		annotations, instead of the simple API. Without this flag, labels and
-		annotations in the payload are discarded.
+		annotations, instead of the simple API. Without this
+		flag, only the spec is sent and labels/annotations cannot be
+		specified. See *SIMPLE VERSUS ADVANCED API* for details.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data
@@ -1197,8 +1197,9 @@ Subcommands for this command are as follows:
 
 	*-e, --envelope*
 		Use the envelope (advanced) API, preserving metadata, labels, and
-		annotations, instead of the simple API. Without this flag, labels and
-		annotations in the payload are discarded.
+		annotations, instead of the simple API. Without this
+		flag, only the spec is sent and labels/annotations cannot be
+		specified. See *SIMPLE VERSUS ADVANCED API* for details.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data
@@ -1458,8 +1459,9 @@ Subcommands for this command are as follows:
 
 	*-e, --envelope*
 		Use the envelope (advanced) API, preserving metadata, labels, and
-		annotations, instead of the simple API. Without this flag, labels and
-		annotations in the payload are discarded.
+		annotations, instead of the simple API. Without this
+		flag, only the spec is sent and labels/annotations cannot be
+		specified. See *SIMPLE VERSUS ADVANCED API* for details.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data

--- a/man/ochami-metadata.1.sc
+++ b/man/ochami-metadata.1.sc
@@ -8,13 +8,13 @@ ochami-metadata - Communicate with the Metadata Service
 
 *ochami metadata* [_global-options_] _command_ [_command-options_] [_arguments_]
 
-*ochami metadata* (*defaults* | *group* | *instance* | *peer*) *add* [-f _format_] [-d (_data_ | @_path_)]++
+*ochami metadata* (*defaults* | *group* | *instance* | *peer*) *add* [-e] [-f _format_] [-d (_data_ | @_path_)]++
 *ochami metadata* (*defaults* | *group* | *instance* | *peer*) *delete* [--no-confirm] _uid_...++
 *ochami metadata* (*defaults* | *group* | *instance* | *peer*) *get* [-F _format_] _uid_++
 *ochami metadata* (*defaults* | *group* | *instance* | *peer*) *list* [-F _format_]++
 *ochami metadata* (*defaults* | *group* | *instance* | *peer*) *patch* [-f _format_] [-p _patch_method_] [-d (_data_ | @_path_ | @-)] _uid_++
 *ochami metadata* (*defaults* | *group* | *instance* | *peer*) *patch* (--add _key_=_val_ | --remove _key_=_val_ | --set _key_=_val_ | --unset _key_)... _uid_++
-*ochami metadata* (*defaults* | *group* | *instance* | *peer*) *set* [-f _format_] [-d (_data_ | @_path_)] _uid_++
+*ochami metadata* (*defaults* | *group* | *instance* | *peer*) *set* [-e] [-f _format_] [-d (_data_ | @_path_)] _uid_++
 *ochami metadata service status* [-F _format_]
 
 # DATA STRUCTURE
@@ -255,6 +255,14 @@ subcommands for creating, deleting, reading, listing, patching, and replacing
 metadata-service resources. The *service* command provides operations for
 metadata-service itself.
 
+By default, the *add* and *set* subcommands use the metadata-service _simple_
+API, which sends only the resource name (from _metadata.name_) and spec. Any
+_labels_ or _annotations_ present in the payload are discarded and a warning is
+logged. To use the _envelope_ (advanced) API, which preserves metadata, labels,
+and annotations, pass the *-e, --envelope* flag. This flag is available on the
+*add* and *set* subcommands of the *defaults*, *group*, *instance*, and *peer*
+commands.
+
 [[ *Resource*
 :< *Subcommands*
 :< *Description*
@@ -280,10 +288,10 @@ Manage cluster defaults in the metadata service.
 
 Subcommands for this command are as follows:
 
-*add* [-f _format_] < _file_++
-*add* [-f _format_] -d @_file_++
-*add* [-f _format_] -d @- < _file_++
-*add* [-f _format_] -d _data_
+*add* [-e] [-f _format_] < _file_++
+*add* [-e] [-f _format_] -d @_file_++
+*add* [-e] [-f _format_] -d @- < _file_++
+*add* [-e] [-f _format_] -d _data_
 	Add one or more cluster defaults to metadata-service.
 
 	In the first and third forms of the command, data is read from standard
@@ -299,6 +307,11 @@ Subcommands for this command are as follows:
 	defaults endpoint.
 
 	This command accepts the following flags:
+
+	*-e, --envelope*
+		Use the envelope (advanced) API, preserving metadata, labels, and
+		annotations, instead of the simple API. Without this flag, labels and
+		annotations in the payload are discarded.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data
@@ -473,10 +486,10 @@ Subcommands for this command are as follows:
 		(automatic if any of
 		*--add*/*--remove*/*--set*/*--unset* are specified).
 
-*set* [-f _format_] _uid_ < _file_++
-*set* [-f _format_] -d @_file_ _uid_++
-*set* [-f _format_] -d @- _uid_ < _file_++
-*set* [-f _format_] -d _data_ _uid_
+*set* [-e] [-f _format_] _uid_ < _file_++
+*set* [-e] [-f _format_] -d @_file_ _uid_++
+*set* [-e] [-f _format_] -d @- _uid_ < _file_++
+*set* [-e] [-f _format_] -d _data_ _uid_
 	Set the specification of a cluster defaults identified by _uid_. The entire
 	specification for the cluster defaults is replaced with the specification
 	that is passed.
@@ -494,6 +507,11 @@ Subcommands for this command are as follows:
 	endpoint.
 
 	This command accepts the following options:
+
+	*-e, --envelope*
+		Use the envelope (advanced) API, preserving metadata, labels, and
+		annotations, instead of the simple API. Without this flag, labels and
+		annotations in the payload are discarded.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data
@@ -514,10 +532,10 @@ Manage cloud-init group templates in the metadata service.
 
 Subcommands for this command are as follows:
 
-*add* [-f _format_] < _file_++
-*add* [-f _format_] -d @_file_++
-*add* [-f _format_] -d @- < _file_++
-*add* [-f _format_] -d _data_
+*add* [-e] [-f _format_] < _file_++
+*add* [-e] [-f _format_] -d @_file_++
+*add* [-e] [-f _format_] -d @- < _file_++
+*add* [-e] [-f _format_] -d _data_
 	Add one or more groups to metadata-service.
 
 	In the first and third forms of the command, data is read from standard
@@ -533,6 +551,11 @@ Subcommands for this command are as follows:
 	endpoint.
 
 	This command accepts the following flags:
+
+	*-e, --envelope*
+		Use the envelope (advanced) API, preserving metadata, labels, and
+		annotations, instead of the simple API. Without this flag, labels and
+		annotations in the payload are discarded.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data
@@ -777,10 +800,10 @@ Subcommands for this command are as follows:
 	ochami metadata group patch group-d614b918 -d @payload.json
 	```
 
-*set* [-f _format_] _uid_ < _file_++
-*set* [-f _format_] -d @_file_ _uid_++
-*set* [-f _format_] -d @- _uid_ < _file_++
-*set* [-f _format_] -d _data_ _uid_
+*set* [-e] [-f _format_] _uid_ < _file_++
+*set* [-e] [-f _format_] -d @_file_ _uid_++
+*set* [-e] [-f _format_] -d @- _uid_ < _file_++
+*set* [-e] [-f _format_] -d _data_ _uid_
 	Set the specification of a group identified by _uid_. The entire
 	specification for the group is replaced with the specification that is
 	passed.
@@ -797,6 +820,11 @@ Subcommands for this command are as follows:
 	This command sends a PUT request to metadata-service's group endpoint.
 
 	This command accepts the following options:
+
+	*-e, --envelope*
+		Use the envelope (advanced) API, preserving metadata, labels, and
+		annotations, instead of the simple API. Without this flag, labels and
+		annotations in the payload are discarded.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data
@@ -835,10 +863,10 @@ Manage instance information in the metadata service.
 
 Subcommands for this command are as follows:
 
-*add* [-f _format_] < _file_++
-*add* [-f _format_] -d @_file_++
-*add* [-f _format_] -d @- < _file_++
-*add* [-f _format_] -d _data_
+*add* [-e] [-f _format_] < _file_++
+*add* [-e] [-f _format_] -d @_file_++
+*add* [-e] [-f _format_] -d @- < _file_++
+*add* [-e] [-f _format_] -d _data_
 	Add one or more instance infos to metadata-service.
 
 	In the first and third forms of the command, data is read from standard
@@ -854,6 +882,11 @@ Subcommands for this command are as follows:
 	info endpoint.
 
 	This command accepts the following flags:
+
+	*-e, --envelope*
+		Use the envelope (advanced) API, preserving metadata, labels, and
+		annotations, instead of the simple API. Without this flag, labels and
+		annotations in the payload are discarded.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data
@@ -1079,10 +1112,10 @@ Subcommands for this command are as follows:
 	ochami metadata instance patch instanceinfo-d614b918 -d @payload.yaml -f yaml
 	```
 
-*set* [-f _format_] _uid_ < _file_++
-*set* [-f _format_] -d @_file_ _uid_++
-*set* [-f _format_] -d @- _uid_ < _file_++
-*set* [-f _format_] -d _data_ _uid_
+*set* [-e] [-f _format_] _uid_ < _file_++
+*set* [-e] [-f _format_] -d @_file_ _uid_++
+*set* [-e] [-f _format_] -d @- _uid_ < _file_++
+*set* [-e] [-f _format_] -d _data_ _uid_
 	Set the specification of an instance info identified by _uid_. The entire
 	specification for the instance info is replaced with the specification that
 	is passed.
@@ -1099,6 +1132,11 @@ Subcommands for this command are as follows:
 	This command sends a PUT request to metadata-service's instance info endpoint.
 
 	This command accepts the following options:
+
+	*-e, --envelope*
+		Use the envelope (advanced) API, preserving metadata, labels, and
+		annotations, instead of the simple API. Without this flag, labels and
+		annotations in the payload are discarded.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data
@@ -1137,10 +1175,10 @@ Manage WireGuard peer configurations in the metadata service.
 
 Subcommands for this command are as follows:
 
-*add* [-f _format_] < _file_++
-*add* [-f _format_] -d @_file_++
-*add* [-f _format_] -d @- < _file_++
-*add* [-f _format_] -d _data_
+*add* [-e] [-f _format_] < _file_++
+*add* [-e] [-f _format_] -d @_file_++
+*add* [-e] [-f _format_] -d @- < _file_++
+*add* [-e] [-f _format_] -d _data_
 	Add one or more WireGuard peers to metadata-service.
 
 	In the first and third forms of the command, data is read from standard
@@ -1156,6 +1194,11 @@ Subcommands for this command are as follows:
 	peer endpoint.
 
 	This command accepts the following flags:
+
+	*-e, --envelope*
+		Use the envelope (advanced) API, preserving metadata, labels, and
+		annotations, instead of the simple API. Without this flag, labels and
+		annotations in the payload are discarded.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data
@@ -1392,10 +1435,10 @@ Subcommands for this command are as follows:
 	ochami metadata peer patch wireguardpeer-d614b918 -d @payload.json
 	```
 
-*set* [-f _format_] _uid_ < _file_++
-*set* [-f _format_] -d @_file_ _uid_++
-*set* [-f _format_] -d @- _uid_ < _file_++
-*set* [-f _format_] -d _data_ _uid_
+*set* [-e] [-f _format_] _uid_ < _file_++
+*set* [-e] [-f _format_] -d @_file_ _uid_++
+*set* [-e] [-f _format_] -d @- _uid_ < _file_++
+*set* [-e] [-f _format_] -d _data_ _uid_
 	Set the specification of a WireGuard peer identified by _uid_. The entire
 	specification for the WireGuard peer is replaced with the specification that
 	is passed.
@@ -1412,6 +1455,11 @@ Subcommands for this command are as follows:
 	This command sends a PUT request to metadata-service's WireGuard peer endpoint.
 
 	This command accepts the following options:
+
+	*-e, --envelope*
+		Use the envelope (advanced) API, preserving metadata, labels, and
+		annotations, instead of the simple API. Without this flag, labels and
+		annotations in the payload are discarded.
 
 	*-d, --data* (_data_ | @_path_ | @-)
 		Specify raw _data_ to send, the _path_ to a file to read payload data

--- a/pkg/client/boot_service/bmc.go
+++ b/pkg/client/boot_service/bmc.go
@@ -11,6 +11,7 @@ import (
 	api "github.com/openchami/boot-service/apis/boot.openchami.io/v1"
 	boot_service_client "github.com/openchami/boot-service/pkg/client"
 
+	"github.com/OpenCHAMI/ochami/internal/cli"
 	"github.com/OpenCHAMI/ochami/pkg/client"
 	"github.com/OpenCHAMI/ochami/pkg/format"
 )
@@ -140,6 +141,48 @@ func (bsc *BootServiceClient) SetBMC(token string, uid string, bmc boot_service_
 	defer cancel()
 
 	item, err := bsc.Client.WithBearerToken(token).UpdateBMC(ctx, uid, bmc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set BMC %+v: %w", bmc, err)
+	}
+
+	return item, nil
+}
+
+// AddBMCsSimple is like AddBMCs but calls the boot-service client's simple
+// CreateBMCSimple() function, which only sends the resource name and spec. Any
+// labels or annotations present in the request are discarded and a warning is
+// logged advising the user to pass --envelope to preserve them.
+func (bsc *BootServiceClient) AddBMCsSimple(token string, bmcs []boot_service_client.CreateBMCRequest) (bmcsAdded []*api.BMC, errors []error, funcErr error) {
+	// TODO: Make concurrent
+	for _, bmc := range bmcs {
+		ctx, cancel := context.WithTimeout(context.Background(), bsc.Timeout)
+		defer cancel()
+
+		cli.WarnDiscardedEnvelope(bmc.Metadata.Name, bmc.Labels, bmc.Annotations)
+
+		item, err := bsc.Client.WithBearerToken(token).CreateBMCSimple(ctx, bmc.Metadata.Name, bmc.Spec)
+		if err != nil {
+			newErr := fmt.Errorf("failed to add bmc %+v: %w", bmc, err)
+			errors = append(errors, newErr)
+			bmcsAdded = append(bmcsAdded, nil)
+		}
+		bmcsAdded = append(bmcsAdded, item)
+	}
+
+	return
+}
+
+// SetBMCSimple is like SetBMC but calls the boot-service client's simple
+// UpdateBMCSimple() function, which only sends the resource spec. Any labels or
+// annotations present in the request are discarded and a warning is logged
+// advising the user to pass --envelope to preserve them.
+func (bsc *BootServiceClient) SetBMCSimple(token string, uid string, bmc boot_service_client.UpdateBMCRequest) (*api.BMC, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), bsc.Timeout)
+	defer cancel()
+
+	cli.WarnDiscardedEnvelope(bmc.Metadata.Name, bmc.Labels, bmc.Annotations)
+
+	item, err := bsc.Client.WithBearerToken(token).UpdateBMCSimple(ctx, uid, bmc.Spec)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set BMC %+v: %w", bmc, err)
 	}

--- a/pkg/client/boot_service/bmc.go
+++ b/pkg/client/boot_service/bmc.go
@@ -11,10 +11,20 @@ import (
 	api "github.com/openchami/boot-service/apis/boot.openchami.io/v1"
 	boot_service_client "github.com/openchami/boot-service/pkg/client"
 
-	"github.com/OpenCHAMI/ochami/internal/cli"
 	"github.com/OpenCHAMI/ochami/pkg/client"
 	"github.com/OpenCHAMI/ochami/pkg/format"
 )
+
+// BMCSpec is a wrapper around the boot-service's BMCSpec and is used
+// specifically for the simple API. For adding BMCs, a "name" field is required
+// but is only provided in the "metadata" structure, which is outside of the
+// spec and is only available in the advanced API. To get around this, the
+// upstream spec is wrapped with a "name" field so bulk specs can be added with
+// names specified for each without having to provide them as arguments.
+type BMCSpec struct {
+	Name string `json:"name" yaml:"name"` // Mandatory for adding resource
+	api.BMCSpec
+}
 
 // AddBMCs is a wrapper that calls the boot-service client's CreateBMC()
 // function, passing it context. The output is a slice of the BMCs it created,
@@ -148,21 +158,17 @@ func (bsc *BootServiceClient) SetBMC(token string, uid string, bmc boot_service_
 	return item, nil
 }
 
-// AddBMCsSimple is like AddBMCs but calls the boot-service client's simple
-// CreateBMCSimple() function, which only sends the resource name and spec. Any
-// labels or annotations present in the request are discarded and a warning is
-// logged advising the user to pass --envelope to preserve them.
-func (bsc *BootServiceClient) AddBMCsSimple(token string, bmcs []boot_service_client.CreateBMCRequest) (bmcsAdded []*api.BMC, errors []error, funcErr error) {
+// AddBMCSpecs is like AddBMCs but calls the boot-service client's simple
+// CreateBMCSimple() function, which only sends the resource name and spec.
+func (bsc *BootServiceClient) AddBMCSpecs(token string, bmcs []BMCSpec) (bmcsAdded []*api.BMC, errors []error, funcErr error) {
 	// TODO: Make concurrent
 	for _, bmc := range bmcs {
 		ctx, cancel := context.WithTimeout(context.Background(), bsc.Timeout)
 		defer cancel()
 
-		cli.WarnDiscardedEnvelope(bmc.Metadata.Name, bmc.Labels, bmc.Annotations)
-
-		item, err := bsc.Client.WithBearerToken(token).CreateBMCSimple(ctx, bmc.Metadata.Name, bmc.Spec)
+		item, err := bsc.Client.WithBearerToken(token).CreateBMCSimple(ctx, bmc.Name, bmc.BMCSpec)
 		if err != nil {
-			newErr := fmt.Errorf("failed to add bmc %+v: %w", bmc, err)
+			newErr := fmt.Errorf("failed to add bmc %q (%+v): %w", bmc.Name, bmc.BMCSpec, err)
 			errors = append(errors, newErr)
 			bmcsAdded = append(bmcsAdded, nil)
 		}
@@ -172,19 +178,15 @@ func (bsc *BootServiceClient) AddBMCsSimple(token string, bmcs []boot_service_cl
 	return
 }
 
-// SetBMCSimple is like SetBMC but calls the boot-service client's simple
-// UpdateBMCSimple() function, which only sends the resource spec. Any labels or
-// annotations present in the request are discarded and a warning is logged
-// advising the user to pass --envelope to preserve them.
-func (bsc *BootServiceClient) SetBMCSimple(token string, uid string, bmc boot_service_client.UpdateBMCRequest) (*api.BMC, error) {
+// SetBMCSpec is like SetBMC but calls the boot-service client's simple
+// UpdateBMCSimple() function, which only sends the resource spec.
+func (bsc *BootServiceClient) SetBMCSpec(token string, uid string, spec api.BMCSpec) (*api.BMC, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), bsc.Timeout)
 	defer cancel()
 
-	cli.WarnDiscardedEnvelope(bmc.Metadata.Name, bmc.Labels, bmc.Annotations)
-
-	item, err := bsc.Client.WithBearerToken(token).UpdateBMCSimple(ctx, uid, bmc.Spec)
+	item, err := bsc.Client.WithBearerToken(token).UpdateBMCSimple(ctx, uid, spec)
 	if err != nil {
-		return nil, fmt.Errorf("failed to set BMC %+v: %w", bmc, err)
+		return nil, fmt.Errorf("failed to set BMC %+v: %w", spec, err)
 	}
 
 	return item, nil

--- a/pkg/client/boot_service/bmc_test.go
+++ b/pkg/client/boot_service/bmc_test.go
@@ -6,32 +6,15 @@ package boot_service
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
-	"net/http/httptest"
 	"testing"
-	"time"
 
 	api "github.com/openchami/boot-service/apis/boot.openchami.io/v1"
 	boot_service_client "github.com/openchami/boot-service/pkg/client"
 	"github.com/openchami/fabrica/pkg/fabrica"
-	"github.com/rs/zerolog"
 )
 
-// newTestClient spins up an httptest server with the given handler and returns
-// a BootServiceClient pointed at it.
-func newTestClient(t *testing.T, handler http.HandlerFunc) (*BootServiceClient, *httptest.Server) {
-	t.Helper()
-	srv := httptest.NewServer(handler)
-	c, err := NewClient(srv.URL, false, 5*time.Second, "", zerolog.New(io.Discard))
-	if err != nil {
-		srv.Close()
-		t.Fatalf("failed to create client: %v", err)
-	}
-	return c, srv
-}
-
-func TestAddNodeSpecs_SendsNameAndSpecWithoutEnvelopeExtras(t *testing.T) {
+func TestAddBMCSpecs_SendsNameAndSpecWithoutEnvelopeExtras(t *testing.T) {
 	var gotBody map[string]interface{}
 	var gotPath, gotMethod string
 	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
@@ -39,32 +22,32 @@ func TestAddNodeSpecs_SendsNameAndSpecWithoutEnvelopeExtras(t *testing.T) {
 		gotMethod = r.Method
 		_ = json.NewDecoder(r.Body).Decode(&gotBody)
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(api.Node{})
+		_ = json.NewEncoder(w).Encode(api.BMC{})
 	})
 	defer srv.Close()
 
-	nodes := []NodeSpec{
+	bmcs := []BMCSpec{
 		{
-			Name:     "x1000c0s0b0n0",
-			NodeSpec: api.NodeSpec{XName: "x1000c0s0b0n0", NID: 42},
+			Name:    "bmc01",
+			BMCSpec: api.BMCSpec{XName: "x1000c0s0b0"},
 		},
 	}
 
-	_, errs, err := c.AddNodeSpecs("", nodes)
+	_, errs, err := c.AddBMCSpecs("", bmcs)
 	if err != nil {
-		t.Fatalf("AddNodeSpecs returned func error: %v", err)
+		t.Fatalf("AddBMCSpecs returned func error: %v", err)
 	}
 	for _, e := range errs {
 		if e != nil {
-			t.Fatalf("AddNodeSpecs per-request error: %v", e)
+			t.Fatalf("AddBMCSpecs per-request error: %v", e)
 		}
 	}
 
 	if gotMethod != http.MethodPost {
 		t.Errorf("method = %q, want POST", gotMethod)
 	}
-	if gotPath != "/nodes" {
-		t.Errorf("path = %q, want /nodes", gotPath)
+	if gotPath != "/bmcs" {
+		t.Errorf("path = %q, want /bmcs", gotPath)
 	}
 	// Simple API still sends an envelope built from name + spec, but must NOT
 	// carry labels/annotations supplied on the request.
@@ -72,31 +55,31 @@ func TestAddNodeSpecs_SendsNameAndSpecWithoutEnvelopeExtras(t *testing.T) {
 		t.Errorf("simple request unexpectedly included labels: %+v", gotBody["labels"])
 	}
 	meta, _ := gotBody["metadata"].(map[string]interface{})
-	if meta == nil || meta["name"] != "x1000c0s0b0n0" {
-		t.Errorf("metadata.name = %+v, want x1000c0s0b0n0", meta)
+	if meta == nil || meta["name"] != "bmc01" {
+		t.Errorf("metadata.name = %+v, want bmc01", meta)
 	}
 }
 
-func TestAddNodes_EnvelopeIncludesLabels(t *testing.T) {
+func TestAddBMCs_EnvelopeIncludesLabels(t *testing.T) {
 	var gotBody map[string]interface{}
 	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewDecoder(r.Body).Decode(&gotBody)
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(api.Node{})
+		_ = json.NewEncoder(w).Encode(api.BMC{})
 	})
 	defer srv.Close()
 
-	nodes := []boot_service_client.CreateNodeRequest{
+	bmcs := []boot_service_client.CreateBMCRequest{
 		{
-			Metadata: fabrica.Metadata{Name: "x1000c0s0b0n0", Labels: map[string]string{"env": "prod"}},
-			Spec:     api.NodeSpec{XName: "x1000c0s0b0n0"},
+			Metadata: fabrica.Metadata{Name: "bmc01", Labels: map[string]string{"env": "prod"}},
+			Spec:     api.BMCSpec{XName: "x1000c0s0b0"},
 			Labels:   map[string]string{"env": "prod"},
 		},
 	}
 
-	_, _, err := c.AddNodes("", nodes)
+	_, _, err := c.AddBMCs("", bmcs)
 	if err != nil {
-		t.Fatalf("AddNodes returned func error: %v", err)
+		t.Fatalf("AddBMCs returned func error: %v", err)
 	}
 
 	labels, ok := gotBody["labels"].(map[string]interface{})
@@ -105,7 +88,7 @@ func TestAddNodes_EnvelopeIncludesLabels(t *testing.T) {
 	}
 }
 
-func TestSetNodeSpec_SendsSpecToUIDEndpoint(t *testing.T) {
+func TestSetBMCSpec_SendsSpecToUIDEndpoint(t *testing.T) {
 	var gotPath, gotMethod string
 	var gotBody map[string]interface{}
 	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
@@ -113,22 +96,22 @@ func TestSetNodeSpec_SendsSpecToUIDEndpoint(t *testing.T) {
 		gotMethod = r.Method
 		_ = json.NewDecoder(r.Body).Decode(&gotBody)
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(api.Node{})
+		_ = json.NewEncoder(w).Encode(api.BMC{})
 	})
 	defer srv.Close()
 
-	spec := api.NodeSpec{XName: "x1000c0s0b0n0", NID: 7}
+	spec := api.BMCSpec{XName: "x1000c0s0b0"}
 
-	_, err := c.SetNodeSpec("", "nod-abc123", spec)
+	_, err := c.SetBMCSpec("", "bmc-abc123", spec)
 	if err != nil {
-		t.Fatalf("SetNodeSpec returned error: %v", err)
+		t.Fatalf("SetBMCSpec returned error: %v", err)
 	}
 
 	if gotMethod != http.MethodPut {
 		t.Errorf("method = %q, want PUT", gotMethod)
 	}
-	if gotPath != "/nodes/nod-abc123" {
-		t.Errorf("path = %q, want /nodes/nod-abc123", gotPath)
+	if gotPath != "/bmcs/bmc-abc123" {
+		t.Errorf("path = %q, want /bmcs/bmc-abc123", gotPath)
 	}
 	if _, ok := gotBody["labels"]; ok {
 		t.Errorf("simple set unexpectedly included labels: %+v", gotBody["labels"])

--- a/pkg/client/boot_service/bootconfig.go
+++ b/pkg/client/boot_service/bootconfig.go
@@ -11,10 +11,21 @@ import (
 	api "github.com/openchami/boot-service/apis/boot.openchami.io/v1"
 	boot_service_client "github.com/openchami/boot-service/pkg/client"
 
-	"github.com/OpenCHAMI/ochami/internal/cli"
 	"github.com/OpenCHAMI/ochami/pkg/client"
 	"github.com/OpenCHAMI/ochami/pkg/format"
 )
+
+// BootConfigSpec is a wrapper around the boot-service's BootConfigurationSpec
+// and is used specifically for the simple API. For adding boot configurations,
+// a "name" field is required but is only provided in the "metadata" structure,
+// which is outside of the spec and is only available in the advanced API. To get
+// around this, the upstream spec is wrapped with a "name" field so bulk specs
+// can be added with names specified for each without having to provide them as
+// arguments.
+type BootConfigSpec struct {
+	Name string `json:"name" yaml:"name"` // Mandatory for adding resource
+	api.BootConfigurationSpec
+}
 
 // AddBootConfigs is a wrapper that calls the boot-service client's
 // CreateBootConfiguration() function, passing it context. The output is a slice
@@ -153,22 +164,18 @@ func (bsc *BootServiceClient) SetBootConfig(token string, uid string, bootCfg bo
 	return item, nil
 }
 
-// AddBootConfigsSimple is like AddBootConfigs but calls the boot-service
+// AddBootConfigSpecs is like AddBootConfigs but calls the boot-service
 // client's simple CreateBootConfigurationSimple() function, which only sends
-// the resource name and spec. Any labels or annotations present in the request
-// are discarded and a warning is logged advising the user to pass --envelope to
-// preserve them.
-func (bsc *BootServiceClient) AddBootConfigsSimple(token string, bootCfgs []boot_service_client.CreateBootConfigurationRequest) (cfgsAdded []*api.BootConfiguration, errors []error, funcErr error) {
+// the resource name and spec.
+func (bsc *BootServiceClient) AddBootConfigSpecs(token string, bootCfgs []BootConfigSpec) (cfgsAdded []*api.BootConfiguration, errors []error, funcErr error) {
 	// TODO: Make concurrent
 	for _, bootCfg := range bootCfgs {
 		ctx, cancel := context.WithTimeout(context.Background(), bsc.Timeout)
 		defer cancel()
 
-		cli.WarnDiscardedEnvelope(bootCfg.Metadata.Name, bootCfg.Labels, bootCfg.Annotations)
-
-		item, err := bsc.Client.WithBearerToken(token).CreateBootConfigurationSimple(ctx, bootCfg.Metadata.Name, bootCfg.Spec)
+		item, err := bsc.Client.WithBearerToken(token).CreateBootConfigurationSimple(ctx, bootCfg.Name, bootCfg.BootConfigurationSpec)
 		if err != nil {
-			newErr := fmt.Errorf("failed to add boot configuration %+v: %w", bootCfg, err)
+			newErr := fmt.Errorf("failed to add boot configuration %q (%+v): %w", bootCfg.Name, bootCfg.BootConfigurationSpec, err)
 			errors = append(errors, newErr)
 			cfgsAdded = append(cfgsAdded, nil)
 		}
@@ -178,20 +185,16 @@ func (bsc *BootServiceClient) AddBootConfigsSimple(token string, bootCfgs []boot
 	return
 }
 
-// SetBootConfigSimple is like SetBootConfig but calls the boot-service client's
+// SetBootConfigSpec is like SetBootConfig but calls the boot-service client's
 // simple UpdateBootConfigurationSimple() function, which only sends the
-// resource spec. Any labels or annotations present in the request are discarded
-// and a warning is logged advising the user to pass --envelope to preserve
-// them.
-func (bsc *BootServiceClient) SetBootConfigSimple(token string, uid string, bootCfg boot_service_client.UpdateBootConfigurationRequest) (*api.BootConfiguration, error) {
+// resource spec.
+func (bsc *BootServiceClient) SetBootConfigSpec(token string, uid string, spec api.BootConfigurationSpec) (*api.BootConfiguration, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), bsc.Timeout)
 	defer cancel()
 
-	cli.WarnDiscardedEnvelope(bootCfg.Metadata.Name, bootCfg.Labels, bootCfg.Annotations)
-
-	item, err := bsc.Client.WithBearerToken(token).UpdateBootConfigurationSimple(ctx, uid, bootCfg.Spec)
+	item, err := bsc.Client.WithBearerToken(token).UpdateBootConfigurationSimple(ctx, uid, spec)
 	if err != nil {
-		return nil, fmt.Errorf("failed to set boot configuration %+v: %w", bootCfg, err)
+		return nil, fmt.Errorf("failed to set boot configuration %+v: %w", spec, err)
 	}
 
 	return item, nil

--- a/pkg/client/boot_service/bootconfig.go
+++ b/pkg/client/boot_service/bootconfig.go
@@ -11,6 +11,7 @@ import (
 	api "github.com/openchami/boot-service/apis/boot.openchami.io/v1"
 	boot_service_client "github.com/openchami/boot-service/pkg/client"
 
+	"github.com/OpenCHAMI/ochami/internal/cli"
 	"github.com/OpenCHAMI/ochami/pkg/client"
 	"github.com/OpenCHAMI/ochami/pkg/format"
 )
@@ -145,6 +146,50 @@ func (bsc *BootServiceClient) SetBootConfig(token string, uid string, bootCfg bo
 	defer cancel()
 
 	item, err := bsc.Client.WithBearerToken(token).UpdateBootConfiguration(ctx, uid, bootCfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set boot configuration %+v: %w", bootCfg, err)
+	}
+
+	return item, nil
+}
+
+// AddBootConfigsSimple is like AddBootConfigs but calls the boot-service
+// client's simple CreateBootConfigurationSimple() function, which only sends
+// the resource name and spec. Any labels or annotations present in the request
+// are discarded and a warning is logged advising the user to pass --envelope to
+// preserve them.
+func (bsc *BootServiceClient) AddBootConfigsSimple(token string, bootCfgs []boot_service_client.CreateBootConfigurationRequest) (cfgsAdded []*api.BootConfiguration, errors []error, funcErr error) {
+	// TODO: Make concurrent
+	for _, bootCfg := range bootCfgs {
+		ctx, cancel := context.WithTimeout(context.Background(), bsc.Timeout)
+		defer cancel()
+
+		cli.WarnDiscardedEnvelope(bootCfg.Metadata.Name, bootCfg.Labels, bootCfg.Annotations)
+
+		item, err := bsc.Client.WithBearerToken(token).CreateBootConfigurationSimple(ctx, bootCfg.Metadata.Name, bootCfg.Spec)
+		if err != nil {
+			newErr := fmt.Errorf("failed to add boot configuration %+v: %w", bootCfg, err)
+			errors = append(errors, newErr)
+			cfgsAdded = append(cfgsAdded, nil)
+		}
+		cfgsAdded = append(cfgsAdded, item)
+	}
+
+	return
+}
+
+// SetBootConfigSimple is like SetBootConfig but calls the boot-service client's
+// simple UpdateBootConfigurationSimple() function, which only sends the
+// resource spec. Any labels or annotations present in the request are discarded
+// and a warning is logged advising the user to pass --envelope to preserve
+// them.
+func (bsc *BootServiceClient) SetBootConfigSimple(token string, uid string, bootCfg boot_service_client.UpdateBootConfigurationRequest) (*api.BootConfiguration, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), bsc.Timeout)
+	defer cancel()
+
+	cli.WarnDiscardedEnvelope(bootCfg.Metadata.Name, bootCfg.Labels, bootCfg.Annotations)
+
+	item, err := bsc.Client.WithBearerToken(token).UpdateBootConfigurationSimple(ctx, uid, bootCfg.Spec)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set boot configuration %+v: %w", bootCfg, err)
 	}

--- a/pkg/client/boot_service/bootconfig_test.go
+++ b/pkg/client/boot_service/bootconfig_test.go
@@ -6,32 +6,15 @@ package boot_service
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
-	"net/http/httptest"
 	"testing"
-	"time"
 
 	api "github.com/openchami/boot-service/apis/boot.openchami.io/v1"
 	boot_service_client "github.com/openchami/boot-service/pkg/client"
 	"github.com/openchami/fabrica/pkg/fabrica"
-	"github.com/rs/zerolog"
 )
 
-// newTestClient spins up an httptest server with the given handler and returns
-// a BootServiceClient pointed at it.
-func newTestClient(t *testing.T, handler http.HandlerFunc) (*BootServiceClient, *httptest.Server) {
-	t.Helper()
-	srv := httptest.NewServer(handler)
-	c, err := NewClient(srv.URL, false, 5*time.Second, "", zerolog.New(io.Discard))
-	if err != nil {
-		srv.Close()
-		t.Fatalf("failed to create client: %v", err)
-	}
-	return c, srv
-}
-
-func TestAddNodeSpecs_SendsNameAndSpecWithoutEnvelopeExtras(t *testing.T) {
+func TestAddBootConfigSpecs_SendsNameAndSpecWithoutEnvelopeExtras(t *testing.T) {
 	var gotBody map[string]interface{}
 	var gotPath, gotMethod string
 	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
@@ -39,32 +22,32 @@ func TestAddNodeSpecs_SendsNameAndSpecWithoutEnvelopeExtras(t *testing.T) {
 		gotMethod = r.Method
 		_ = json.NewDecoder(r.Body).Decode(&gotBody)
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(api.Node{})
+		_ = json.NewEncoder(w).Encode(api.BootConfiguration{})
 	})
 	defer srv.Close()
 
-	nodes := []NodeSpec{
+	cfgs := []BootConfigSpec{
 		{
-			Name:     "x1000c0s0b0n0",
-			NodeSpec: api.NodeSpec{XName: "x1000c0s0b0n0", NID: 42},
+			Name:                  "compute-boot",
+			BootConfigurationSpec: api.BootConfigurationSpec{Hosts: []string{"host1"}},
 		},
 	}
 
-	_, errs, err := c.AddNodeSpecs("", nodes)
+	_, errs, err := c.AddBootConfigSpecs("", cfgs)
 	if err != nil {
-		t.Fatalf("AddNodeSpecs returned func error: %v", err)
+		t.Fatalf("AddBootConfigSpecs returned func error: %v", err)
 	}
 	for _, e := range errs {
 		if e != nil {
-			t.Fatalf("AddNodeSpecs per-request error: %v", e)
+			t.Fatalf("AddBootConfigSpecs per-request error: %v", e)
 		}
 	}
 
 	if gotMethod != http.MethodPost {
 		t.Errorf("method = %q, want POST", gotMethod)
 	}
-	if gotPath != "/nodes" {
-		t.Errorf("path = %q, want /nodes", gotPath)
+	if gotPath != "/bootconfigurations" {
+		t.Errorf("path = %q, want /bootconfigurations", gotPath)
 	}
 	// Simple API still sends an envelope built from name + spec, but must NOT
 	// carry labels/annotations supplied on the request.
@@ -72,31 +55,31 @@ func TestAddNodeSpecs_SendsNameAndSpecWithoutEnvelopeExtras(t *testing.T) {
 		t.Errorf("simple request unexpectedly included labels: %+v", gotBody["labels"])
 	}
 	meta, _ := gotBody["metadata"].(map[string]interface{})
-	if meta == nil || meta["name"] != "x1000c0s0b0n0" {
-		t.Errorf("metadata.name = %+v, want x1000c0s0b0n0", meta)
+	if meta == nil || meta["name"] != "compute-boot" {
+		t.Errorf("metadata.name = %+v, want compute-boot", meta)
 	}
 }
 
-func TestAddNodes_EnvelopeIncludesLabels(t *testing.T) {
+func TestAddBootConfigs_EnvelopeIncludesLabels(t *testing.T) {
 	var gotBody map[string]interface{}
 	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewDecoder(r.Body).Decode(&gotBody)
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(api.Node{})
+		_ = json.NewEncoder(w).Encode(api.BootConfiguration{})
 	})
 	defer srv.Close()
 
-	nodes := []boot_service_client.CreateNodeRequest{
+	cfgs := []boot_service_client.CreateBootConfigurationRequest{
 		{
-			Metadata: fabrica.Metadata{Name: "x1000c0s0b0n0", Labels: map[string]string{"env": "prod"}},
-			Spec:     api.NodeSpec{XName: "x1000c0s0b0n0"},
+			Metadata: fabrica.Metadata{Name: "compute-boot", Labels: map[string]string{"env": "prod"}},
+			Spec:     api.BootConfigurationSpec{Hosts: []string{"host1"}},
 			Labels:   map[string]string{"env": "prod"},
 		},
 	}
 
-	_, _, err := c.AddNodes("", nodes)
+	_, _, err := c.AddBootConfigs("", cfgs)
 	if err != nil {
-		t.Fatalf("AddNodes returned func error: %v", err)
+		t.Fatalf("AddBootConfigs returned func error: %v", err)
 	}
 
 	labels, ok := gotBody["labels"].(map[string]interface{})
@@ -105,7 +88,7 @@ func TestAddNodes_EnvelopeIncludesLabels(t *testing.T) {
 	}
 }
 
-func TestSetNodeSpec_SendsSpecToUIDEndpoint(t *testing.T) {
+func TestSetBootConfigSpec_SendsSpecToUIDEndpoint(t *testing.T) {
 	var gotPath, gotMethod string
 	var gotBody map[string]interface{}
 	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
@@ -113,22 +96,22 @@ func TestSetNodeSpec_SendsSpecToUIDEndpoint(t *testing.T) {
 		gotMethod = r.Method
 		_ = json.NewDecoder(r.Body).Decode(&gotBody)
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(api.Node{})
+		_ = json.NewEncoder(w).Encode(api.BootConfiguration{})
 	})
 	defer srv.Close()
 
-	spec := api.NodeSpec{XName: "x1000c0s0b0n0", NID: 7}
+	spec := api.BootConfigurationSpec{Hosts: []string{"host1"}}
 
-	_, err := c.SetNodeSpec("", "nod-abc123", spec)
+	_, err := c.SetBootConfigSpec("", "boo-abc123", spec)
 	if err != nil {
-		t.Fatalf("SetNodeSpec returned error: %v", err)
+		t.Fatalf("SetBootConfigSpec returned error: %v", err)
 	}
 
 	if gotMethod != http.MethodPut {
 		t.Errorf("method = %q, want PUT", gotMethod)
 	}
-	if gotPath != "/nodes/nod-abc123" {
-		t.Errorf("path = %q, want /nodes/nod-abc123", gotPath)
+	if gotPath != "/bootconfigurations/boo-abc123" {
+		t.Errorf("path = %q, want /bootconfigurations/boo-abc123", gotPath)
 	}
 	if _, ok := gotBody["labels"]; ok {
 		t.Errorf("simple set unexpectedly included labels: %+v", gotBody["labels"])

--- a/pkg/client/boot_service/node.go
+++ b/pkg/client/boot_service/node.go
@@ -11,6 +11,7 @@ import (
 	api "github.com/openchami/boot-service/apis/boot.openchami.io/v1"
 	boot_service_client "github.com/openchami/boot-service/pkg/client"
 
+	"github.com/OpenCHAMI/ochami/internal/cli"
 	"github.com/OpenCHAMI/ochami/pkg/client"
 	"github.com/OpenCHAMI/ochami/pkg/format"
 )
@@ -143,6 +144,48 @@ func (bsc *BootServiceClient) SetNode(token string, uid string, node boot_servic
 	defer cancel()
 
 	item, err := bsc.Client.WithBearerToken(token).UpdateNode(ctx, uid, node)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set node %+v: %w", node, err)
+	}
+
+	return item, nil
+}
+
+// AddNodesSimple is like AddNodes but calls the boot-service client's simple
+// CreateNodeSimple() function, which only sends the resource name and spec.
+// Any labels or annotations present in the request are discarded and a warning
+// is logged advising the user to pass --envelope to preserve them.
+func (bsc *BootServiceClient) AddNodesSimple(token string, nodes []boot_service_client.CreateNodeRequest) (nodesAdded []*api.Node, errors []error, funcErr error) {
+	// TODO: Make concurrent
+	for _, node := range nodes {
+		ctx, cancel := context.WithTimeout(context.Background(), bsc.Timeout)
+		defer cancel()
+
+		cli.WarnDiscardedEnvelope(node.Metadata.Name, node.Labels, node.Annotations)
+
+		item, err := bsc.Client.WithBearerToken(token).CreateNodeSimple(ctx, node.Metadata.Name, node.Spec)
+		if err != nil {
+			newErr := fmt.Errorf("failed to add node %+v: %w", node, err)
+			errors = append(errors, newErr)
+			nodesAdded = append(nodesAdded, nil)
+		}
+		nodesAdded = append(nodesAdded, item)
+	}
+
+	return
+}
+
+// SetNodeSimple is like SetNode but calls the boot-service client's simple
+// UpdateNodeSimple() function, which only sends the resource spec. Any labels
+// or annotations present in the request are discarded and a warning is logged
+// advising the user to pass --envelope to preserve them.
+func (bsc *BootServiceClient) SetNodeSimple(token string, uid string, node boot_service_client.UpdateNodeRequest) (*api.Node, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), bsc.Timeout)
+	defer cancel()
+
+	cli.WarnDiscardedEnvelope(node.Metadata.Name, node.Labels, node.Annotations)
+
+	item, err := bsc.Client.WithBearerToken(token).UpdateNodeSimple(ctx, uid, node.Spec)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set node %+v: %w", node, err)
 	}

--- a/pkg/client/boot_service/node.go
+++ b/pkg/client/boot_service/node.go
@@ -11,10 +11,20 @@ import (
 	api "github.com/openchami/boot-service/apis/boot.openchami.io/v1"
 	boot_service_client "github.com/openchami/boot-service/pkg/client"
 
-	"github.com/OpenCHAMI/ochami/internal/cli"
 	"github.com/OpenCHAMI/ochami/pkg/client"
 	"github.com/OpenCHAMI/ochami/pkg/format"
 )
+
+// NodeSpec is a wrapper around the boot-service's NodeSpec and is used
+// specifically for the simple API. For adding Nodes, a "name" field is required
+// but is only provided in the "metadata" structure, which is outside of the
+// spec and is only available in the advanced API. To get around this, the
+// upstream spec is wrapped with a "name" field so bulk specs can be added with
+// names specified for each without having to provide them as arguments.
+type NodeSpec struct {
+	Name string `json:"name" yaml:"name"` // Mandatory for adding resource
+	api.NodeSpec
+}
 
 // AddNodes is a wrapper that calls the boot-service client's CreateNode()
 // function, passing it context. The output is a slice of the nodes it created,
@@ -151,21 +161,17 @@ func (bsc *BootServiceClient) SetNode(token string, uid string, node boot_servic
 	return item, nil
 }
 
-// AddNodesSimple is like AddNodes but calls the boot-service client's simple
+// AddNodeSpecs is like AddNodes but calls the boot-service client's simple
 // CreateNodeSimple() function, which only sends the resource name and spec.
-// Any labels or annotations present in the request are discarded and a warning
-// is logged advising the user to pass --envelope to preserve them.
-func (bsc *BootServiceClient) AddNodesSimple(token string, nodes []boot_service_client.CreateNodeRequest) (nodesAdded []*api.Node, errors []error, funcErr error) {
+func (bsc *BootServiceClient) AddNodeSpecs(token string, nodes []NodeSpec) (nodesAdded []*api.Node, errors []error, funcErr error) {
 	// TODO: Make concurrent
 	for _, node := range nodes {
 		ctx, cancel := context.WithTimeout(context.Background(), bsc.Timeout)
 		defer cancel()
 
-		cli.WarnDiscardedEnvelope(node.Metadata.Name, node.Labels, node.Annotations)
-
-		item, err := bsc.Client.WithBearerToken(token).CreateNodeSimple(ctx, node.Metadata.Name, node.Spec)
+		item, err := bsc.Client.WithBearerToken(token).CreateNodeSimple(ctx, node.Name, node.NodeSpec)
 		if err != nil {
-			newErr := fmt.Errorf("failed to add node %+v: %w", node, err)
+			newErr := fmt.Errorf("failed to add node %q (%+v): %w", node.Name, node.NodeSpec, err)
 			errors = append(errors, newErr)
 			nodesAdded = append(nodesAdded, nil)
 		}
@@ -175,19 +181,15 @@ func (bsc *BootServiceClient) AddNodesSimple(token string, nodes []boot_service_
 	return
 }
 
-// SetNodeSimple is like SetNode but calls the boot-service client's simple
-// UpdateNodeSimple() function, which only sends the resource spec. Any labels
-// or annotations present in the request are discarded and a warning is logged
-// advising the user to pass --envelope to preserve them.
-func (bsc *BootServiceClient) SetNodeSimple(token string, uid string, node boot_service_client.UpdateNodeRequest) (*api.Node, error) {
+// SetNodeSpec is like SetNode but calls the boot-service client's simple
+// UpdateNodeSimple() function, which only sends the resource spec.
+func (bsc *BootServiceClient) SetNodeSpec(token string, uid string, spec api.NodeSpec) (*api.Node, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), bsc.Timeout)
 	defer cancel()
 
-	cli.WarnDiscardedEnvelope(node.Metadata.Name, node.Labels, node.Annotations)
-
-	item, err := bsc.Client.WithBearerToken(token).UpdateNodeSimple(ctx, uid, node.Spec)
+	item, err := bsc.Client.WithBearerToken(token).UpdateNodeSimple(ctx, uid, spec)
 	if err != nil {
-		return nil, fmt.Errorf("failed to set node %+v: %w", node, err)
+		return nil, fmt.Errorf("failed to set node %+v: %w", spec, err)
 	}
 
 	return item, nil

--- a/pkg/client/boot_service/node_test.go
+++ b/pkg/client/boot_service/node_test.go
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package boot_service
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	api "github.com/openchami/boot-service/apis/boot.openchami.io/v1"
+	boot_service_client "github.com/openchami/boot-service/pkg/client"
+	"github.com/openchami/fabrica/pkg/fabrica"
+	"github.com/rs/zerolog"
+)
+
+// newTestClient spins up an httptest server with the given handler and returns
+// a BootServiceClient pointed at it.
+func newTestClient(t *testing.T, handler http.HandlerFunc) (*BootServiceClient, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	c, err := NewClient(srv.URL, false, 5*time.Second, "", zerolog.New(io.Discard))
+	if err != nil {
+		srv.Close()
+		t.Fatalf("failed to create client: %v", err)
+	}
+	return c, srv
+}
+
+func TestAddNodesSimple_SendsNameAndSpecWithoutEnvelopeExtras(t *testing.T) {
+	var gotBody map[string]interface{}
+	var gotPath, gotMethod string
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.Node{})
+	})
+	defer srv.Close()
+
+	nodes := []boot_service_client.CreateNodeRequest{
+		{
+			Metadata: fabrica.Metadata{Name: "x1000c0s0b0n0", Labels: map[string]string{"env": "prod"}},
+			Spec:     api.NodeSpec{XName: "x1000c0s0b0n0", NID: 42},
+			Labels:   map[string]string{"env": "prod"},
+		},
+	}
+
+	_, errs, err := c.AddNodesSimple("", nodes)
+	if err != nil {
+		t.Fatalf("AddNodesSimple returned func error: %v", err)
+	}
+	for _, e := range errs {
+		if e != nil {
+			t.Fatalf("AddNodesSimple per-request error: %v", e)
+		}
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/nodes" {
+		t.Errorf("path = %q, want /nodes", gotPath)
+	}
+	// Simple API still sends an envelope built from name + spec, but must NOT
+	// carry labels/annotations supplied on the request.
+	if _, ok := gotBody["labels"]; ok {
+		t.Errorf("simple request unexpectedly included labels: %+v", gotBody["labels"])
+	}
+	meta, _ := gotBody["metadata"].(map[string]interface{})
+	if meta == nil || meta["name"] != "x1000c0s0b0n0" {
+		t.Errorf("metadata.name = %+v, want x1000c0s0b0n0", meta)
+	}
+}
+
+func TestAddNodes_EnvelopeIncludesLabels(t *testing.T) {
+	var gotBody map[string]interface{}
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.Node{})
+	})
+	defer srv.Close()
+
+	nodes := []boot_service_client.CreateNodeRequest{
+		{
+			Metadata: fabrica.Metadata{Name: "x1000c0s0b0n0", Labels: map[string]string{"env": "prod"}},
+			Spec:     api.NodeSpec{XName: "x1000c0s0b0n0"},
+			Labels:   map[string]string{"env": "prod"},
+		},
+	}
+
+	_, _, err := c.AddNodes("", nodes)
+	if err != nil {
+		t.Fatalf("AddNodes returned func error: %v", err)
+	}
+
+	labels, ok := gotBody["labels"].(map[string]interface{})
+	if !ok || labels["env"] != "prod" {
+		t.Errorf("envelope request labels = %+v, want env=prod", gotBody["labels"])
+	}
+}
+
+func TestSetNodeSimple_SendsSpecToUIDEndpoint(t *testing.T) {
+	var gotPath, gotMethod string
+	var gotBody map[string]interface{}
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.Node{})
+	})
+	defer srv.Close()
+
+	req := boot_service_client.UpdateNodeRequest{
+		Spec:   api.NodeSpec{XName: "x1000c0s0b0n0", NID: 7},
+		Labels: map[string]string{"env": "prod"},
+	}
+
+	_, err := c.SetNodeSimple("", "nod-abc123", req)
+	if err != nil {
+		t.Fatalf("SetNodeSimple returned error: %v", err)
+	}
+
+	if gotMethod != http.MethodPut {
+		t.Errorf("method = %q, want PUT", gotMethod)
+	}
+	if gotPath != "/nodes/nod-abc123" {
+		t.Errorf("path = %q, want /nodes/nod-abc123", gotPath)
+	}
+	if _, ok := gotBody["labels"]; ok {
+		t.Errorf("simple set unexpectedly included labels: %+v", gotBody["labels"])
+	}
+}

--- a/pkg/client/metadata_service/defaults.go
+++ b/pkg/client/metadata_service/defaults.go
@@ -11,6 +11,7 @@ import (
 	api "github.com/OpenCHAMI/metadata-service/apis/cloud-init.openchami.io/v1"
 	metadata_service_client "github.com/OpenCHAMI/metadata-service/pkg/client"
 
+	"github.com/OpenCHAMI/ochami/internal/cli"
 	"github.com/OpenCHAMI/ochami/pkg/client"
 	"github.com/OpenCHAMI/ochami/pkg/format"
 )
@@ -146,6 +147,52 @@ func (msc *MetadataServiceClient) SetDefaults(token string, uid string, defaults
 	defer cancel()
 
 	item, err := msc.Client.WithBearerToken(token).UpdateClusterDefaults(ctx, uid, defaults)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set cluster defaults %+v: %w", defaults, err)
+	}
+
+	return item, nil
+}
+
+// AddDefaultsSimple is like AddDefaults but calls the metadata-service client's
+// simple CreateClusterDefaultsSimple() function, which only sends the resource
+// name and spec. Any labels or annotations present in the request are discarded
+// and a warning is logged advising the user to pass --envelope to preserve
+// them.
+func (msc *MetadataServiceClient) AddDefaultsSimple(token string, defaults []metadata_service_client.CreateClusterDefaultsRequest) (defaultsAdded []api.ClusterDefaults, errors []error, funcErr error) {
+	// TODO: Make concurrent
+	for _, d := range defaults {
+		ctx, cancel := context.WithTimeout(context.Background(), msc.Timeout)
+		defer cancel()
+
+		cli.WarnDiscardedEnvelope(d.Metadata.Name, d.Labels, d.Annotations)
+
+		item, err := msc.Client.WithBearerToken(token).CreateClusterDefaultsSimple(ctx, d.Metadata.Name, d.Spec)
+		if err != nil {
+			newErr := fmt.Errorf("failed to add cluster defaults %+v: %w", d, err)
+			errors = append(errors, newErr)
+		} else if item != nil {
+			defaultsAdded = append(defaultsAdded, *item)
+		} else {
+			newErr := fmt.Errorf("cluster defaults creation did not err, but was not created for: %+v", d)
+			errors = append(errors, newErr)
+		}
+	}
+
+	return
+}
+
+// SetDefaultsSimple is like SetDefaults but calls the metadata-service client's
+// simple UpdateClusterDefaultsSimple() function, which only sends the resource
+// spec. Any labels or annotations present in the request are discarded and a
+// warning is logged advising the user to pass --envelope to preserve them.
+func (msc *MetadataServiceClient) SetDefaultsSimple(token string, uid string, defaults metadata_service_client.UpdateClusterDefaultsRequest) (*api.ClusterDefaults, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), msc.Timeout)
+	defer cancel()
+
+	cli.WarnDiscardedEnvelope(defaults.Metadata.Name, defaults.Labels, defaults.Annotations)
+
+	item, err := msc.Client.WithBearerToken(token).UpdateClusterDefaultsSimple(ctx, uid, defaults.Spec)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set cluster defaults %+v: %w", defaults, err)
 	}

--- a/pkg/client/metadata_service/defaults.go
+++ b/pkg/client/metadata_service/defaults.go
@@ -11,10 +11,21 @@ import (
 	api "github.com/OpenCHAMI/metadata-service/apis/cloud-init.openchami.io/v1"
 	metadata_service_client "github.com/OpenCHAMI/metadata-service/pkg/client"
 
-	"github.com/OpenCHAMI/ochami/internal/cli"
 	"github.com/OpenCHAMI/ochami/pkg/client"
 	"github.com/OpenCHAMI/ochami/pkg/format"
 )
+
+// ClusterDefaultsSpec is a wrapper around the metadata-service's
+// ClusterDefaultsSpec and is used specifically for the simple API. For adding
+// cluster defaults, a "name" field is required but is only provided in the
+// "metadata" structure, which is outside of the spec and is only available in
+// the advanced API. To get around this, the upstream spec is wrapped with a
+// "name" field so bulk specs can be added with names specified for each without
+// having to provide them as arguments.
+type ClusterDefaultsSpec struct {
+	Name string `json:"name" yaml:"name"` // Mandatory for adding resource
+	api.ClusterDefaultsSpec
+}
 
 // AddDefaults is a wrapper that calls the metadata-service client's
 // CreateClusterDefaults() function, passing it context. It returns a slice of
@@ -154,22 +165,18 @@ func (msc *MetadataServiceClient) SetDefaults(token string, uid string, defaults
 	return item, nil
 }
 
-// AddDefaultsSimple is like AddDefaults but calls the metadata-service client's
+// AddDefaultsSpecs is like AddDefaults but calls the metadata-service client's
 // simple CreateClusterDefaultsSimple() function, which only sends the resource
-// name and spec. Any labels or annotations present in the request are discarded
-// and a warning is logged advising the user to pass --envelope to preserve
-// them.
-func (msc *MetadataServiceClient) AddDefaultsSimple(token string, defaults []metadata_service_client.CreateClusterDefaultsRequest) (defaultsAdded []api.ClusterDefaults, errors []error, funcErr error) {
+// name and spec.
+func (msc *MetadataServiceClient) AddDefaultsSpecs(token string, defaults []ClusterDefaultsSpec) (defaultsAdded []api.ClusterDefaults, errors []error, funcErr error) {
 	// TODO: Make concurrent
 	for _, d := range defaults {
 		ctx, cancel := context.WithTimeout(context.Background(), msc.Timeout)
 		defer cancel()
 
-		cli.WarnDiscardedEnvelope(d.Metadata.Name, d.Labels, d.Annotations)
-
-		item, err := msc.Client.WithBearerToken(token).CreateClusterDefaultsSimple(ctx, d.Metadata.Name, d.Spec)
+		item, err := msc.Client.WithBearerToken(token).CreateClusterDefaultsSimple(ctx, d.Name, d.ClusterDefaultsSpec)
 		if err != nil {
-			newErr := fmt.Errorf("failed to add cluster defaults %+v: %w", d, err)
+			newErr := fmt.Errorf("failed to add cluster defaults %q (%+v): %w", d.Name, d.ClusterDefaultsSpec, err)
 			errors = append(errors, newErr)
 		} else if item != nil {
 			defaultsAdded = append(defaultsAdded, *item)
@@ -182,19 +189,16 @@ func (msc *MetadataServiceClient) AddDefaultsSimple(token string, defaults []met
 	return
 }
 
-// SetDefaultsSimple is like SetDefaults but calls the metadata-service client's
+// SetDefaultsSpec is like SetDefaults but calls the metadata-service client's
 // simple UpdateClusterDefaultsSimple() function, which only sends the resource
-// spec. Any labels or annotations present in the request are discarded and a
-// warning is logged advising the user to pass --envelope to preserve them.
-func (msc *MetadataServiceClient) SetDefaultsSimple(token string, uid string, defaults metadata_service_client.UpdateClusterDefaultsRequest) (*api.ClusterDefaults, error) {
+// spec.
+func (msc *MetadataServiceClient) SetDefaultsSpec(token string, uid string, spec api.ClusterDefaultsSpec) (*api.ClusterDefaults, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), msc.Timeout)
 	defer cancel()
 
-	cli.WarnDiscardedEnvelope(defaults.Metadata.Name, defaults.Labels, defaults.Annotations)
-
-	item, err := msc.Client.WithBearerToken(token).UpdateClusterDefaultsSimple(ctx, uid, defaults.Spec)
+	item, err := msc.Client.WithBearerToken(token).UpdateClusterDefaultsSimple(ctx, uid, spec)
 	if err != nil {
-		return nil, fmt.Errorf("failed to set cluster defaults %+v: %w", defaults, err)
+		return nil, fmt.Errorf("failed to set cluster defaults %+v: %w", spec, err)
 	}
 
 	return item, nil

--- a/pkg/client/metadata_service/defaults_test.go
+++ b/pkg/client/metadata_service/defaults_test.go
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package metadata_service
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	api "github.com/OpenCHAMI/metadata-service/apis/cloud-init.openchami.io/v1"
+	metadata_service_client "github.com/OpenCHAMI/metadata-service/pkg/client"
+	"github.com/openchami/fabrica/pkg/fabrica"
+)
+
+func TestAddDefaultsSpecs_OmitsLabels(t *testing.T) {
+	var gotBody map[string]interface{}
+	var gotPath, gotMethod string
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.ClusterDefaults{})
+	})
+	defer srv.Close()
+
+	defaults := []ClusterDefaultsSpec{
+		{
+			Name:                "demo-cluster-defaults",
+			ClusterDefaultsSpec: api.ClusterDefaultsSpec{BaseURL: "https://demo.openchami.cluster:8443/cloud-init", ClusterName: "demo"},
+		},
+	}
+
+	_, errs, err := c.AddDefaultsSpecs("", defaults)
+	if err != nil {
+		t.Fatalf("AddDefaultsSpecs func error: %v", err)
+	}
+	for _, e := range errs {
+		if e != nil {
+			t.Fatalf("AddDefaultsSpecs per-request error: %v", e)
+		}
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/clusterdefaultss" {
+		t.Errorf("path = %q, want /clusterdefaultss", gotPath)
+	}
+	if _, ok := gotBody["labels"]; ok {
+		t.Errorf("simple request unexpectedly included labels: %+v", gotBody["labels"])
+	}
+	meta, _ := gotBody["metadata"].(map[string]interface{})
+	if meta == nil || meta["name"] != "demo-cluster-defaults" {
+		t.Errorf("metadata.name = %+v, want demo-cluster-defaults", meta)
+	}
+}
+
+func TestAddDefaults_EnvelopeIncludesLabels(t *testing.T) {
+	var gotBody map[string]interface{}
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.ClusterDefaults{})
+	})
+	defer srv.Close()
+
+	defaults := []metadata_service_client.CreateClusterDefaultsRequest{
+		{
+			Metadata: fabrica.Metadata{Name: "demo-cluster-defaults", Labels: map[string]string{"env": "prod"}},
+			Spec:     api.ClusterDefaultsSpec{BaseURL: "https://demo.openchami.cluster:8443/cloud-init", ClusterName: "demo"},
+			Labels:   map[string]string{"env": "prod"},
+		},
+	}
+
+	_, _, err := c.AddDefaults("", defaults)
+	if err != nil {
+		t.Fatalf("AddDefaults func error: %v", err)
+	}
+
+	labels, ok := gotBody["labels"].(map[string]interface{})
+	if !ok || labels["env"] != "prod" {
+		t.Errorf("envelope request labels = %+v, want env=prod", gotBody["labels"])
+	}
+}
+
+func TestSetDefaultsSpec_UsesUIDEndpoint(t *testing.T) {
+	var gotPath, gotMethod string
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.ClusterDefaults{})
+	})
+	defer srv.Close()
+
+	spec := api.ClusterDefaultsSpec{BaseURL: "https://demo.openchami.cluster:8443/cloud-init", ClusterName: "demo"}
+
+	_, err := c.SetDefaultsSpec("", "clusterdefaults-abc", spec)
+	if err != nil {
+		t.Fatalf("SetDefaultsSpec error: %v", err)
+	}
+	if gotMethod != http.MethodPut {
+		t.Errorf("method = %q, want PUT", gotMethod)
+	}
+	if gotPath != "/clusterdefaultss/clusterdefaults-abc" {
+		t.Errorf("path = %q, want /clusterdefaultss/clusterdefaults-abc", gotPath)
+	}
+}

--- a/pkg/client/metadata_service/group.go
+++ b/pkg/client/metadata_service/group.go
@@ -11,6 +11,7 @@ import (
 	api "github.com/OpenCHAMI/metadata-service/apis/cloud-init.openchami.io/v1"
 	metadata_service_client "github.com/OpenCHAMI/metadata-service/pkg/client"
 
+	"github.com/OpenCHAMI/ochami/internal/cli"
 	"github.com/OpenCHAMI/ochami/pkg/client"
 	"github.com/OpenCHAMI/ochami/pkg/format"
 )
@@ -146,6 +147,51 @@ func (msc *MetadataServiceClient) SetGroup(token string, uid string, group metad
 	defer cancel()
 
 	item, err := msc.Client.WithBearerToken(token).UpdateGroup(ctx, uid, group)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set group %+v: %w", group, err)
+	}
+
+	return item, nil
+}
+
+// AddGroupsSimple is like AddGroups but calls the metadata-service client's
+// simple CreateGroupSimple() function, which only sends the resource name and
+// spec. Any labels or annotations present in the request are discarded and a
+// warning is logged advising the user to pass --envelope to preserve them.
+func (msc *MetadataServiceClient) AddGroupsSimple(token string, groups []metadata_service_client.CreateGroupRequest) (groupsAdded []api.Group, errors []error, funcErr error) {
+	// TODO: Make concurrent
+	for _, g := range groups {
+		ctx, cancel := context.WithTimeout(context.Background(), msc.Timeout)
+		defer cancel()
+
+		cli.WarnDiscardedEnvelope(g.Metadata.Name, g.Labels, g.Annotations)
+
+		item, err := msc.Client.WithBearerToken(token).CreateGroupSimple(ctx, g.Metadata.Name, g.Spec)
+		if err != nil {
+			newErr := fmt.Errorf("failed to add group %+v: %w", g, err)
+			errors = append(errors, newErr)
+		} else if item != nil {
+			groupsAdded = append(groupsAdded, *item)
+		} else {
+			newErr := fmt.Errorf("group creation did not err, but was not created for: %+v", g)
+			errors = append(errors, newErr)
+		}
+	}
+
+	return
+}
+
+// SetGroupSimple is like SetGroup but calls the metadata-service client's
+// simple UpdateGroupSimple() function, which only sends the resource spec. Any
+// labels or annotations present in the request are discarded and a warning is
+// logged advising the user to pass --envelope to preserve them.
+func (msc *MetadataServiceClient) SetGroupSimple(token string, uid string, group metadata_service_client.UpdateGroupRequest) (*api.Group, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), msc.Timeout)
+	defer cancel()
+
+	cli.WarnDiscardedEnvelope(group.Metadata.Name, group.Labels, group.Annotations)
+
+	item, err := msc.Client.WithBearerToken(token).UpdateGroupSimple(ctx, uid, group.Spec)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set group %+v: %w", group, err)
 	}

--- a/pkg/client/metadata_service/group.go
+++ b/pkg/client/metadata_service/group.go
@@ -11,10 +11,20 @@ import (
 	api "github.com/OpenCHAMI/metadata-service/apis/cloud-init.openchami.io/v1"
 	metadata_service_client "github.com/OpenCHAMI/metadata-service/pkg/client"
 
-	"github.com/OpenCHAMI/ochami/internal/cli"
 	"github.com/OpenCHAMI/ochami/pkg/client"
 	"github.com/OpenCHAMI/ochami/pkg/format"
 )
+
+// GroupSpec is a wrapper around the metadata-service's GroupSpec and is used
+// specifically for the simple API. For adding groups, a "name" field is
+// required but is only provided in the "metadata" structure, which is outside
+// of the spec and is only available in the advanced API. To get around this,
+// the upstream spec is wrapped with a "name" field so bulk specs can be added
+// with names specified for each without having to provide them as arguments.
+type GroupSpec struct {
+	Name string `json:"name" yaml:"name"` // Mandatory for adding resource
+	api.GroupSpec
+}
 
 // AddGroups is a wrapper that calls the metadata-service client's
 // CreateGroup() function, passing it context. It returns a slice of
@@ -154,21 +164,18 @@ func (msc *MetadataServiceClient) SetGroup(token string, uid string, group metad
 	return item, nil
 }
 
-// AddGroupsSimple is like AddGroups but calls the metadata-service client's
+// AddGroupSpecs is like AddGroups but calls the metadata-service client's
 // simple CreateGroupSimple() function, which only sends the resource name and
-// spec. Any labels or annotations present in the request are discarded and a
-// warning is logged advising the user to pass --envelope to preserve them.
-func (msc *MetadataServiceClient) AddGroupsSimple(token string, groups []metadata_service_client.CreateGroupRequest) (groupsAdded []api.Group, errors []error, funcErr error) {
+// spec.
+func (msc *MetadataServiceClient) AddGroupSpecs(token string, groups []GroupSpec) (groupsAdded []api.Group, errors []error, funcErr error) {
 	// TODO: Make concurrent
 	for _, g := range groups {
 		ctx, cancel := context.WithTimeout(context.Background(), msc.Timeout)
 		defer cancel()
 
-		cli.WarnDiscardedEnvelope(g.Metadata.Name, g.Labels, g.Annotations)
-
-		item, err := msc.Client.WithBearerToken(token).CreateGroupSimple(ctx, g.Metadata.Name, g.Spec)
+		item, err := msc.Client.WithBearerToken(token).CreateGroupSimple(ctx, g.Name, g.GroupSpec)
 		if err != nil {
-			newErr := fmt.Errorf("failed to add group %+v: %w", g, err)
+			newErr := fmt.Errorf("failed to add group %q (%+v): %w", g.Name, g.GroupSpec, err)
 			errors = append(errors, newErr)
 		} else if item != nil {
 			groupsAdded = append(groupsAdded, *item)
@@ -181,19 +188,15 @@ func (msc *MetadataServiceClient) AddGroupsSimple(token string, groups []metadat
 	return
 }
 
-// SetGroupSimple is like SetGroup but calls the metadata-service client's
-// simple UpdateGroupSimple() function, which only sends the resource spec. Any
-// labels or annotations present in the request are discarded and a warning is
-// logged advising the user to pass --envelope to preserve them.
-func (msc *MetadataServiceClient) SetGroupSimple(token string, uid string, group metadata_service_client.UpdateGroupRequest) (*api.Group, error) {
+// SetGroupSpec is like SetGroup but calls the metadata-service client's simple
+// UpdateGroupSimple() function, which only sends the resource spec.
+func (msc *MetadataServiceClient) SetGroupSpec(token string, uid string, spec api.GroupSpec) (*api.Group, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), msc.Timeout)
 	defer cancel()
 
-	cli.WarnDiscardedEnvelope(group.Metadata.Name, group.Labels, group.Annotations)
-
-	item, err := msc.Client.WithBearerToken(token).UpdateGroupSimple(ctx, uid, group.Spec)
+	item, err := msc.Client.WithBearerToken(token).UpdateGroupSimple(ctx, uid, spec)
 	if err != nil {
-		return nil, fmt.Errorf("failed to set group %+v: %w", group, err)
+		return nil, fmt.Errorf("failed to set group %+v: %w", spec, err)
 	}
 
 	return item, nil

--- a/pkg/client/metadata_service/group_test.go
+++ b/pkg/client/metadata_service/group_test.go
@@ -29,7 +29,7 @@ func newTestClient(t *testing.T, handler http.HandlerFunc) (*MetadataServiceClie
 	return c, srv
 }
 
-func TestAddGroupsSimple_OmitsLabels(t *testing.T) {
+func TestAddGroupSpecs_OmitsLabels(t *testing.T) {
 	var gotBody map[string]interface{}
 	var gotPath, gotMethod string
 	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
@@ -41,21 +41,20 @@ func TestAddGroupsSimple_OmitsLabels(t *testing.T) {
 	})
 	defer srv.Close()
 
-	groups := []metadata_service_client.CreateGroupRequest{
+	groups := []GroupSpec{
 		{
-			Metadata: fabrica.Metadata{Name: "compute-group", Labels: map[string]string{"role": "compute"}},
-			Spec:     api.GroupSpec{},
-			Labels:   map[string]string{"role": "compute"},
+			Name:      "compute-group",
+			GroupSpec: api.GroupSpec{},
 		},
 	}
 
-	_, errs, err := c.AddGroupsSimple("", groups)
+	_, errs, err := c.AddGroupSpecs("", groups)
 	if err != nil {
-		t.Fatalf("AddGroupsSimple func error: %v", err)
+		t.Fatalf("AddGroupSpecs func error: %v", err)
 	}
 	for _, e := range errs {
 		if e != nil {
-			t.Fatalf("AddGroupsSimple per-request error: %v", e)
+			t.Fatalf("AddGroupSpecs per-request error: %v", e)
 		}
 	}
 
@@ -102,7 +101,7 @@ func TestAddGroups_EnvelopeIncludesLabels(t *testing.T) {
 	}
 }
 
-func TestSetGroupSimple_UsesUIDEndpoint(t *testing.T) {
+func TestSetGroupSpec_UsesUIDEndpoint(t *testing.T) {
 	var gotPath, gotMethod string
 	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
@@ -112,11 +111,11 @@ func TestSetGroupSimple_UsesUIDEndpoint(t *testing.T) {
 	})
 	defer srv.Close()
 
-	req := metadata_service_client.UpdateGroupRequest{Spec: api.GroupSpec{}}
+	spec := api.GroupSpec{}
 
-	_, err := c.SetGroupSimple("", "grp-abc", req)
+	_, err := c.SetGroupSpec("", "grp-abc", spec)
 	if err != nil {
-		t.Fatalf("SetGroupSimple error: %v", err)
+		t.Fatalf("SetGroupSpec error: %v", err)
 	}
 	if gotMethod != http.MethodPut {
 		t.Errorf("method = %q, want PUT", gotMethod)

--- a/pkg/client/metadata_service/group_test.go
+++ b/pkg/client/metadata_service/group_test.go
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package metadata_service
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	api "github.com/OpenCHAMI/metadata-service/apis/cloud-init.openchami.io/v1"
+	metadata_service_client "github.com/OpenCHAMI/metadata-service/pkg/client"
+	"github.com/openchami/fabrica/pkg/fabrica"
+	"github.com/rs/zerolog"
+)
+
+func newTestClient(t *testing.T, handler http.HandlerFunc) (*MetadataServiceClient, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	c, err := NewClient(srv.URL, false, 5*time.Second, "", zerolog.New(io.Discard))
+	if err != nil {
+		srv.Close()
+		t.Fatalf("failed to create client: %v", err)
+	}
+	return c, srv
+}
+
+func TestAddGroupsSimple_OmitsLabels(t *testing.T) {
+	var gotBody map[string]interface{}
+	var gotPath, gotMethod string
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.Group{})
+	})
+	defer srv.Close()
+
+	groups := []metadata_service_client.CreateGroupRequest{
+		{
+			Metadata: fabrica.Metadata{Name: "compute-group", Labels: map[string]string{"role": "compute"}},
+			Spec:     api.GroupSpec{},
+			Labels:   map[string]string{"role": "compute"},
+		},
+	}
+
+	_, errs, err := c.AddGroupsSimple("", groups)
+	if err != nil {
+		t.Fatalf("AddGroupsSimple func error: %v", err)
+	}
+	for _, e := range errs {
+		if e != nil {
+			t.Fatalf("AddGroupsSimple per-request error: %v", e)
+		}
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/groups" {
+		t.Errorf("path = %q, want /groups", gotPath)
+	}
+	if _, ok := gotBody["labels"]; ok {
+		t.Errorf("simple request unexpectedly included labels: %+v", gotBody["labels"])
+	}
+	meta, _ := gotBody["metadata"].(map[string]interface{})
+	if meta == nil || meta["name"] != "compute-group" {
+		t.Errorf("metadata.name = %+v, want compute-group", meta)
+	}
+}
+
+func TestAddGroups_EnvelopeIncludesLabels(t *testing.T) {
+	var gotBody map[string]interface{}
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.Group{})
+	})
+	defer srv.Close()
+
+	groups := []metadata_service_client.CreateGroupRequest{
+		{
+			Metadata: fabrica.Metadata{Name: "compute-group", Labels: map[string]string{"role": "compute"}},
+			Spec:     api.GroupSpec{},
+			Labels:   map[string]string{"role": "compute"},
+		},
+	}
+
+	_, _, err := c.AddGroups("", groups)
+	if err != nil {
+		t.Fatalf("AddGroups func error: %v", err)
+	}
+
+	labels, ok := gotBody["labels"].(map[string]interface{})
+	if !ok || labels["role"] != "compute" {
+		t.Errorf("envelope request labels = %+v, want role=compute", gotBody["labels"])
+	}
+}
+
+func TestSetGroupSimple_UsesUIDEndpoint(t *testing.T) {
+	var gotPath, gotMethod string
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.Group{})
+	})
+	defer srv.Close()
+
+	req := metadata_service_client.UpdateGroupRequest{Spec: api.GroupSpec{}}
+
+	_, err := c.SetGroupSimple("", "grp-abc", req)
+	if err != nil {
+		t.Fatalf("SetGroupSimple error: %v", err)
+	}
+	if gotMethod != http.MethodPut {
+		t.Errorf("method = %q, want PUT", gotMethod)
+	}
+	if gotPath != "/groups/grp-abc" {
+		t.Errorf("path = %q, want /groups/grp-abc", gotPath)
+	}
+}

--- a/pkg/client/metadata_service/instanceinfo.go
+++ b/pkg/client/metadata_service/instanceinfo.go
@@ -11,10 +11,21 @@ import (
 	api "github.com/OpenCHAMI/metadata-service/apis/cloud-init.openchami.io/v1"
 	metadata_service_client "github.com/OpenCHAMI/metadata-service/pkg/client"
 
-	"github.com/OpenCHAMI/ochami/internal/cli"
 	"github.com/OpenCHAMI/ochami/pkg/client"
 	"github.com/OpenCHAMI/ochami/pkg/format"
 )
+
+// InstanceInfoSpec is a wrapper around the metadata-service's InstanceInfoSpec
+// and is used specifically for the simple API. For adding instance info, a
+// "name" field is required but is only provided in the "metadata" structure,
+// which is outside of the spec and is only available in the advanced API. To get
+// around this, the upstream spec is wrapped with a "name" field so bulk specs
+// can be added with names specified for each without having to provide them as
+// arguments.
+type InstanceInfoSpec struct {
+	Name string `json:"name" yaml:"name"` // Mandatory for adding resource
+	api.InstanceInfoSpec
+}
 
 // AddInstanceInfos is a wrapper that calls the metadata-service client's
 // CreateInstanceInfo() function, passing it context. It returns a slice of
@@ -154,22 +165,18 @@ func (msc *MetadataServiceClient) SetInstanceInfo(token string, uid string, inst
 	return item, nil
 }
 
-// AddInstanceInfosSimple is like AddInstanceInfos but calls the
-// metadata-service client's simple CreateInstanceInfoSimple() function, which
-// only sends the resource name and spec. Any labels or annotations present in
-// the request are discarded and a warning is logged advising the user to pass
-// --envelope to preserve them.
-func (msc *MetadataServiceClient) AddInstanceInfosSimple(token string, instances []metadata_service_client.CreateInstanceInfoRequest) (instancesAdded []api.InstanceInfo, errors []error, funcErr error) {
+// AddInstanceInfoSpecs is like AddInstanceInfos but calls the metadata-service
+// client's simple CreateInstanceInfoSimple() function, which only sends the
+// resource name and spec.
+func (msc *MetadataServiceClient) AddInstanceInfoSpecs(token string, instances []InstanceInfoSpec) (instancesAdded []api.InstanceInfo, errors []error, funcErr error) {
 	// TODO: Make concurrent
 	for _, i := range instances {
 		ctx, cancel := context.WithTimeout(context.Background(), msc.Timeout)
 		defer cancel()
 
-		cli.WarnDiscardedEnvelope(i.Metadata.Name, i.Labels, i.Annotations)
-
-		item, err := msc.Client.WithBearerToken(token).CreateInstanceInfoSimple(ctx, i.Metadata.Name, i.Spec)
+		item, err := msc.Client.WithBearerToken(token).CreateInstanceInfoSimple(ctx, i.Name, i.InstanceInfoSpec)
 		if err != nil {
-			newErr := fmt.Errorf("failed to add instance info %+v: %w", i, err)
+			newErr := fmt.Errorf("failed to add instance info %q (%+v): %w", i.Name, i.InstanceInfoSpec, err)
 			errors = append(errors, newErr)
 		} else if item != nil {
 			instancesAdded = append(instancesAdded, *item)
@@ -182,20 +189,16 @@ func (msc *MetadataServiceClient) AddInstanceInfosSimple(token string, instances
 	return
 }
 
-// SetInstanceInfoSimple is like SetInstanceInfo but calls the metadata-service
+// SetInstanceInfoSpec is like SetInstanceInfo but calls the metadata-service
 // client's simple UpdateInstanceInfoSimple() function, which only sends the
-// resource spec. Any labels or annotations present in the request are discarded
-// and a warning is logged advising the user to pass --envelope to preserve
-// them.
-func (msc *MetadataServiceClient) SetInstanceInfoSimple(token string, uid string, instance metadata_service_client.UpdateInstanceInfoRequest) (*api.InstanceInfo, error) {
+// resource spec.
+func (msc *MetadataServiceClient) SetInstanceInfoSpec(token string, uid string, spec api.InstanceInfoSpec) (*api.InstanceInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), msc.Timeout)
 	defer cancel()
 
-	cli.WarnDiscardedEnvelope(instance.Metadata.Name, instance.Labels, instance.Annotations)
-
-	item, err := msc.Client.WithBearerToken(token).UpdateInstanceInfoSimple(ctx, uid, instance.Spec)
+	item, err := msc.Client.WithBearerToken(token).UpdateInstanceInfoSimple(ctx, uid, spec)
 	if err != nil {
-		return nil, fmt.Errorf("failed to set instance info %+v: %w", instance, err)
+		return nil, fmt.Errorf("failed to set instance info %+v: %w", spec, err)
 	}
 
 	return item, nil

--- a/pkg/client/metadata_service/instanceinfo.go
+++ b/pkg/client/metadata_service/instanceinfo.go
@@ -11,6 +11,7 @@ import (
 	api "github.com/OpenCHAMI/metadata-service/apis/cloud-init.openchami.io/v1"
 	metadata_service_client "github.com/OpenCHAMI/metadata-service/pkg/client"
 
+	"github.com/OpenCHAMI/ochami/internal/cli"
 	"github.com/OpenCHAMI/ochami/pkg/client"
 	"github.com/OpenCHAMI/ochami/pkg/format"
 )
@@ -146,6 +147,53 @@ func (msc *MetadataServiceClient) SetInstanceInfo(token string, uid string, inst
 	defer cancel()
 
 	item, err := msc.Client.WithBearerToken(token).UpdateInstanceInfo(ctx, uid, instance)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set instance info %+v: %w", instance, err)
+	}
+
+	return item, nil
+}
+
+// AddInstanceInfosSimple is like AddInstanceInfos but calls the
+// metadata-service client's simple CreateInstanceInfoSimple() function, which
+// only sends the resource name and spec. Any labels or annotations present in
+// the request are discarded and a warning is logged advising the user to pass
+// --envelope to preserve them.
+func (msc *MetadataServiceClient) AddInstanceInfosSimple(token string, instances []metadata_service_client.CreateInstanceInfoRequest) (instancesAdded []api.InstanceInfo, errors []error, funcErr error) {
+	// TODO: Make concurrent
+	for _, i := range instances {
+		ctx, cancel := context.WithTimeout(context.Background(), msc.Timeout)
+		defer cancel()
+
+		cli.WarnDiscardedEnvelope(i.Metadata.Name, i.Labels, i.Annotations)
+
+		item, err := msc.Client.WithBearerToken(token).CreateInstanceInfoSimple(ctx, i.Metadata.Name, i.Spec)
+		if err != nil {
+			newErr := fmt.Errorf("failed to add instance info %+v: %w", i, err)
+			errors = append(errors, newErr)
+		} else if item != nil {
+			instancesAdded = append(instancesAdded, *item)
+		} else {
+			newErr := fmt.Errorf("instance info creation did not err, but was not created for: %+v", i)
+			errors = append(errors, newErr)
+		}
+	}
+
+	return
+}
+
+// SetInstanceInfoSimple is like SetInstanceInfo but calls the metadata-service
+// client's simple UpdateInstanceInfoSimple() function, which only sends the
+// resource spec. Any labels or annotations present in the request are discarded
+// and a warning is logged advising the user to pass --envelope to preserve
+// them.
+func (msc *MetadataServiceClient) SetInstanceInfoSimple(token string, uid string, instance metadata_service_client.UpdateInstanceInfoRequest) (*api.InstanceInfo, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), msc.Timeout)
+	defer cancel()
+
+	cli.WarnDiscardedEnvelope(instance.Metadata.Name, instance.Labels, instance.Annotations)
+
+	item, err := msc.Client.WithBearerToken(token).UpdateInstanceInfoSimple(ctx, uid, instance.Spec)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set instance info %+v: %w", instance, err)
 	}

--- a/pkg/client/metadata_service/instanceinfo_test.go
+++ b/pkg/client/metadata_service/instanceinfo_test.go
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package metadata_service
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	api "github.com/OpenCHAMI/metadata-service/apis/cloud-init.openchami.io/v1"
+	metadata_service_client "github.com/OpenCHAMI/metadata-service/pkg/client"
+	"github.com/openchami/fabrica/pkg/fabrica"
+)
+
+func TestAddInstanceInfoSpecs_OmitsLabels(t *testing.T) {
+	var gotBody map[string]interface{}
+	var gotPath, gotMethod string
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.InstanceInfo{})
+	})
+	defer srv.Close()
+
+	instances := []InstanceInfoSpec{
+		{
+			Name:             "x1000c0s0b0n0-instance",
+			InstanceInfoSpec: api.InstanceInfoSpec{InstanceID: "x1000c0s0b0n0"},
+		},
+	}
+
+	_, errs, err := c.AddInstanceInfoSpecs("", instances)
+	if err != nil {
+		t.Fatalf("AddInstanceInfoSpecs func error: %v", err)
+	}
+	for _, e := range errs {
+		if e != nil {
+			t.Fatalf("AddInstanceInfoSpecs per-request error: %v", e)
+		}
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/instanceinfos" {
+		t.Errorf("path = %q, want /instanceinfos", gotPath)
+	}
+	if _, ok := gotBody["labels"]; ok {
+		t.Errorf("simple request unexpectedly included labels: %+v", gotBody["labels"])
+	}
+	meta, _ := gotBody["metadata"].(map[string]interface{})
+	if meta == nil || meta["name"] != "x1000c0s0b0n0-instance" {
+		t.Errorf("metadata.name = %+v, want x1000c0s0b0n0-instance", meta)
+	}
+}
+
+func TestAddInstanceInfos_EnvelopeIncludesLabels(t *testing.T) {
+	var gotBody map[string]interface{}
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.InstanceInfo{})
+	})
+	defer srv.Close()
+
+	instances := []metadata_service_client.CreateInstanceInfoRequest{
+		{
+			Metadata: fabrica.Metadata{Name: "x1000c0s0b0n0-instance", Labels: map[string]string{"env": "prod"}},
+			Spec:     api.InstanceInfoSpec{InstanceID: "x1000c0s0b0n0"},
+			Labels:   map[string]string{"env": "prod"},
+		},
+	}
+
+	_, _, err := c.AddInstanceInfos("", instances)
+	if err != nil {
+		t.Fatalf("AddInstanceInfos func error: %v", err)
+	}
+
+	labels, ok := gotBody["labels"].(map[string]interface{})
+	if !ok || labels["env"] != "prod" {
+		t.Errorf("envelope request labels = %+v, want env=prod", gotBody["labels"])
+	}
+}
+
+func TestSetInstanceInfoSpec_UsesUIDEndpoint(t *testing.T) {
+	var gotPath, gotMethod string
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.InstanceInfo{})
+	})
+	defer srv.Close()
+
+	spec := api.InstanceInfoSpec{InstanceID: "x1000c0s0b0n0"}
+
+	_, err := c.SetInstanceInfoSpec("", "instanceinfo-abc", spec)
+	if err != nil {
+		t.Fatalf("SetInstanceInfoSpec error: %v", err)
+	}
+	if gotMethod != http.MethodPut {
+		t.Errorf("method = %q, want PUT", gotMethod)
+	}
+	if gotPath != "/instanceinfos/instanceinfo-abc" {
+		t.Errorf("path = %q, want /instanceinfos/instanceinfo-abc", gotPath)
+	}
+}

--- a/pkg/client/metadata_service/wireguardpeer.go
+++ b/pkg/client/metadata_service/wireguardpeer.go
@@ -11,10 +11,21 @@ import (
 	api "github.com/OpenCHAMI/metadata-service/apis/cloud-init.openchami.io/v1"
 	metadata_service_client "github.com/OpenCHAMI/metadata-service/pkg/client"
 
-	"github.com/OpenCHAMI/ochami/internal/cli"
 	"github.com/OpenCHAMI/ochami/pkg/client"
 	"github.com/OpenCHAMI/ochami/pkg/format"
 )
+
+// WireGuardPeerSpec is a wrapper around the metadata-service's
+// WireGuardPeerSpec and is used specifically for the simple API. For adding
+// WireGuard peers, a "name" field is required but is only provided in the
+// "metadata" structure, which is outside of the spec and is only available in
+// the advanced API. To get around this, the upstream spec is wrapped with a
+// "name" field so bulk specs can be added with names specified for each without
+// having to provide them as arguments.
+type WireGuardPeerSpec struct {
+	Name string `json:"name" yaml:"name"` // Mandatory for adding resource
+	api.WireGuardPeerSpec
+}
 
 // AddWireGuardPeers is a wrapper that calls the metadata-service client's
 // CreateWireGuardPeer() function, passing it context. It returns a slice of
@@ -154,22 +165,18 @@ func (msc *MetadataServiceClient) SetWireGuardPeer(token string, uid string, pee
 	return item, nil
 }
 
-// AddWireGuardPeersSimple is like AddWireGuardPeers but calls the
+// AddWireGuardPeerSpecs is like AddWireGuardPeers but calls the
 // metadata-service client's simple CreateWireGuardPeerSimple() function, which
-// only sends the resource name and spec. Any labels or annotations present in
-// the request are discarded and a warning is logged advising the user to pass
-// --envelope to preserve them.
-func (msc *MetadataServiceClient) AddWireGuardPeersSimple(token string, peers []metadata_service_client.CreateWireGuardPeerRequest) (peersAdded []api.WireGuardPeer, errors []error, funcErr error) {
+// only sends the resource name and spec.
+func (msc *MetadataServiceClient) AddWireGuardPeerSpecs(token string, peers []WireGuardPeerSpec) (peersAdded []api.WireGuardPeer, errors []error, funcErr error) {
 	// TODO: Make concurrent
 	for _, p := range peers {
 		ctx, cancel := context.WithTimeout(context.Background(), msc.Timeout)
 		defer cancel()
 
-		cli.WarnDiscardedEnvelope(p.Metadata.Name, p.Labels, p.Annotations)
-
-		item, err := msc.Client.WithBearerToken(token).CreateWireGuardPeerSimple(ctx, p.Metadata.Name, p.Spec)
+		item, err := msc.Client.WithBearerToken(token).CreateWireGuardPeerSimple(ctx, p.Name, p.WireGuardPeerSpec)
 		if err != nil {
-			newErr := fmt.Errorf("failed to add WireGuard peer %+v: %w", p, err)
+			newErr := fmt.Errorf("failed to add WireGuard peer %q (%+v): %w", p.Name, p.WireGuardPeerSpec, err)
 			errors = append(errors, newErr)
 		} else if item != nil {
 			peersAdded = append(peersAdded, *item)
@@ -182,20 +189,16 @@ func (msc *MetadataServiceClient) AddWireGuardPeersSimple(token string, peers []
 	return
 }
 
-// SetWireGuardPeerSimple is like SetWireGuardPeer but calls the metadata-service
+// SetWireGuardPeerSpec is like SetWireGuardPeer but calls the metadata-service
 // client's simple UpdateWireGuardPeerSimple() function, which only sends the
-// resource spec. Any labels or annotations present in the request are discarded
-// and a warning is logged advising the user to pass --envelope to preserve
-// them.
-func (msc *MetadataServiceClient) SetWireGuardPeerSimple(token string, uid string, peer metadata_service_client.UpdateWireGuardPeerRequest) (*api.WireGuardPeer, error) {
+// resource spec.
+func (msc *MetadataServiceClient) SetWireGuardPeerSpec(token string, uid string, spec api.WireGuardPeerSpec) (*api.WireGuardPeer, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), msc.Timeout)
 	defer cancel()
 
-	cli.WarnDiscardedEnvelope(peer.Metadata.Name, peer.Labels, peer.Annotations)
-
-	item, err := msc.Client.WithBearerToken(token).UpdateWireGuardPeerSimple(ctx, uid, peer.Spec)
+	item, err := msc.Client.WithBearerToken(token).UpdateWireGuardPeerSimple(ctx, uid, spec)
 	if err != nil {
-		return nil, fmt.Errorf("failed to set WireGuard peer %+v: %w", peer, err)
+		return nil, fmt.Errorf("failed to set WireGuard peer %+v: %w", spec, err)
 	}
 
 	return item, nil

--- a/pkg/client/metadata_service/wireguardpeer.go
+++ b/pkg/client/metadata_service/wireguardpeer.go
@@ -11,6 +11,7 @@ import (
 	api "github.com/OpenCHAMI/metadata-service/apis/cloud-init.openchami.io/v1"
 	metadata_service_client "github.com/OpenCHAMI/metadata-service/pkg/client"
 
+	"github.com/OpenCHAMI/ochami/internal/cli"
 	"github.com/OpenCHAMI/ochami/pkg/client"
 	"github.com/OpenCHAMI/ochami/pkg/format"
 )
@@ -146,6 +147,53 @@ func (msc *MetadataServiceClient) SetWireGuardPeer(token string, uid string, pee
 	defer cancel()
 
 	item, err := msc.Client.WithBearerToken(token).UpdateWireGuardPeer(ctx, uid, peer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set WireGuard peer %+v: %w", peer, err)
+	}
+
+	return item, nil
+}
+
+// AddWireGuardPeersSimple is like AddWireGuardPeers but calls the
+// metadata-service client's simple CreateWireGuardPeerSimple() function, which
+// only sends the resource name and spec. Any labels or annotations present in
+// the request are discarded and a warning is logged advising the user to pass
+// --envelope to preserve them.
+func (msc *MetadataServiceClient) AddWireGuardPeersSimple(token string, peers []metadata_service_client.CreateWireGuardPeerRequest) (peersAdded []api.WireGuardPeer, errors []error, funcErr error) {
+	// TODO: Make concurrent
+	for _, p := range peers {
+		ctx, cancel := context.WithTimeout(context.Background(), msc.Timeout)
+		defer cancel()
+
+		cli.WarnDiscardedEnvelope(p.Metadata.Name, p.Labels, p.Annotations)
+
+		item, err := msc.Client.WithBearerToken(token).CreateWireGuardPeerSimple(ctx, p.Metadata.Name, p.Spec)
+		if err != nil {
+			newErr := fmt.Errorf("failed to add WireGuard peer %+v: %w", p, err)
+			errors = append(errors, newErr)
+		} else if item != nil {
+			peersAdded = append(peersAdded, *item)
+		} else {
+			newErr := fmt.Errorf("WireGuard peer creation did not err, but was not created for: %+v", p)
+			errors = append(errors, newErr)
+		}
+	}
+
+	return
+}
+
+// SetWireGuardPeerSimple is like SetWireGuardPeer but calls the metadata-service
+// client's simple UpdateWireGuardPeerSimple() function, which only sends the
+// resource spec. Any labels or annotations present in the request are discarded
+// and a warning is logged advising the user to pass --envelope to preserve
+// them.
+func (msc *MetadataServiceClient) SetWireGuardPeerSimple(token string, uid string, peer metadata_service_client.UpdateWireGuardPeerRequest) (*api.WireGuardPeer, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), msc.Timeout)
+	defer cancel()
+
+	cli.WarnDiscardedEnvelope(peer.Metadata.Name, peer.Labels, peer.Annotations)
+
+	item, err := msc.Client.WithBearerToken(token).UpdateWireGuardPeerSimple(ctx, uid, peer.Spec)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set WireGuard peer %+v: %w", peer, err)
 	}

--- a/pkg/client/metadata_service/wireguardpeer_test.go
+++ b/pkg/client/metadata_service/wireguardpeer_test.go
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package metadata_service
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	api "github.com/OpenCHAMI/metadata-service/apis/cloud-init.openchami.io/v1"
+	metadata_service_client "github.com/OpenCHAMI/metadata-service/pkg/client"
+	"github.com/openchami/fabrica/pkg/fabrica"
+)
+
+func TestAddWireGuardPeerSpecs_OmitsLabels(t *testing.T) {
+	var gotBody map[string]interface{}
+	var gotPath, gotMethod string
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.WireGuardPeer{})
+	})
+	defer srv.Close()
+
+	peers := []WireGuardPeerSpec{
+		{
+			Name:              "peer-nid001000",
+			WireGuardPeerSpec: api.WireGuardPeerSpec{PublicKey: "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=", AllowedIP: "10.42.1.1/32"},
+		},
+	}
+
+	_, errs, err := c.AddWireGuardPeerSpecs("", peers)
+	if err != nil {
+		t.Fatalf("AddWireGuardPeerSpecs func error: %v", err)
+	}
+	for _, e := range errs {
+		if e != nil {
+			t.Fatalf("AddWireGuardPeerSpecs per-request error: %v", e)
+		}
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/wireguardpeers" {
+		t.Errorf("path = %q, want /wireguardpeers", gotPath)
+	}
+	if _, ok := gotBody["labels"]; ok {
+		t.Errorf("simple request unexpectedly included labels: %+v", gotBody["labels"])
+	}
+	meta, _ := gotBody["metadata"].(map[string]interface{})
+	if meta == nil || meta["name"] != "peer-nid001000" {
+		t.Errorf("metadata.name = %+v, want peer-nid001000", meta)
+	}
+}
+
+func TestAddWireGuardPeers_EnvelopeIncludesLabels(t *testing.T) {
+	var gotBody map[string]interface{}
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.WireGuardPeer{})
+	})
+	defer srv.Close()
+
+	peers := []metadata_service_client.CreateWireGuardPeerRequest{
+		{
+			Metadata: fabrica.Metadata{Name: "peer-nid001000", Labels: map[string]string{"env": "prod"}},
+			Spec:     api.WireGuardPeerSpec{PublicKey: "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=", AllowedIP: "10.42.1.1/32"},
+			Labels:   map[string]string{"env": "prod"},
+		},
+	}
+
+	_, _, err := c.AddWireGuardPeers("", peers)
+	if err != nil {
+		t.Fatalf("AddWireGuardPeers func error: %v", err)
+	}
+
+	labels, ok := gotBody["labels"].(map[string]interface{})
+	if !ok || labels["env"] != "prod" {
+		t.Errorf("envelope request labels = %+v, want env=prod", gotBody["labels"])
+	}
+}
+
+func TestSetWireGuardPeerSpec_UsesUIDEndpoint(t *testing.T) {
+	var gotPath, gotMethod string
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.WireGuardPeer{})
+	})
+	defer srv.Close()
+
+	spec := api.WireGuardPeerSpec{PublicKey: "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=", AllowedIP: "10.42.1.1/32"}
+
+	_, err := c.SetWireGuardPeerSpec("", "wireguardpeer-abc", spec)
+	if err != nil {
+		t.Fatalf("SetWireGuardPeerSpec error: %v", err)
+	}
+	if gotMethod != http.MethodPut {
+		t.Errorf("method = %q, want PUT", gotMethod)
+	}
+	if gotPath != "/wireguardpeers/wireguardpeer-abc" {
+		t.Errorf("path = %q, want /wireguardpeers/wireguardpeer-abc", gotPath)
+	}
+}


### PR DESCRIPTION
### Description

Implement API changes from https://github.com/OpenCHAMI/fabrica/pull/64.

Add `--envelope` flag to fabrica resource commands to allow the user to specify additional metadata that envelops the spec, which contains the actual data. By default (without `--envelope`), the payload is just the spec and additional metadata is ignored.

Fixes #115 

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [x] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass
- [x] I have updated the relevant documentation (CLI examples, man pages, README, other docs, etc.)
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Type of Change

- [ ] Bug fix  
- [x] New feature  
- [ ] Breaking change  
- [ ] Documentation update  
- [ ] Dependency update

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
