### PR TITLE
revert: ci: temporarily disable AUR builds (#141)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
           IS_PR_BUILD: 'false'
         with:
           version: '~> v2'
-          args: release --clean --release-notes ../notes.md --skip aur
+          args: release --clean --release-notes ../notes.md
         id: goreleaser
 
       - name: Process goreleaser output


### PR DESCRIPTION
This reverts commit 629a27e0bee5e263089a381317d5c1581093e63b.

According to:

https://www.mail-archive.com/aur-general@lists.archlinux.org/msg02722.html

> aurweb v6.5.0 is now deployed on aur.archlinux.org.
>
> - SSH/git push access is re-enabled along with adoption.
> - Registration remains closed for now.

The AUR has re-enabled pushes. Re-enable package updates in releases.

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [ ] I have added tests that prove my fix is effective or my feature works  
- [ ] I have run `make test` (or equivalent) locally and all tests pass
- [ ] I have updated the relevant documentation (CLI examples, man pages, README, other docs, etc.)
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Type of Change

- [ ] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  
- [ ] Dependency update

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
