### PR TITLE
fix(client): inline embedded specs when parsing YAML

### DIFF
--- a/pkg/client/boot_service/bmc.go
+++ b/pkg/client/boot_service/bmc.go
@@ -22,8 +22,8 @@ import (
 // upstream spec is wrapped with a "name" field so bulk specs can be added with
 // names specified for each without having to provide them as arguments.
 type BMCSpec struct {
-	Name string `json:"name" yaml:"name"` // Mandatory for adding resource
-	api.BMCSpec
+	Name        string `json:"name" yaml:"name"` // Mandatory for adding resource
+	api.BMCSpec `yaml:",inline"`
 }
 
 // AddBMCs is a wrapper that calls the boot-service client's CreateBMC()

--- a/pkg/client/boot_service/bootconfig.go
+++ b/pkg/client/boot_service/bootconfig.go
@@ -23,8 +23,8 @@ import (
 // can be added with names specified for each without having to provide them as
 // arguments.
 type BootConfigSpec struct {
-	Name string `json:"name" yaml:"name"` // Mandatory for adding resource
-	api.BootConfigurationSpec
+	Name                      string `json:"name" yaml:"name"` // Mandatory for adding resource
+	api.BootConfigurationSpec `yaml:",inline"`
 }
 
 // AddBootConfigs is a wrapper that calls the boot-service client's

--- a/pkg/client/boot_service/node.go
+++ b/pkg/client/boot_service/node.go
@@ -22,8 +22,8 @@ import (
 // upstream spec is wrapped with a "name" field so bulk specs can be added with
 // names specified for each without having to provide them as arguments.
 type NodeSpec struct {
-	Name string `json:"name" yaml:"name"` // Mandatory for adding resource
-	api.NodeSpec
+	Name         string `json:"name" yaml:"name"` // Mandatory for adding resource
+	api.NodeSpec `yaml:",inline"`
 }
 
 // AddNodes is a wrapper that calls the boot-service client's CreateNode()

--- a/pkg/client/boot_service/spec_yaml_test.go
+++ b/pkg/client/boot_service/spec_yaml_test.go
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package boot_service
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestBootConfigSpecUnmarshalsFlatYAML(t *testing.T) {
+	data := []byte(`
+- name: compute-debug-rocky9
+  kernel: http://172.16.0.254:7070/boot-images/compute/debug/vmlinuz
+  initrd: http://172.16.0.254:7070/boot-images/compute/debug/initramfs.img
+  params: ip=dhcp console=ttyS0,115200
+  macs:
+    - 52:54:00:be:ef:01
+    - 52:54:00:be:ef:02
+`)
+
+	var got []BootConfigSpec
+	if err := yaml.Unmarshal(data, &got); err != nil {
+		t.Fatalf("failed to unmarshal boot configuration YAML: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d boot configurations, want 1", len(got))
+	}
+	if got[0].Name != "compute-debug-rocky9" {
+		t.Errorf("name = %q, want compute-debug-rocky9", got[0].Name)
+	}
+	if got[0].Kernel != "http://172.16.0.254:7070/boot-images/compute/debug/vmlinuz" {
+		t.Errorf("kernel = %q, want flat YAML kernel value", got[0].Kernel)
+	}
+	if got[0].Initrd != "http://172.16.0.254:7070/boot-images/compute/debug/initramfs.img" {
+		t.Errorf("initrd = %q, want flat YAML initrd value", got[0].Initrd)
+	}
+	if got[0].Params != "ip=dhcp console=ttyS0,115200" {
+		t.Errorf("params = %q, want flat YAML params value", got[0].Params)
+	}
+	if len(got[0].MACs) != 2 || got[0].MACs[0] != "52:54:00:be:ef:01" {
+		t.Errorf("macs = %#v, want flat YAML MAC values", got[0].MACs)
+	}
+}
+
+func TestNodeSpecUnmarshalsFlatYAML(t *testing.T) {
+	var got NodeSpec
+	if err := yaml.Unmarshal([]byte("name: node-1\nxname: x1000c0s0b0n0\nnid: 42\n"), &got); err != nil {
+		t.Fatalf("failed to unmarshal node YAML: %v", err)
+	}
+	if got.Name != "node-1" || got.XName != "x1000c0s0b0n0" || got.NID != 42 {
+		t.Errorf("node = %+v, want flat YAML name, xname, and nid values", got)
+	}
+}
+
+func TestBMCSpecUnmarshalsFlatYAML(t *testing.T) {
+	var got BMCSpec
+	if err := yaml.Unmarshal([]byte("name: bmc-1\nxname: x1000c0s0b0\ndescription: test BMC\n"), &got); err != nil {
+		t.Fatalf("failed to unmarshal BMC YAML: %v", err)
+	}
+	if got.Name != "bmc-1" || got.XName != "x1000c0s0b0" || got.Description != "test BMC" {
+		t.Errorf("BMC = %+v, want flat YAML name, xname, and description values", got)
+	}
+}

--- a/pkg/client/metadata_service/defaults.go
+++ b/pkg/client/metadata_service/defaults.go
@@ -23,8 +23,8 @@ import (
 // "name" field so bulk specs can be added with names specified for each without
 // having to provide them as arguments.
 type ClusterDefaultsSpec struct {
-	Name string `json:"name" yaml:"name"` // Mandatory for adding resource
-	api.ClusterDefaultsSpec
+	Name                    string `json:"name" yaml:"name"` // Mandatory for adding resource
+	api.ClusterDefaultsSpec `yaml:",inline"`
 }
 
 // AddDefaults is a wrapper that calls the metadata-service client's

--- a/pkg/client/metadata_service/group.go
+++ b/pkg/client/metadata_service/group.go
@@ -22,8 +22,8 @@ import (
 // the upstream spec is wrapped with a "name" field so bulk specs can be added
 // with names specified for each without having to provide them as arguments.
 type GroupSpec struct {
-	Name string `json:"name" yaml:"name"` // Mandatory for adding resource
-	api.GroupSpec
+	Name          string `json:"name" yaml:"name"` // Mandatory for adding resource
+	api.GroupSpec `yaml:",inline"`
 }
 
 // AddGroups is a wrapper that calls the metadata-service client's

--- a/pkg/client/metadata_service/instanceinfo.go
+++ b/pkg/client/metadata_service/instanceinfo.go
@@ -23,8 +23,8 @@ import (
 // can be added with names specified for each without having to provide them as
 // arguments.
 type InstanceInfoSpec struct {
-	Name string `json:"name" yaml:"name"` // Mandatory for adding resource
-	api.InstanceInfoSpec
+	Name                 string `json:"name" yaml:"name"` // Mandatory for adding resource
+	api.InstanceInfoSpec `yaml:",inline"`
 }
 
 // AddInstanceInfos is a wrapper that calls the metadata-service client's

--- a/pkg/client/metadata_service/spec_yaml_test.go
+++ b/pkg/client/metadata_service/spec_yaml_test.go
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package metadata_service
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestClusterDefaultsSpecUnmarshalsFlatYAML(t *testing.T) {
+	var got ClusterDefaultsSpec
+	data := []byte("name: defaults\nbase_url: https://example.com/cloud-init\ncluster_name: demo\n")
+	if err := yaml.Unmarshal(data, &got); err != nil {
+		t.Fatalf("failed to unmarshal cluster defaults YAML: %v", err)
+	}
+	if got.Name != "defaults" || got.BaseURL != "https://example.com/cloud-init" || got.ClusterName != "demo" {
+		t.Errorf("cluster defaults = %+v, want flat YAML name, base URL, and cluster name values", got)
+	}
+}
+
+func TestGroupSpecUnmarshalsFlatYAML(t *testing.T) {
+	var got GroupSpec
+	if err := yaml.Unmarshal([]byte("name: computes\ntemplate: compute.yaml\nosVersion: rocky9\n"), &got); err != nil {
+		t.Fatalf("failed to unmarshal group YAML: %v", err)
+	}
+	if got.Name != "computes" || got.Template != "compute.yaml" || got.OSVersion != "rocky9" {
+		t.Errorf("group = %+v, want flat YAML name, template, and OS version values", got)
+	}
+}
+
+func TestInstanceInfoSpecUnmarshalsFlatYAML(t *testing.T) {
+	var got InstanceInfoSpec
+	data := []byte("name: node-1\ninstance_id: x1000c0s0b0n0\nlocal_hostname: node-1\n")
+	if err := yaml.Unmarshal(data, &got); err != nil {
+		t.Fatalf("failed to unmarshal instance info YAML: %v", err)
+	}
+	if got.Name != "node-1" || got.InstanceID != "x1000c0s0b0n0" || got.LocalHostname != "node-1" {
+		t.Errorf("instance info = %+v, want flat YAML name, instance ID, and hostname values", got)
+	}
+}
+
+func TestWireGuardPeerSpecUnmarshalsFlatYAML(t *testing.T) {
+	var got WireGuardPeerSpec
+	data := []byte("name: peer-1\npublic_key: test-key\nallowed_ip: 10.0.0.1/32\n")
+	if err := yaml.Unmarshal(data, &got); err != nil {
+		t.Fatalf("failed to unmarshal WireGuard peer YAML: %v", err)
+	}
+	if got.Name != "peer-1" || got.PublicKey != "test-key" || got.AllowedIP != "10.0.0.1/32" {
+		t.Errorf("WireGuard peer = %+v, want flat YAML name, public key, and allowed IP values", got)
+	}
+}

--- a/pkg/client/metadata_service/wireguardpeer.go
+++ b/pkg/client/metadata_service/wireguardpeer.go
@@ -23,8 +23,8 @@ import (
 // "name" field so bulk specs can be added with names specified for each without
 // having to provide them as arguments.
 type WireGuardPeerSpec struct {
-	Name string `json:"name" yaml:"name"` // Mandatory for adding resource
-	api.WireGuardPeerSpec
+	Name                  string `json:"name" yaml:"name"` // Mandatory for adding resource
+	api.WireGuardPeerSpec `yaml:",inline"`
 }
 
 // AddWireGuardPeers is a wrapper that calls the metadata-service client's


### PR DESCRIPTION
### Description

Flat YAML payloads only populated the wrapper's name field for fabrica service resource specs (e.g. `BootConfigSpec`) because `yaml.v3` does not automatically inline anonymous embedded structs. As a result, fields such as `kernel`, `initrd`, `params`, and `macs` were silently ignored and empty specs were sent to the service.

Add the `yaml:",inline"` tag to every simple API spec wrapper so YAML fields are decoded into their embedded boot-service and metadata-service specifications.  Do not add an equivalent JSON tag because `encoding/json` already promotes fields from anonymous embedded structs.

Add regression tests covering flat YAML decoding for boot configurations, BMCs, nodes, cluster defaults, groups, instance information, and WireGuard peers. This ensures the CLI's YAML and JSON payload formats retain the same flat simple-API structure.

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [x] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass
- [x] I have updated the relevant documentation (CLI examples, man pages, README, other docs, etc.)
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  
- [ ] Dependency update

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
