### PR TITLE
feat(log)!: truncate access tokens in debug logs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ or `default-cluster` in the config file, the former taking precedence over the
 latter) in all capitals and with dashes (-) and spaces substituted with
 underscores (_).
 
+When debug logging is enabled (e.g. `--log-level debug`), any access token that
+would appear in the logs is truncated by default (e.g. `eyJhbG...`) so that the
+logs still indicate a token is present without revealing its full value. Pass
+`--show-token` to log the full, untruncated token instead.
+
 ### 5. Testing Authenticated Cluster Access
 
 Now, we should be able to contact the API on an endpoint that requires

--- a/cmd/discover/static/static.go
+++ b/cmd/discover/static/static.go
@@ -81,7 +81,7 @@ See ochami-discover(1) for more details.`,
 			cli.HandleToken(cmd)
 
 			// Create client to make request to SMD
-			smdClient, err := smd.NewClient(smdBaseURI, cli.Insecure)
+			smdClient, err := smd.NewClient(smdBaseURI, client.WithInsecure(cli.Insecure), client.WithShowToken(cli.ShowToken(cmd)))
 			if err != nil {
 				log.Logger.Error().Err(err).Msg("error creating new SMD client")
 				cli.LogHelpError(cmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,6 +87,7 @@ See ochami-config(5) for more details on configuring the ochami config file(s).`
 	rootCmd.PersistentFlags().StringVar(&cli.CACertPath, "cacert", "", "path to root CA certificate in PEM format")
 	rootCmd.PersistentFlags().StringVarP(&cli.Token, "token", "t", "", "access cli.Token to present for authentication")
 	rootCmd.PersistentFlags().Bool("no-token", false, "do not check for or use an access cli.Token")
+	rootCmd.PersistentFlags().Bool("show-token", false, "show full access token in debug logs instead of a truncated value")
 	rootCmd.PersistentFlags().BoolVarP(&cli.Insecure, "insecure", "k", false, "do not verify TLS certificates")
 	rootCmd.PersistentFlags().Bool("ignore-config", false, "do not use any config file")
 	rootCmd.PersistentFlags().BoolVarP(&log.EarlyLogger.EarlyVerbose, "verbose", "v", false, "be verbose before logging is initialized")

--- a/internal/cli/boot_service/boot_service.go
+++ b/internal/cli/boot_service/boot_service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openchami/ochami/internal/cli"
 	"github.com/openchami/ochami/internal/config"
 	"github.com/openchami/ochami/internal/log"
+	"github.com/openchami/ochami/pkg/client"
 	"github.com/openchami/ochami/pkg/client/boot_service"
 )
 
@@ -33,7 +34,7 @@ func GetClient(cmd *cobra.Command) *boot_service.BootServiceClient {
 	}
 
 	// Create client to make request to boot-service
-	bootServiceClient, err := boot_service.NewClient(bootServiceBaseURI, cli.Insecure, cli.GetTimeout(cmd), apiVersion, log.Logger)
+	bootServiceClient, err := boot_service.NewClient(bootServiceBaseURI, cli.GetTimeout(cmd), apiVersion, log.Logger, client.WithInsecure(cli.Insecure), client.WithShowToken(cli.ShowToken(cmd)))
 	if err != nil {
 		log.Logger.Error().Err(err).Msg("error creating new boot-service client")
 		cli.LogHelpError(cmd)

--- a/internal/cli/bss/bss.go
+++ b/internal/cli/bss/bss.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/openchami/ochami/internal/cli"
 	"github.com/openchami/ochami/internal/log"
+	"github.com/openchami/ochami/pkg/client"
 	"github.com/openchami/ochami/pkg/client/bss"
 )
 
@@ -27,7 +28,7 @@ func GetClient(cmd *cobra.Command) *bss.BSSClient {
 	}
 
 	// Create client to make request to BSS
-	bssClient, err := bss.NewClient(bssBaseURI, cli.Insecure)
+	bssClient, err := bss.NewClient(bssBaseURI, client.WithInsecure(cli.Insecure), client.WithShowToken(cli.ShowToken(cmd)))
 	if err != nil {
 		log.Logger.Error().Err(err).Msg("error creating new BSS client")
 		cli.LogHelpError(cmd)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -220,6 +220,16 @@ func InitConfigAndLogging(cmd *cobra.Command, createCfg bool) {
 	}
 }
 
+// ShowToken reports whether the --show-token flag was passed for cmd, indicating
+// that full access tokens should be shown in debug logs instead of being
+// truncated. It returns false if the flag is not defined for the command.
+func ShowToken(cmd *cobra.Command) bool {
+	if f := cmd.Flag("show-token"); f != nil {
+		return f.Value.String() == "true"
+	}
+	return false
+}
+
 // CreateIfNotExists creates path (a file with optional leading directories) if
 // any of the path components do not exist, returning an error if one occurred
 // with the creation.
@@ -557,7 +567,7 @@ func SetToken(cmd *cobra.Command) {
 	)
 	if cmd.Flag("token").Changed {
 		Token = cmd.Flag("token").Value.String()
-		log.Logger.Debug().Msg("--token passed, setting token to its value: " + Token)
+		log.Logger.Debug().Msg("--token passed, setting token to its value: " + client.RedactToken(Token, ShowToken(cmd)))
 		return
 	}
 
@@ -580,7 +590,7 @@ func SetToken(cmd *cobra.Command) {
 	envVarToRead := strings.ToUpper(varPrefix) + "_ACCESS_TOKEN"
 	log.Logger.Debug().Msg("Reading token from environment variable: " + envVarToRead)
 	if t, tokenSet := os.LookupEnv(envVarToRead); tokenSet {
-		log.Logger.Debug().Msgf("Token found from environment variable: %s=%s", envVarToRead, t)
+		log.Logger.Debug().Msgf("Token found from environment variable: %s=%s", envVarToRead, client.RedactToken(t, ShowToken(cmd)))
 		Token = t
 		return
 	}

--- a/internal/cli/cloud_init/cloud_init.go
+++ b/internal/cli/cloud_init/cloud_init.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/openchami/ochami/internal/cli"
 	"github.com/openchami/ochami/internal/log"
+	"github.com/openchami/ochami/pkg/client"
 	"github.com/openchami/ochami/pkg/client/cloud_init"
 )
 
@@ -78,7 +79,7 @@ func GetClient(cmd *cobra.Command) *cloud_init.CloudInitClient {
 	}
 
 	// Create client to make request to cloud-init
-	cloudInitClient, err := cloud_init.NewClient(cloudInitbaseURI, cli.Insecure)
+	cloudInitClient, err := cloud_init.NewClient(cloudInitbaseURI, client.WithInsecure(cli.Insecure), client.WithShowToken(cli.ShowToken(cmd)))
 	if err != nil {
 		log.Logger.Error().Err(err).Msg("error creating new cloud-init client")
 		cli.LogHelpError(cmd)

--- a/internal/cli/metadata_service/metadata_service.go
+++ b/internal/cli/metadata_service/metadata_service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openchami/ochami/internal/cli"
 	"github.com/openchami/ochami/internal/config"
 	"github.com/openchami/ochami/internal/log"
+	"github.com/openchami/ochami/pkg/client"
 	"github.com/openchami/ochami/pkg/client/metadata_service"
 )
 
@@ -33,7 +34,7 @@ func GetClient(cmd *cobra.Command) *metadata_service.MetadataServiceClient {
 	}
 
 	// Create client to make request to metadata-service
-	metadataServiceClient, err := metadata_service.NewClient(metadataServiceBaseURI, cli.Insecure, cli.GetTimeout(cmd), apiVersion, log.Logger)
+	metadataServiceClient, err := metadata_service.NewClient(metadataServiceBaseURI, cli.GetTimeout(cmd), apiVersion, log.Logger, client.WithInsecure(cli.Insecure), client.WithShowToken(cli.ShowToken(cmd)))
 	if err != nil {
 		log.Logger.Error().Err(err).Msg("error creating new metadata-service client")
 		cli.LogHelpError(cmd)

--- a/internal/cli/pcs/pcs.go
+++ b/internal/cli/pcs/pcs.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/openchami/ochami/internal/cli"
 	"github.com/openchami/ochami/internal/log"
+	"github.com/openchami/ochami/pkg/client"
 	"github.com/openchami/ochami/pkg/client/pcs"
 )
 
@@ -27,7 +28,7 @@ func GetClient(cmd *cobra.Command) *pcs.PCSClient {
 	}
 
 	// Create client to make request to PCS
-	pcsClient, err := pcs.NewClient(pcsBaseURI, cli.Insecure)
+	pcsClient, err := pcs.NewClient(pcsBaseURI, client.WithInsecure(cli.Insecure), client.WithShowToken(cli.ShowToken(cmd)))
 	if err != nil {
 		log.Logger.Fatal().Err(err).Msg("error creating new PCS client")
 	}

--- a/internal/cli/rcs/rcs.go
+++ b/internal/cli/rcs/rcs.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/openchami/ochami/internal/cli"
 	"github.com/openchami/ochami/internal/log"
+	"github.com/openchami/ochami/pkg/client"
 	"github.com/openchami/ochami/pkg/client/rcs"
 )
 
@@ -26,7 +27,7 @@ func GetClient(cmd *cobra.Command) *rcs.RCSClient {
 
 	insecure, _ := cmd.Flags().GetBool("insecure")
 
-	rcsClient, err := rcs.NewClient(rcsBaseURI, insecure)
+	rcsClient, err := rcs.NewClient(rcsBaseURI, client.WithInsecure(insecure), client.WithShowToken(cli.ShowToken(cmd)))
 	if err != nil {
 		log.Logger.Error().Err(err).Msg("error creating new remote-console client")
 		cli.LogHelpError(cmd)

--- a/internal/cli/smd/smd.go
+++ b/internal/cli/smd/smd.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/openchami/ochami/internal/cli"
 	"github.com/openchami/ochami/internal/log"
+	"github.com/openchami/ochami/pkg/client"
 	"github.com/openchami/ochami/pkg/client/smd"
 )
 
@@ -27,7 +28,7 @@ func GetClient(cmd *cobra.Command) *smd.SMDClient {
 	}
 
 	// Create client to make request to SMD
-	smdClient, err := smd.NewClient(smdBaseURI, cli.Insecure)
+	smdClient, err := smd.NewClient(smdBaseURI, client.WithInsecure(cli.Insecure), client.WithShowToken(cli.ShowToken(cmd)))
 	if err != nil {
 		log.Logger.Error().Err(err).Msg("error creating new SMD client")
 		cli.LogHelpError(cmd)

--- a/man/ochami.1.sc
+++ b/man/ochami.1.sc
@@ -89,6 +89,10 @@ export FOOBAR_ACCESS_TOKEN=...
 Once these steps are completed, *ochami* should be ready to use with cluster
 _foobar_.
 
+When debug logging is enabled, any access token that would appear in the logs is
+truncated by default so that the logs still indicate a token is present without
+revealing its full value. Pass *--show-token* to log the full token instead.
+
 # GLOBAL OPTIONS
 
 *--cacert* _cacert_
@@ -158,6 +162,15 @@ _foobar_.
 
 	This flag is useful for testing access to API endpoints that don't have JWT
 	authentication enabled, e.g. in a test environment.
+
+*--show-token*
+	Show the full access token in debug logs. By default, when debug logging is
+	enabled (see *--log-level*), any access token that appears in the logs
+	(e.g. in the request *Authorization* header or when reading the token) is
+	truncated to its first few characters followed by an ellipsis so that the
+	logs still indicate that a token is present without revealing its full
+	value. Passing this flag causes the full, untruncated token to be shown in
+	the logs instead.
 
 *-t, --token* _token_
 	Access token to include in request headers for authentication to protected

--- a/pkg/client/boot_service/client.go
+++ b/pkg/client/boot_service/client.go
@@ -29,13 +29,14 @@ type BootServiceClient struct {
 // NewClient takes a baseURI, timeout duration, optional API version string, and
 // logger and returns a pointer to a new BootServiceClient.  If an error
 // occurred creating the embedded OchamiClient or the boot service client, it is
-// returned. If insecure is true, TLS certificates will not be verified. An API
-// version can also be specified (e.g. 'v1beta2'), though it can be left blank
-// to use the default.
-func NewClient(baseURI string, insecure bool, timeout time.Duration, apiVersion string, logger zerolog.Logger) (*BootServiceClient, error) {
+// returned. Behavior such as TLS verification and token redaction is configured
+// via functional options (e.g. client.WithInsecure, client.WithShowToken). An
+// API version can also be specified (e.g. 'v1beta2'), though it can be left
+// blank to use the default.
+func NewClient(baseURI string, timeout time.Duration, apiVersion string, logger zerolog.Logger, opts ...client.Option) (*BootServiceClient, error) {
 	// Create OchamiClient to ensure http client is configured via ochami CLI
 	// flags/config.
-	oc, err := client.NewOchamiClient(serviceNameBootService, baseURI, insecure)
+	oc, err := client.NewOchamiClient(serviceNameBootService, baseURI, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OchamiClient for %s: %w", serviceNameBootService, err)
 	}

--- a/pkg/client/boot_service/node_test.go
+++ b/pkg/client/boot_service/node_test.go
@@ -23,7 +23,7 @@ import (
 func newTestClient(t *testing.T, handler http.HandlerFunc) (*BootServiceClient, *httptest.Server) {
 	t.Helper()
 	srv := httptest.NewServer(handler)
-	c, err := NewClient(srv.URL, false, 5*time.Second, "", zerolog.New(io.Discard))
+	c, err := NewClient(srv.URL, 5*time.Second, "", zerolog.New(io.Discard))
 	if err != nil {
 		srv.Close()
 		t.Fatalf("failed to create client: %v", err)

--- a/pkg/client/bss/bss.go
+++ b/pkg/client/bss/bss.go
@@ -33,10 +33,11 @@ type BSSClient struct {
 }
 
 // NewClient takes a baseURI and returns a pointer to a new BSSClient. If an
-// error occurred creating the embedded OchamiClient, it is returned. If
-// insecure is true, TLS certificates will not be verified.
-func NewClient(baseURI string, insecure bool) (*BSSClient, error) {
-	oc, err := client.NewOchamiClient(serviceNameBSS, baseURI, insecure)
+// error occurred creating the embedded OchamiClient, it is returned. Behavior
+// such as TLS verification and token redaction is configured via functional
+// options (e.g. client.WithInsecure, client.WithShowToken).
+func NewClient(baseURI string, opts ...client.Option) (*BSSClient, error) {
+	oc, err := client.NewOchamiClient(serviceNameBSS, baseURI, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OchamiClient for %s: %w", serviceNameBSS, err)
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -38,6 +38,36 @@ type OchamiClient struct {
 	*http.Client
 	BaseURI     *url.URL // Base URL for OpenCHAMI services (e.g. https://foobar.openchami.cluster)
 	ServiceName string   // Name of service being contacted (e.g. BSS)
+
+	// ShowToken controls whether access tokens are shown in full in debug
+	// logs for requests made by this client. It defaults to false, meaning
+	// tokens are truncated (see RedactToken).
+	ShowToken bool
+
+	// insecure records whether TLS certificate verification should be
+	// skipped. It is set by the WithInsecure option and consumed when the
+	// underlying HTTP client is built.
+	insecure bool
+}
+
+// Option configures an OchamiClient. Options are applied by NewOchamiClient
+// after the client is created but before its underlying HTTP client is built.
+type Option func(*OchamiClient)
+
+// WithInsecure configures whether the client should skip TLS certificate
+// verification.
+func WithInsecure(insecure bool) Option {
+	return func(oc *OchamiClient) {
+		oc.insecure = insecure
+	}
+}
+
+// WithShowToken configures whether the client shows full access tokens in debug
+// logs (true) or truncates them (false, the default).
+func WithShowToken(show bool) Option {
+	return func(oc *OchamiClient) {
+		oc.ShowToken = show
+	}
 }
 
 // defaultClient creates an http.DefaultClient for its OchamiClient.
@@ -61,9 +91,10 @@ func (oc *OchamiClient) defaultClientInsecure() {
 // new OchamiClient. If an error occurs parsing baseURI, it is returned. baseURI
 // is the base URI of the OpenCHAMI service (e.g.
 // https://foobar.openchami.cluster/hsm/v2 for SMD) and serviceName is the
-// human-readable name of the service (e.g. SMD). If insecure is true, the
-// client will not verify TLS certificates.
-func NewOchamiClient(serviceName, baseURI string, insecure bool) (*OchamiClient, error) {
+// human-readable name of the service (e.g. SMD). Behavior such as TLS
+// verification and token redaction is configured via functional options (e.g.
+// WithInsecure, WithShowToken).
+func NewOchamiClient(serviceName, baseURI string, opts ...Option) (*OchamiClient, error) {
 	u, err := url.Parse(baseURI)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse URI: %w", err)
@@ -72,7 +103,10 @@ func NewOchamiClient(serviceName, baseURI string, insecure bool) (*OchamiClient,
 		BaseURI:     u,
 		ServiceName: serviceName,
 	}
-	if insecure {
+	for _, opt := range opts {
+		opt(oc)
+	}
+	if oc.insecure {
 		oc.defaultClientInsecure()
 	} else {
 		oc.defaultClient()
@@ -269,7 +303,11 @@ func (oc *OchamiClient) MakeRequest(method, uri string, headers *HTTPHeaders, bo
 	if len(req.Header) > 0 {
 		log.Logger.Debug().Msg("Request headers:")
 		for k, v := range req.Header {
-			log.Logger.Debug().Msgf("  %s: %s", k, v)
+			if isAuthorizationHeader(k) {
+				log.Logger.Debug().Msgf("  %s: %s", k, redactAuthHeaderValues(v, oc.ShowToken))
+			} else {
+				log.Logger.Debug().Msgf("  %s: %s", k, v)
+			}
 		}
 	} else {
 		log.Logger.Debug().Msg("No headers in request")

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -34,7 +34,7 @@ func TestGetData(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	oc, err := NewOchamiClient("svc", ts.URL, false)
+	oc, err := NewOchamiClient("svc", ts.URL, WithInsecure(false))
 	if err != nil {
 		t.Fatalf("NewOchamiClient: %v", err)
 	}
@@ -100,7 +100,7 @@ func TestPostData(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	oc, err := NewOchamiClient("svc", ts.URL, false)
+	oc, err := NewOchamiClient("svc", ts.URL, WithInsecure(false))
 	if err != nil {
 		t.Fatalf("NewOchamiClient: %v", err)
 	}

--- a/pkg/client/cloud_init/cloud_init.go
+++ b/pkg/client/cloud_init/cloud_init.go
@@ -78,10 +78,11 @@ func DecodeCloudConfig(ccf cistore.CloudConfigFile) ([]byte, error) {
 }
 
 // NewClient takes a baseURI and returns a pointer to a new CloudInitClient. If
-// an error occurred creating the embedded OchamiClient, it is returned. If
-// insecure is true, TLS certificates will not be verified.
-func NewClient(baseURI string, insecure bool) (*CloudInitClient, error) {
-	oc, err := client.NewOchamiClient(serviceNameCloudInit, baseURI, insecure)
+// an error occurred creating the embedded OchamiClient, it is returned. Behavior
+// such as TLS verification and token redaction is configured via functional
+// options (e.g. client.WithInsecure, client.WithShowToken).
+func NewClient(baseURI string, opts ...client.Option) (*CloudInitClient, error) {
+	oc, err := client.NewOchamiClient(serviceNameCloudInit, baseURI, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OchamiClient for %s: %w", serviceNameCloudInit, err)
 	}

--- a/pkg/client/metadata_service/client.go
+++ b/pkg/client/metadata_service/client.go
@@ -29,13 +29,14 @@ type MetadataServiceClient struct {
 // NewClient takes a baseURI, timeout duration, optional API version string, and
 // logger and returns a pointer to a new MetadataServiceClient.  If an error
 // occurred creating the embedded OchamiClient or the metadata service client,
-// it is returned. If insecure is true, TLS certificates will not be verified.
-// An API version can also be specified (e.g. 'v1beta2'), though it can be left
-// blank to use the default.
-func NewClient(baseURI string, insecure bool, timeout time.Duration, apiVersion string, logger zerolog.Logger) (*MetadataServiceClient, error) {
+// it is returned. Behavior such as TLS verification and token redaction is
+// configured via functional options (e.g. client.WithInsecure,
+// client.WithShowToken). An API version can also be specified (e.g. 'v1beta2'),
+// though it can be left blank to use the default.
+func NewClient(baseURI string, timeout time.Duration, apiVersion string, logger zerolog.Logger, opts ...client.Option) (*MetadataServiceClient, error) {
 	// Create OchamiClient to ensure http client is configured via ochami CLI
 	// flags/config.
-	oc, err := client.NewOchamiClient(serviceNameMetadataService, baseURI, insecure)
+	oc, err := client.NewOchamiClient(serviceNameMetadataService, baseURI, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OchamiClient for %s: %w", serviceNameMetadataService, err)
 	}

--- a/pkg/client/metadata_service/client_test.go
+++ b/pkg/client/metadata_service/client_test.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+
+	"github.com/openchami/ochami/pkg/client"
 )
 
 func TestNewClient(t *testing.T) {
@@ -288,7 +290,7 @@ func TestNewClient(t *testing.T) {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
 			// Call NewClient
-			client, err := NewClient(tc.baseURI, tc.insecure, tc.timeout, tc.apiVersion, tc.logger)
+			mc, err := NewClient(tc.baseURI, tc.timeout, tc.apiVersion, tc.logger, client.WithInsecure(tc.insecure))
 
 			// Check error expectation
 			if (err != nil) != tc.wantErr {
@@ -305,40 +307,40 @@ func TestNewClient(t *testing.T) {
 			}
 
 			// Success case validations
-			if client == nil {
+			if mc == nil {
 				t.Fatal("NewClient() returned nil client without error")
 			}
 
 			// Verify OchamiClient is created and non-nil
-			if client.OchamiClient == nil {
+			if mc.OchamiClient == nil {
 				t.Error("OchamiClient is nil")
 			} else {
 				// Verify OchamiClient has expected fields
-				if client.OchamiClient.BaseURI == nil {
+				if mc.OchamiClient.BaseURI == nil {
 					t.Error("OchamiClient.BaseURI is nil")
 				}
-				if client.OchamiClient.ServiceName != serviceNameMetadataService {
-					t.Errorf("OchamiClient.ServiceName = %q, want %q", client.OchamiClient.ServiceName, serviceNameMetadataService)
+				if mc.OchamiClient.ServiceName != serviceNameMetadataService {
+					t.Errorf("OchamiClient.ServiceName = %q, want %q", mc.OchamiClient.ServiceName, serviceNameMetadataService)
 				}
-				if client.OchamiClient.Client == nil {
+				if mc.OchamiClient.Client == nil {
 					t.Error("OchamiClient.Client (http.Client) is nil")
 				}
 			}
 
 			// Verify metadata-service Client is created and non-nil
-			if client.Client == nil {
+			if mc.Client == nil {
 				t.Error("Client (metadata_service_client.Client) is nil")
 			}
 
 			// Verify Timeout matches input
-			if client.Timeout != tc.timeout {
-				t.Errorf("Timeout = %v, want %v", client.Timeout, tc.timeout)
+			if mc.Timeout != tc.timeout {
+				t.Errorf("Timeout = %v, want %v", mc.Timeout, tc.timeout)
 			}
 
 			// Additional validation for API version (if set)
 			// Note: We can't directly inspect if WithVersion was called,
 			// but we verify the client was created successfully with non-nil Client
-			if tc.apiVersion != "" && client.Client == nil {
+			if tc.apiVersion != "" && mc.Client == nil {
 				t.Error("API version was set but Client is nil")
 			}
 		})

--- a/pkg/client/metadata_service/group_test.go
+++ b/pkg/client/metadata_service/group_test.go
@@ -21,7 +21,7 @@ import (
 func newTestClient(t *testing.T, handler http.HandlerFunc) (*MetadataServiceClient, *httptest.Server) {
 	t.Helper()
 	srv := httptest.NewServer(handler)
-	c, err := NewClient(srv.URL, false, 5*time.Second, "", zerolog.New(io.Discard))
+	c, err := NewClient(srv.URL, 5*time.Second, "", zerolog.New(io.Discard))
 	if err != nil {
 		srv.Close()
 		t.Fatalf("failed to create client: %v", err)

--- a/pkg/client/pcs/pcs.go
+++ b/pkg/client/pcs/pcs.go
@@ -30,10 +30,11 @@ type PCSClient struct {
 }
 
 // NewClient takes a baseURI and returns a pointer to a new PCSClient. If an
-// error occurred creating the embedded OchamiClient, it is returned. If
-// insecure is true, TLS certificates will not be verified.
-func NewClient(baseURI string, insecure bool) (*PCSClient, error) {
-	oc, err := client.NewOchamiClient(serviceNamePCS, baseURI, insecure)
+// error occurred creating the embedded OchamiClient, it is returned. Behavior
+// such as TLS verification and token redaction is configured via functional
+// options (e.g. client.WithInsecure, client.WithShowToken).
+func NewClient(baseURI string, opts ...client.Option) (*PCSClient, error) {
+	oc, err := client.NewOchamiClient(serviceNamePCS, baseURI, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OchamiClient for %s: %w", serviceNamePCS, err)
 	}

--- a/pkg/client/rcs/rcs.go
+++ b/pkg/client/rcs/rcs.go
@@ -51,9 +51,11 @@ type RCSClient struct {
 	*client.OchamiClient
 }
 
-// NewClient creates a new RCSClient with the given base URI and TLS settings.
-func NewClient(baseURI string, insecure bool) (*RCSClient, error) {
-	oc, err := client.NewOchamiClient("Remote Console", baseURI, insecure)
+// NewClient creates a new RCSClient with the given base URI. Behavior such as
+// TLS verification and token redaction is configured via functional options
+// (e.g. client.WithInsecure, client.WithShowToken).
+func NewClient(baseURI string, opts ...client.Option) (*RCSClient, error) {
+	oc, err := client.NewOchamiClient("Remote Console", baseURI, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/redact.go
+++ b/pkg/client/redact.go
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: © 2025 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package client
+
+import (
+	"net/http"
+	"strings"
+)
+
+// tokenPrefixLen is the number of leading characters of a token to keep when
+// truncating it for logs.
+const tokenPrefixLen = 6
+
+// RedactToken returns token unchanged if show is true. Otherwise, it returns a
+// truncated form of the token that still indicates a token exists: the first
+// tokenPrefixLen characters followed by an ellipsis (e.g. "eyJhbG..."). An empty
+// token returns an empty string. Tokens that are tokenPrefixLen characters or
+// shorter are fully masked (returned as just "...") to avoid revealing the
+// entire value.
+func RedactToken(token string, show bool) string {
+	if show || token == "" {
+		return token
+	}
+	if len(token) <= tokenPrefixLen {
+		return "..."
+	}
+	return token[:tokenPrefixLen] + "..."
+}
+
+// redactAuthHeaderValues returns a copy of the given Authorization header values
+// with any bearer token redacted via RedactToken when show is false. Values of
+// the form "Bearer <token>" have their token portion truncated; other values
+// are truncated wholesale. When show is true, the values are returned
+// unchanged.
+func redactAuthHeaderValues(vals []string, show bool) []string {
+	if show {
+		return vals
+	}
+	out := make([]string, len(vals))
+	for i, v := range vals {
+		const bearerPrefix = "Bearer "
+		if strings.HasPrefix(v, bearerPrefix) {
+			out[i] = bearerPrefix + RedactToken(strings.TrimPrefix(v, bearerPrefix), show)
+		} else {
+			out[i] = RedactToken(v, show)
+		}
+	}
+	return out
+}
+
+// isAuthorizationHeader reports whether the given header key is the
+// Authorization header, using canonical header comparison.
+func isAuthorizationHeader(key string) bool {
+	return http.CanonicalHeaderKey(key) == "Authorization"
+}

--- a/pkg/client/redact_test.go
+++ b/pkg/client/redact_test.go
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: © 2025 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package client
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+
+	"github.com/openchami/ochami/internal/log"
+)
+
+func TestRedactToken(t *testing.T) {
+	tests := []struct {
+		name  string
+		show  bool
+		token string
+		want  string
+	}{
+		{
+			name:  "empty token",
+			show:  false,
+			token: "",
+			want:  "",
+		},
+		{
+			name:  "short token fully masked",
+			show:  false,
+			token: "abc",
+			want:  "...",
+		},
+		{
+			name:  "token exactly prefix length fully masked",
+			show:  false,
+			token: "abcdef",
+			want:  "...",
+		},
+		{
+			name:  "long token truncated with prefix and ellipsis",
+			show:  false,
+			token: "eyJhbGciOiJIUzI1NiJ9.payload.sig",
+			want:  "eyJhbG...",
+		},
+		{
+			name:  "show token returns full value",
+			show:  true,
+			token: "eyJhbGciOiJIUzI1NiJ9.payload.sig",
+			want:  "eyJhbGciOiJIUzI1NiJ9.payload.sig",
+		},
+		{
+			name:  "show token with empty stays empty",
+			show:  true,
+			token: "",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RedactToken(tt.token, tt.show)
+			if got != tt.want {
+				t.Errorf("RedactToken(%q, %v) = %q, want %q", tt.token, tt.show, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRedactAuthHeaderValues(t *testing.T) {
+	tests := []struct {
+		name string
+		show bool
+		vals []string
+		want []string
+	}{
+		{
+			name: "bearer token truncated by default",
+			show: false,
+			vals: []string{"Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig"},
+			want: []string{"Bearer eyJhbG..."},
+		},
+		{
+			name: "non-bearer value truncated wholesale",
+			show: false,
+			vals: []string{"eyJhbGciOiJIUzI1NiJ9.payload.sig"},
+			want: []string{"eyJhbG..."},
+		},
+		{
+			name: "multiple values",
+			show: false,
+			vals: []string{"Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig", "Bearer another-long-token-value"},
+			want: []string{"Bearer eyJhbG...", "Bearer anothe..."},
+		},
+		{
+			name: "show token returns values unchanged",
+			show: true,
+			vals: []string{"Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig"},
+			want: []string{"Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := redactAuthHeaderValues(tt.vals, tt.show)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("redactAuthHeaderValues(%v, %v) = %v, want %v", tt.vals, tt.show, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsAuthorizationHeader(t *testing.T) {
+	tests := []struct {
+		key  string
+		want bool
+	}{
+		{"Authorization", true},
+		{"authorization", true},
+		{"AUTHORIZATION", true},
+		{"Content-Type", false},
+		{"X-Auth", false},
+	}
+	for _, tt := range tests {
+		if got := isAuthorizationHeader(tt.key); got != tt.want {
+			t.Errorf("isAuthorizationHeader(%q) = %v, want %v", tt.key, got, tt.want)
+		}
+	}
+}
+
+// TestMakeRequestRedactsAuthorizationInLogs verifies that the Authorization
+// header is truncated in debug logs by default (WithShowToken(false)) and shown
+// in full when the client is created with WithShowToken(true).
+func TestMakeRequestRedactsAuthorizationInLogs(t *testing.T) {
+	origLogger := log.Logger
+	defer func() { log.Logger = origLogger }()
+
+	fullToken := "eyJhbGciOiJIUzI1NiJ9.payload.sig"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	run := func(showToken bool) string {
+		var buf bytes.Buffer
+		log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
+
+		oc, err := NewOchamiClient("test", ts.URL, WithShowToken(showToken))
+		if err != nil {
+			t.Fatalf("failed to create client: %v", err)
+		}
+		headers := NewHTTPHeaders()
+		if err := headers.SetAuthorization(fullToken); err != nil {
+			t.Fatalf("failed to set authorization: %v", err)
+		}
+		res, err := oc.MakeRequest(http.MethodGet, ts.URL, headers, nil)
+		if err != nil {
+			t.Fatalf("MakeRequest failed: %v", err)
+		}
+		if res != nil && res.Body != nil {
+			res.Body.Close()
+		}
+		return buf.String()
+	}
+
+	// Default (redacted).
+	logs := run(false)
+	if strings.Contains(logs, fullToken) {
+		t.Errorf("logs contained full token by default, expected it to be redacted; logs: %s", logs)
+	}
+	if !strings.Contains(logs, "eyJhbG...") {
+		t.Errorf("logs did not contain truncated token; logs: %s", logs)
+	}
+
+	// ShowToken enabled (full).
+	logs = run(true)
+	if !strings.Contains(logs, fullToken) {
+		t.Errorf("logs did not contain full token with WithShowToken(true); logs: %s", logs)
+	}
+}

--- a/pkg/client/smd/smd.go
+++ b/pkg/client/smd/smd.go
@@ -133,10 +133,11 @@ type GroupMembers struct {
 }
 
 // NewClient takes a baseURI and returns a pointer to a new SMDClient. If an
-// error occurred creating the embedded OchamiClient, it is returned. If
-// insecure is true, TLS certificates will not be verified.
-func NewClient(baseURI string, insecure bool) (*SMDClient, error) {
-	oc, err := client.NewOchamiClient(serviceNameSMD, baseURI, insecure)
+// error occurred creating the embedded OchamiClient, it is returned. Behavior
+// such as TLS verification and token redaction is configured via functional
+// options (e.g. client.WithInsecure, client.WithShowToken).
+func NewClient(baseURI string, opts ...client.Option) (*SMDClient, error) {
+	oc, err := client.NewOchamiClient(serviceNameSMD, baseURI, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OchamiClient for %s: %w", serviceNameSMD, err)
 	}


### PR DESCRIPTION
### Description

Previously, enabling debug logging exposed access tokens in full at three points, leaking live credentials into logs, terminal scrollback, and any captured output shared for troubleshooting.

Debug logging is a common first step when diagnosing auth failures, so users routinely produced and shared logs containing usable bearer tokens without realizing it.

Tokens that would appear in debug logs are now truncated to their first few characters followed by an ellipsis (e.g. "eyJhbG..."). The logs still indicate that a token is present and hint at its identity, but no longer disclose the full credential. A new, persistent `--show-token` flag restores the previous behavior when an operator explicitly needs to inspect the full value.

To carry the "show token?" decision into the client layer idiomatically and without concurrency-unsafe shared state, the `OchamiClient` constructors are refactored to use functional options:

  - `OchamiClient` gains per-instance `ShowToken` configuration; `MakeRequest` reads it from the client rather than a package-level global.
  - `NewOchamiClient` and every per-service `NewClient` now accept variadic client.Option values (`WithInsecure`, `WithShowToken`), replacing the positional `insecure bool` argument. This keeps all client behavior configured per-instance instead of via mutable globals, so concurrent clients cannot race or clobber each other, and future options can be added without breaking signatures.
  - `RedactToken` is a pure function taking the show/redact decision as a parameter, making it trivially testable with no hidden dependencies.

BREAKING CHANGE: `pkg/client `constructors (`NewOchamiClient` and the per-service `NewClient` functions) no longer take a positional `insecure bool`; callers must pass `client.WithInsecure(...)` instead.  Token-hiding in debug logs is now the default; pass `--show-token` to log the full token.

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [x] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass
- [x] I have updated the relevant documentation (CLI examples, man pages, README, other docs, etc.)
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Type of Change

- [ ] Bug fix  
- [x] New feature  
- [x] Breaking change  
- [ ] Documentation update  
- [ ] Dependency update

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
