### PR TITLE
chore(reuse): centralize license annotations

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,32 @@
+version = 1
+
+[[annotations]]
+path = [
+    "doc/config.example.yaml",
+    "go.sum",
+    "man/ochami-bss.1.sc",
+    "man/ochami-cloud-init.1.sc",
+    "man/ochami-config.1.sc",
+    "man/ochami-config.5.sc",
+    "man/ochami-discover.1.sc",
+    "man/ochami-pcs.1.sc",
+    "man/ochami-smd.1.sc",
+    "man/ochami.1.sc",
+]
+precedence = "override"
+SPDX-FileCopyrightText = [
+    "© 2024-2025 Triad National Security, LLC. All rights reserved.",
+    "© 2025 OpenCHAMI a Series of LF Projects, LLC",
+]
+SPDX-License-Identifier = "MIT"
+
+[[annotations]]
+path = [
+    "man/ochami-boot.1.sc",
+    "man/ochami-metadata.1.sc",
+    "man/ochami-rcs.1.sc",
+    "renovate.json",
+]
+precedence = "override"
+SPDX-FileCopyrightText = "© 2026 OpenCHAMI a Series of LF Projects, LLC"
+SPDX-License-Identifier = "MIT"

--- a/doc/config.example.yaml.license
+++ b/doc/config.example.yaml.license
@@ -1,4 +1,0 @@
-SPDX-FileCopyrightText: © 2024-2025 Triad National Security, LLC. All rights reserved.
-SPDX-FileCopyrightText: © 2025 OpenCHAMI a Series of LF Projects, LLC
-
-SPDX-License-Identifier: MIT

--- a/go.sum.license
+++ b/go.sum.license
@@ -1,4 +1,0 @@
-SPDX-FileCopyrightText: © 2024-2025 Triad National Security, LLC. All rights reserved.
-SPDX-FileCopyrightText: © 2025 OpenCHAMI a Series of LF Projects, LLC
-
-SPDX-License-Identifier: MIT

--- a/man/.gitignore
+++ b/man/.gitignore
@@ -6,4 +6,3 @@
 *
 !.gitignore
 !*.sc
-!*.license

--- a/man/ochami-boot.1.sc.license
+++ b/man/ochami-boot.1.sc.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: © 2026 OpenCHAMI a Series of LF Projects, LLC
-
-SPDX-License-Identifier: MIT

--- a/man/ochami-bss.1.sc.license
+++ b/man/ochami-bss.1.sc.license
@@ -1,4 +1,0 @@
-SPDX-FileCopyrightText: © 2024-2025 Triad National Security, LLC. All rights reserved.
-SPDX-FileCopyrightText: © 2025 OpenCHAMI a Series of LF Projects, LLC
-
-SPDX-License-Identifier: MIT

--- a/man/ochami-cloud-init.1.sc.license
+++ b/man/ochami-cloud-init.1.sc.license
@@ -1,4 +1,0 @@
-SPDX-FileCopyrightText: © 2024-2025 Triad National Security, LLC. All rights reserved.
-SPDX-FileCopyrightText: © 2025 OpenCHAMI a Series of LF Projects, LLC
-
-SPDX-License-Identifier: MIT

--- a/man/ochami-config.1.sc.license
+++ b/man/ochami-config.1.sc.license
@@ -1,4 +1,0 @@
-SPDX-FileCopyrightText: © 2024-2025 Triad National Security, LLC. All rights reserved.
-SPDX-FileCopyrightText: © 2025 OpenCHAMI a Series of LF Projects, LLC
-
-SPDX-License-Identifier: MIT

--- a/man/ochami-config.5.sc.license
+++ b/man/ochami-config.5.sc.license
@@ -1,4 +1,0 @@
-SPDX-FileCopyrightText: © 2024-2025 Triad National Security, LLC. All rights reserved.
-SPDX-FileCopyrightText: © 2025 OpenCHAMI a Series of LF Projects, LLC
-
-SPDX-License-Identifier: MIT

--- a/man/ochami-discover.1.sc.license
+++ b/man/ochami-discover.1.sc.license
@@ -1,4 +1,0 @@
-SPDX-FileCopyrightText: © 2024-2025 Triad National Security, LLC. All rights reserved.
-SPDX-FileCopyrightText: © 2025 OpenCHAMI a Series of LF Projects, LLC
-
-SPDX-License-Identifier: MIT

--- a/man/ochami-metadata.1.sc.license
+++ b/man/ochami-metadata.1.sc.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: © 2026 OpenCHAMI a Series of LF Projects, LLC
-
-SPDX-License-Identifier: MIT

--- a/man/ochami-pcs.1.sc.license
+++ b/man/ochami-pcs.1.sc.license
@@ -1,4 +1,0 @@
-SPDX-FileCopyrightText: © 2024-2025 Triad National Security, LLC. All rights reserved.
-SPDX-FileCopyrightText: © 2025 OpenCHAMI a Series of LF Projects, LLC
-
-SPDX-License-Identifier: MIT

--- a/man/ochami-rcs.1.sc.license
+++ b/man/ochami-rcs.1.sc.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: © 2026 OpenCHAMI a Series of LF Projects, LLC
-
-SPDX-License-Identifier: MIT

--- a/man/ochami-smd.1.sc.license
+++ b/man/ochami-smd.1.sc.license
@@ -1,4 +1,0 @@
-SPDX-FileCopyrightText: © 2024-2025 Triad National Security, LLC. All rights reserved.
-SPDX-FileCopyrightText: © 2025 OpenCHAMI a Series of LF Projects, LLC
-
-SPDX-License-Identifier: MIT

--- a/man/ochami.1.sc.license
+++ b/man/ochami.1.sc.license
@@ -1,4 +1,0 @@
-SPDX-FileCopyrightText: © 2024-2025 Triad National Security, LLC. All rights reserved.
-SPDX-FileCopyrightText: © 2025 OpenCHAMI a Series of LF Projects, LLC
-
-SPDX-License-Identifier: MIT

--- a/renovate.json.license
+++ b/renovate.json.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2026 OpenCHAMI Contributors
-
-SPDX-License-Identifier: MIT


### PR DESCRIPTION
### Description

Replace per-file license sidecars with a root REUSE.toml to reduce duplication and simplify license maintenance while preserving REUSE compliance.

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [ ] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass
- [x] I have updated the relevant documentation (CLI examples, man pages, README, other docs, etc.)
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers
  - [x] Any non-commentable files include a `<filename>.license` sidecar (moved to REUSE.toml) 
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Type of Change

- [ ] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  
- [ ] Dependency update

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
