### PR TITLE
fix(cmd): log only successfully created resource names

### DIFF
--- a/cmd/boot/bmc/add.go
+++ b/cmd/boot/bmc/add.go
@@ -147,7 +147,11 @@ See ochami-boot(1) for more details.`,
 					reqErrorsOccurred = true
 				}
 			}
-			log.Logger.Debug().Msgf("BMCs created: %+v", bmcsCreated)
+			var names []string
+			for _, bmc := range bmcsCreated {
+				names = append(names, bmc.Metadata.Name)
+			}
+			log.Logger.Debug().Msgf("BMCs created: %q", names)
 			if reqErrorsOccurred {
 				cli.LogHelpError(cmd)
 				log.Logger.Warn().Msg("BMC addition completed with errors")

--- a/cmd/boot/config/add.go
+++ b/cmd/boot/config/add.go
@@ -157,7 +157,11 @@ See ochami-boot(1) for more details.`,
 					reqErrorsOccurred = true
 				}
 			}
-			log.Logger.Debug().Msgf("boot configs created: %+v", cfgsCreated)
+			var names []string
+			for _, cfg := range cfgsCreated {
+				names = append(names, cfg.Metadata.Name)
+			}
+			log.Logger.Debug().Msgf("boot configs created: %q", names)
 			if reqErrorsOccurred {
 				cli.LogHelpError(cmd)
 				log.Logger.Warn().Msg("boot configuration addition completed with errors")

--- a/cmd/boot/node/add.go
+++ b/cmd/boot/node/add.go
@@ -166,7 +166,11 @@ See ochami-boot(1) for more details.`,
 					reqErrorsOccurred = true
 				}
 			}
-			log.Logger.Debug().Msgf("nodes created: %+v", nodesCreated)
+			var names []string
+			for _, node := range nodesCreated {
+				names = append(names, node.Metadata.Name)
+			}
+			log.Logger.Debug().Msgf("nodes created: %q", names)
 			if reqErrorsOccurred {
 				cli.LogHelpError(cmd)
 				log.Logger.Warn().Msg("node addition completed with errors")

--- a/cmd/metadata/defaults/add.go
+++ b/cmd/metadata/defaults/add.go
@@ -153,12 +153,12 @@ See ochami-metadata(1) for more details.`,
 				}
 			}
 
-			// Print UIDs of created items
-			var uids []string
+			// Print names of created items
+			var names []string
 			for _, defaults := range defaultsCreated {
-				uids = append(uids, defaults.Metadata.UID)
+				names = append(names, defaults.Metadata.Name)
 			}
-			log.Logger.Info().Msgf("Cluster defaults created: %+v", uids)
+			log.Logger.Info().Msgf("Cluster defaults created: %q", names)
 
 			// Warn if any request errors occurred
 			if reqErrorsOccurred {

--- a/cmd/metadata/group/add.go
+++ b/cmd/metadata/group/add.go
@@ -158,12 +158,12 @@ See ochami-metadata(1) for more details.`,
 				}
 			}
 
-			// Print UIDs of created items
-			var uids []string
+			// Print names of created items
+			var names []string
 			for _, group := range groupsCreated {
-				uids = append(uids, group.Metadata.UID)
+				names = append(names, group.Metadata.Name)
 			}
-			log.Logger.Info().Msgf("Groups created: %+v", uids)
+			log.Logger.Info().Msgf("Groups created: %q", names)
 
 			// Warn if any request errors occurred
 			if reqErrorsOccurred {

--- a/cmd/metadata/instance/add.go
+++ b/cmd/metadata/instance/add.go
@@ -139,12 +139,12 @@ See ochami-metadata(1) for more details.`,
 				}
 			}
 
-			// Print UIDs of created items
-			var uids []string
+			// Print names of created items
+			var names []string
 			for _, instance := range instancesCreated {
-				uids = append(uids, instance.Metadata.UID)
+				names = append(names, instance.Metadata.Name)
 			}
-			log.Logger.Info().Msgf("Instance infos created: %+v", uids)
+			log.Logger.Info().Msgf("Instance infos created: %q", names)
 
 			// Warn if any request errors occurred
 			if reqErrorsOccurred {

--- a/cmd/metadata/peer/add.go
+++ b/cmd/metadata/peer/add.go
@@ -153,12 +153,12 @@ See ochami-metadata(1) for more details.`,
 				}
 			}
 
-			// Print UIDs of created items
-			var uids []string
+			// Print names of created items
+			var names []string
 			for _, peer := range peersCreated {
-				uids = append(uids, peer.Metadata.UID)
+				names = append(names, peer.Metadata.Name)
 			}
-			log.Logger.Info().Msgf("WireGuard peers created: %+v", uids)
+			log.Logger.Info().Msgf("WireGuard peers created: %q", names)
 
 			// Warn if any request errors occurred
 			if reqErrorsOccurred {

--- a/pkg/client/boot_service/bmc.go
+++ b/pkg/client/boot_service/bmc.go
@@ -27,9 +27,10 @@ type BMCSpec struct {
 }
 
 // AddBMCs is a wrapper that calls the boot-service client's CreateBMC()
-// function, passing it context. The output is a slice of the BMCs it created,
-// each element of which corresponds to an error in an error slice, followed by
-// an error that is populatd if an error occurred in the function itself.
+// function, passing it context. It returns a slice of successfully created
+// BMCs, a slice of per-request errors, and an error that is populated if an
+// error occurred in the function itself. A nil resource returned without an
+// error is reported as a per-request error.
 func (bsc *BootServiceClient) AddBMCs(token string, bmcs []boot_service_client.CreateBMCRequest) (bmcsAdded []*api.BMC, errors []error, funcErr error) {
 	// TODO: Make concurrent
 	for _, bmc := range bmcs {
@@ -40,9 +41,12 @@ func (bsc *BootServiceClient) AddBMCs(token string, bmcs []boot_service_client.C
 		if err != nil {
 			newErr := fmt.Errorf("failed to add bmc %+v: %w", bmc, err)
 			errors = append(errors, newErr)
-			bmcsAdded = append(bmcsAdded, nil)
+		} else if item != nil {
+			bmcsAdded = append(bmcsAdded, item)
+		} else {
+			newErr := fmt.Errorf("BMC creation did not err, but was not created for: %+v", bmc)
+			errors = append(errors, newErr)
 		}
-		bmcsAdded = append(bmcsAdded, item)
 	}
 
 	return
@@ -170,9 +174,12 @@ func (bsc *BootServiceClient) AddBMCSpecs(token string, bmcs []BMCSpec) (bmcsAdd
 		if err != nil {
 			newErr := fmt.Errorf("failed to add bmc %q (%+v): %w", bmc.Name, bmc.BMCSpec, err)
 			errors = append(errors, newErr)
-			bmcsAdded = append(bmcsAdded, nil)
+		} else if item != nil {
+			bmcsAdded = append(bmcsAdded, item)
+		} else {
+			newErr := fmt.Errorf("BMC creation did not err, but was not created for: %+v", bmc)
+			errors = append(errors, newErr)
 		}
-		bmcsAdded = append(bmcsAdded, item)
 	}
 
 	return

--- a/pkg/client/boot_service/bmc_test.go
+++ b/pkg/client/boot_service/bmc_test.go
@@ -88,6 +88,68 @@ func TestAddBMCs_EnvelopeIncludesLabels(t *testing.T) {
 	}
 }
 
+func TestAddBMCSpecs_ReturnsOnlyCreatedResources(t *testing.T) {
+	requests := 0
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests == 1 {
+			http.Error(w, "creation failed", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.BMC{Metadata: fabrica.Metadata{Name: "created BMC"}})
+	})
+	defer srv.Close()
+
+	created, errs, err := c.AddBMCSpecs("", []BMCSpec{
+		{Name: "failed BMC"},
+		{Name: "created BMC"},
+	})
+	if err != nil {
+		t.Fatalf("AddBMCSpecs returned func error: %v", err)
+	}
+	if len(errs) != 1 {
+		t.Fatalf("got %d per-request errors, want 1", len(errs))
+	}
+	if len(created) != 1 {
+		t.Fatalf("got %d created BMCs, want 1", len(created))
+	}
+	if created[0] == nil || created[0].Metadata.Name != "created BMC" {
+		t.Errorf("created BMCs = %+v, want only created BMC", created)
+	}
+}
+
+func TestAddBMCs_ReturnsOnlyCreatedResources(t *testing.T) {
+	requests := 0
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests == 1 {
+			http.Error(w, "creation failed", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.BMC{Metadata: fabrica.Metadata{Name: "created BMC"}})
+	})
+	defer srv.Close()
+
+	created, errs, err := c.AddBMCs("", []boot_service_client.CreateBMCRequest{
+		{Metadata: fabrica.Metadata{Name: "failed BMC"}},
+		{Metadata: fabrica.Metadata{Name: "created BMC"}},
+	})
+	if err != nil {
+		t.Fatalf("AddBMCs returned func error: %v", err)
+	}
+	if len(errs) != 1 {
+		t.Fatalf("got %d per-request errors, want 1", len(errs))
+	}
+	if len(created) != 1 {
+		t.Fatalf("got %d created BMCs, want 1", len(created))
+	}
+	if created[0] == nil || created[0].Metadata.Name != "created BMC" {
+		t.Errorf("created BMCs = %+v, want only created BMC", created)
+	}
+}
+
 func TestSetBMCSpec_SendsSpecToUIDEndpoint(t *testing.T) {
 	var gotPath, gotMethod string
 	var gotBody map[string]interface{}

--- a/pkg/client/boot_service/bootconfig.go
+++ b/pkg/client/boot_service/bootconfig.go
@@ -28,10 +28,10 @@ type BootConfigSpec struct {
 }
 
 // AddBootConfigs is a wrapper that calls the boot-service client's
-// CreateBootConfiguration() function, passing it context. The output is a slice
-// of the boot configurations it created, each element of which corresponds to
-// an error in an error slice, followed by an error that is populatd if an error
-// occurred in the function itself.
+// CreateBootConfiguration() function, passing it context. It returns a slice of
+// successfully created boot configurations, a slice of per-request errors, and
+// an error that is populated if an error occurred in the function itself. A nil
+// resource returned without an error is reported as a per-request error.
 func (bsc *BootServiceClient) AddBootConfigs(token string, bootCfgs []boot_service_client.CreateBootConfigurationRequest) (cfgsAdded []*api.BootConfiguration, errors []error, funcErr error) {
 	// TODO: Make concurrent
 	for _, bootCfg := range bootCfgs {
@@ -42,9 +42,12 @@ func (bsc *BootServiceClient) AddBootConfigs(token string, bootCfgs []boot_servi
 		if err != nil {
 			newErr := fmt.Errorf("failed to add boot configuration %+v: %w", bootCfg, err)
 			errors = append(errors, newErr)
-			cfgsAdded = append(cfgsAdded, nil)
+		} else if item != nil {
+			cfgsAdded = append(cfgsAdded, item)
+		} else {
+			newErr := fmt.Errorf("boot configuration creation did not err, but was not created for: %+v", bootCfg)
+			errors = append(errors, newErr)
 		}
-		cfgsAdded = append(cfgsAdded, item)
 	}
 
 	return
@@ -177,9 +180,12 @@ func (bsc *BootServiceClient) AddBootConfigSpecs(token string, bootCfgs []BootCo
 		if err != nil {
 			newErr := fmt.Errorf("failed to add boot configuration %q (%+v): %w", bootCfg.Name, bootCfg.BootConfigurationSpec, err)
 			errors = append(errors, newErr)
-			cfgsAdded = append(cfgsAdded, nil)
+		} else if item != nil {
+			cfgsAdded = append(cfgsAdded, item)
+		} else {
+			newErr := fmt.Errorf("boot configuration creation did not err, but was not created for: %+v", bootCfg)
+			errors = append(errors, newErr)
 		}
-		cfgsAdded = append(cfgsAdded, item)
 	}
 
 	return

--- a/pkg/client/boot_service/bootconfig_test.go
+++ b/pkg/client/boot_service/bootconfig_test.go
@@ -88,6 +88,68 @@ func TestAddBootConfigs_EnvelopeIncludesLabels(t *testing.T) {
 	}
 }
 
+func TestAddBootConfigSpecs_ReturnsOnlyCreatedResources(t *testing.T) {
+	requests := 0
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests == 1 {
+			http.Error(w, "creation failed", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.BootConfiguration{Metadata: fabrica.Metadata{Name: "created config"}})
+	})
+	defer srv.Close()
+
+	created, errs, err := c.AddBootConfigSpecs("", []BootConfigSpec{
+		{Name: "failed config"},
+		{Name: "created config"},
+	})
+	if err != nil {
+		t.Fatalf("AddBootConfigSpecs returned func error: %v", err)
+	}
+	if len(errs) != 1 {
+		t.Fatalf("got %d per-request errors, want 1", len(errs))
+	}
+	if len(created) != 1 {
+		t.Fatalf("got %d created boot configurations, want 1", len(created))
+	}
+	if created[0] == nil || created[0].Metadata.Name != "created config" {
+		t.Errorf("created boot configurations = %+v, want only created config", created)
+	}
+}
+
+func TestAddBootConfigs_ReturnsOnlyCreatedResources(t *testing.T) {
+	requests := 0
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests == 1 {
+			http.Error(w, "creation failed", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.BootConfiguration{Metadata: fabrica.Metadata{Name: "created config"}})
+	})
+	defer srv.Close()
+
+	created, errs, err := c.AddBootConfigs("", []boot_service_client.CreateBootConfigurationRequest{
+		{Metadata: fabrica.Metadata{Name: "failed config"}},
+		{Metadata: fabrica.Metadata{Name: "created config"}},
+	})
+	if err != nil {
+		t.Fatalf("AddBootConfigs returned func error: %v", err)
+	}
+	if len(errs) != 1 {
+		t.Fatalf("got %d per-request errors, want 1", len(errs))
+	}
+	if len(created) != 1 {
+		t.Fatalf("got %d created boot configurations, want 1", len(created))
+	}
+	if created[0] == nil || created[0].Metadata.Name != "created config" {
+		t.Errorf("created boot configurations = %+v, want only created config", created)
+	}
+}
+
 func TestSetBootConfigSpec_SendsSpecToUIDEndpoint(t *testing.T) {
 	var gotPath, gotMethod string
 	var gotBody map[string]interface{}

--- a/pkg/client/boot_service/node.go
+++ b/pkg/client/boot_service/node.go
@@ -27,9 +27,10 @@ type NodeSpec struct {
 }
 
 // AddNodes is a wrapper that calls the boot-service client's CreateNode()
-// function, passing it context. The output is a slice of the nodes it created,
-// each element of which corresponds to an error in an error slice, followed by
-// an error that is populatd if an error occurred in the function itself.
+// function, passing it context. It returns a slice of successfully created
+// nodes, a slice of per-request errors, and an error that is populated if an
+// error occurred in the function itself. A nil resource returned without an
+// error is reported as a per-request error.
 func (bsc *BootServiceClient) AddNodes(token string, nodes []boot_service_client.CreateNodeRequest) (nodesAdded []*api.Node, errors []error, funcErr error) {
 	// TODO: Make concurrent
 	for _, node := range nodes {
@@ -40,9 +41,12 @@ func (bsc *BootServiceClient) AddNodes(token string, nodes []boot_service_client
 		if err != nil {
 			newErr := fmt.Errorf("failed to add node %+v: %w", node, err)
 			errors = append(errors, newErr)
-			nodesAdded = append(nodesAdded, nil)
+		} else if item != nil {
+			nodesAdded = append(nodesAdded, item)
+		} else {
+			newErr := fmt.Errorf("node creation did not err, but was not created for: %+v", node)
+			errors = append(errors, newErr)
 		}
-		nodesAdded = append(nodesAdded, item)
 	}
 
 	return
@@ -173,9 +177,12 @@ func (bsc *BootServiceClient) AddNodeSpecs(token string, nodes []NodeSpec) (node
 		if err != nil {
 			newErr := fmt.Errorf("failed to add node %q (%+v): %w", node.Name, node.NodeSpec, err)
 			errors = append(errors, newErr)
-			nodesAdded = append(nodesAdded, nil)
+		} else if item != nil {
+			nodesAdded = append(nodesAdded, item)
+		} else {
+			newErr := fmt.Errorf("node creation did not err, but was not created for: %+v", node)
+			errors = append(errors, newErr)
 		}
-		nodesAdded = append(nodesAdded, item)
 	}
 
 	return

--- a/pkg/client/boot_service/node_test.go
+++ b/pkg/client/boot_service/node_test.go
@@ -105,6 +105,68 @@ func TestAddNodes_EnvelopeIncludesLabels(t *testing.T) {
 	}
 }
 
+func TestAddNodeSpecs_ReturnsOnlyCreatedResources(t *testing.T) {
+	requests := 0
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests == 1 {
+			http.Error(w, "creation failed", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.Node{Metadata: fabrica.Metadata{Name: "created node"}})
+	})
+	defer srv.Close()
+
+	created, errs, err := c.AddNodeSpecs("", []NodeSpec{
+		{Name: "failed node"},
+		{Name: "created node"},
+	})
+	if err != nil {
+		t.Fatalf("AddNodeSpecs returned func error: %v", err)
+	}
+	if len(errs) != 1 {
+		t.Fatalf("got %d per-request errors, want 1", len(errs))
+	}
+	if len(created) != 1 {
+		t.Fatalf("got %d created nodes, want 1", len(created))
+	}
+	if created[0] == nil || created[0].Metadata.Name != "created node" {
+		t.Errorf("created nodes = %+v, want only created node", created)
+	}
+}
+
+func TestAddNodes_ReturnsOnlyCreatedResources(t *testing.T) {
+	requests := 0
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests == 1 {
+			http.Error(w, "creation failed", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.Node{Metadata: fabrica.Metadata{Name: "created node"}})
+	})
+	defer srv.Close()
+
+	created, errs, err := c.AddNodes("", []boot_service_client.CreateNodeRequest{
+		{Metadata: fabrica.Metadata{Name: "failed node"}},
+		{Metadata: fabrica.Metadata{Name: "created node"}},
+	})
+	if err != nil {
+		t.Fatalf("AddNodes returned func error: %v", err)
+	}
+	if len(errs) != 1 {
+		t.Fatalf("got %d per-request errors, want 1", len(errs))
+	}
+	if len(created) != 1 {
+		t.Fatalf("got %d created nodes, want 1", len(created))
+	}
+	if created[0] == nil || created[0].Metadata.Name != "created node" {
+		t.Errorf("created nodes = %+v, want only created node", created)
+	}
+}
+
 func TestSetNodeSpec_SendsSpecToUIDEndpoint(t *testing.T) {
 	var gotPath, gotMethod string
 	var gotBody map[string]interface{}


### PR DESCRIPTION
### Description

Boot resource creation helpers appended nil entries when requests failed, causing `add` commands to report resources that were not created. For example, upon success:

```
boot configs created: [0x26959d13d380]
```

Upon failure:

```
boot configs created: [<nil> <nil>] 
```

These are not useful for debugging.

The boot commands also logged resource pointers directly, producing pointer addresses rather than useful identifiers. Metadata commands logged UIDs, making their output inconsistent with the resource names supplied by users.

Only append boot configurations, nodes, and BMCs to the returned result slice when creation succeeds and the service returns a non-nil resource. Treat a nil resource returned without an error as a per-request failure so it cannot be reported as successfully created.

Update `boot` and `metadata add` commands to collect resource names from successful responses and print them using quoted formatting. Quoting makes names containing spaces or other ambiguous characters clearly distinguishable while avoiding nil values and pointer addresses.

Add regression coverage for both simple and envelope boot-service APIs using mixed successful and failed requests. Verify that failed resources remain in the per-request error results while only successfully created resources appear in the created-resource slice.

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [x] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass
- [x] I have updated the relevant documentation (CLI examples, man pages, README, other docs, etc.)
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  
- [ ] Dependency update

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
