### PR TITLE
ci: temporarily disable AUR builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
           IS_PR_BUILD: 'false'
         with:
           version: '~> v2'
-          args: release --clean --release-notes ../notes.md
+          args: release --clean --release-notes ../notes.md --skip aur
         id: goreleaser
 
       - name: Process goreleaser output


### PR DESCRIPTION
### Description

The AUR has temporarily disabled pushing to the AUR until they can work out security issues on their end.

See: https://lists.archlinux.org/archives/list/aur-general@lists.archlinux.org/message/YPJ3FQYJTJXXY3RUXCYLMHUKHLIUNVFF/

Current release builds are failing because of this.

**THIS SHOULD BE REVERTED ONCE PUSHING IS ENABLED AGAIN!**

## Pull Request Template

Thank you for your contribution! Please ensure the following before submitting:

### Checklist

- [x] My code follows the style guidelines of this project  
- [ ] I have added/updated comments where needed  
- [ ] I have added tests that prove my fix is effective or my feature works  
- [ ] I have run `make test` (or equivalent) locally and all tests pass
- [ ] I have updated the relevant documentation (CLI examples, man pages, README, other docs, etc.)
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  
- [ ] Dependency update

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
